### PR TITLE
Update workflow to match release strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+      - release/*
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: ./SourceCode/AgOpenGPS.sln
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}} -PackagesDirectory .\SourceCode\packages -source "https://api.nuget.org/v3/index.json"
+
+    - name: Build
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Create AgOpenGPS.zip
+      shell: powershell
+      run: Compress-Archive -Path "AgOpenGPS" -Destination "AgOpenGPS.zip"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: AgOpenGPS.zip
+        path: AgOpenGPS.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - master
-      - develop
-  pull_request:
-    branches:
-      - develop
+      - release/*
+  workflow_dispatch:
 
 env:
   # Path to the solution file relative to the root of the project.
@@ -19,11 +17,8 @@ env:
   BUILD_CONFIGURATION: Release
 
 jobs:
-  build:
+  build-and-release:
     runs-on: windows-latest
-    outputs:
-      version: ${{ steps.variables.outputs.VERSION }}
-      prerelease: ${{ steps.variables.outputs.PRERELEASE }}
 
     steps:
     - name: Checkout
@@ -40,32 +35,9 @@ jobs:
     - name: Build
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Set variables
-      id: variables
-      run: |
-        echo "VERSION=${{env.GitVersion_SemVer}}" >> $env:GITHUB_OUTPUT
-        echo "PRERELEASE=${{env.GitVersion_PreReleaseTag != ''}}" >> $env:GITHUB_OUTPUT
-
     - name: Create AgOpenGPS.zip
       shell: powershell
       run: Compress-Archive -Path "AgOpenGPS" -Destination "AgOpenGPS.zip"
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: AgOpenGPS.zip
-        path: AgOpenGPS.zip
-
-  release:
-    needs: build
-    runs-on: windows-latest
-    if: github.event_name != 'pull_request'
-
-    steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: AgOpenGPS.zip
 
     - name: Create Release
       id: create_release
@@ -73,12 +45,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ needs.build.outputs.version }}
-        release_name: Release ${{ needs.build.outputs.version }}
+        tag_name: ${{ env.GitVersion_SemVer }}
+        release_name: Release ${{ env.GitVersion_SemVer }}
         body: |
           Automated Release by GitHub Action CI
         draft: false
-        prerelease: ${{ needs.build.outputs.prerelease }}
+        prerelease: ${{ contains(github.ref_name, 'release/') }}
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
This will allow the following workflow:

- `release/*` branches will create pre-releases automatically
- `develop` branch will only build, without a release
- `master` will create an official release