### PR TITLE
Soft delete / ignore corrupted settings files

### DIFF
--- a/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
@@ -87,7 +87,7 @@ namespace AgOpenGPS
                             var path = Path.Combine(mf.vehiclesDirectory, newname + ".XML");
 
                             if (File.Exists(path))
-                                File.Delete(path);
+                                File.Move(path, path+".CORRUPT");
 
                             UpdateVehicleListView();
                             return;


### PR DESCRIPTION
Instead of forcefully deleting the settings file when it has any kind of errors, this fix allow us to retain it but in the form it won't be visible.