### PR TITLE
Extract Keypad & Keyboard display into extension methods

### DIFF
--- a/SourceCode/AgIO/Source/Controls/NumericUpDownExtensions.cs
+++ b/SourceCode/AgIO/Source/Controls/NumericUpDownExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace AgIO.Controls
+{
+    public static class NumericUpDownExtensions
+    {
+        public static void ShowKeypad(this NumericUpDown numericUpDown, Form owner)
+        {
+            numericUpDown.BackColor = Color.Red;
+            using (var form = new FormNumeric((double)numericUpDown.Minimum, (double)numericUpDown.Maximum, (double)numericUpDown.Value))
+            {
+                if (form.ShowDialog(owner) == DialogResult.OK)
+                {
+                    numericUpDown.Value = (decimal)form.ReturnValue;
+                }
+            }
+            numericUpDown.BackColor = Color.AliceBlue;
+        }
+    }
+}

--- a/SourceCode/AgIO/Source/Controls/TextBoxExtensions.cs
+++ b/SourceCode/AgIO/Source/Controls/TextBoxExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace AgIO.Controls
+{
+    public static class TextBoxExtensions
+    {
+        public static void ShowKeyboard(this TextBox textBox, Form owner)
+        {
+            textBox.BackColor = Color.Red;
+            using (var form = new FormKeyboard(textBox.Text))
+            {
+                if (form.ShowDialog(owner) == DialogResult.OK)
+                {
+                    textBox.Text = form.ReturnString;
+                }
+            }
+            textBox.BackColor = Color.AliceBlue;
+        }
+    }
+}

--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -500,20 +500,6 @@ namespace AgIO
             }
         }
 
-        public void KeyboardToText(TextBox sender, Form owner)
-        {
-            TextBox tbox = (TextBox)sender;
-            tbox.BackColor = System.Drawing.Color.Red;
-            using (var form = new FormKeyboard((string)tbox.Text))
-            {
-                if (form.ShowDialog(owner) == DialogResult.OK)
-                {
-                    tbox.Text = (string)form.ReturnString;
-                }
-            }
-            tbox.BackColor = System.Drawing.Color.AliceBlue;
-        }
-
         private ToolStripDropDownButton toolStripDropDownButton1;
         private ToolStripMenuItem toolStripMenuProfiles;
         private ToolStripMenuItem deviceManagerToolStripMenuItem;

--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -500,19 +500,6 @@ namespace AgIO
             }
         }
 
-        public void KeypadToNUD(NumericUpDown sender, Form owner)
-        {
-            sender.BackColor = System.Drawing.Color.Red;
-            using (var form = new FormNumeric((double)sender.Minimum, (double)sender.Maximum, (double)sender.Value))
-            {
-                if (form.ShowDialog(owner) == DialogResult.OK)
-                {
-                    sender.Value = (decimal)form.ReturnValue;
-                }
-            }
-            sender.BackColor = System.Drawing.Color.AliceBlue;
-        }
-
         public void KeyboardToText(TextBox sender, Form owner)
         {
             TextBox tbox = (TextBox)sender;

--- a/SourceCode/AgIO/Source/Forms/FormEthernet.cs
+++ b/SourceCode/AgIO/Source/Forms/FormEthernet.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using AgIO.Controls;
 using AgLibrary.Logging;
 
 namespace AgIO
@@ -42,7 +43,7 @@ namespace AgIO
 
         private void nudFirstIP_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
         }
 
         private void btnSerialCancel_Click(object sender, EventArgs e)

--- a/SourceCode/AgIO/Source/Forms/FormNtrip.cs
+++ b/SourceCode/AgIO/Source/Forms/FormNtrip.cs
@@ -407,7 +407,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
             btnGetIP.PerformClick();
@@ -417,7 +417,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -426,7 +426,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -435,7 +435,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }

--- a/SourceCode/AgIO/Source/Forms/FormNtrip.cs
+++ b/SourceCode/AgIO/Source/Forms/FormNtrip.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using AgIO.Controls;
 using AgLibrary.Logging;
 
 namespace AgIO
@@ -374,31 +375,31 @@ namespace AgIO
 
         private void NudCasterPort_Enter(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             btnSerialCancel.Focus();
         }
 
         private void NudGGAInterval_Enter(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             btnSerialCancel.Focus();
         }
 
         private void NudLatitude_Enter(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             btnSerialCancel.Focus();
         }
 
         private void NudLongitude_Enter(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             btnSerialCancel.Focus();
         }
 
         private void NudSendToUDPPort_Enter(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             btnSerialCancel.Focus();
         }
 

--- a/SourceCode/AgIO/Source/Forms/FormProfiles.cs
+++ b/SourceCode/AgIO/Source/Forms/FormProfiles.cs
@@ -1,4 +1,5 @@
-﻿using AgIO.Properties;
+﻿using AgIO.Controls;
+using AgIO.Properties;
 using Microsoft.Win32;
 using System;
 using System.Drawing;
@@ -127,7 +128,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSaveNewProfile.Focus();
             }
         }
@@ -155,7 +156,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSaveNewProfile.Focus();
             }
         }

--- a/SourceCode/AgIO/Source/Forms/FormRadio.cs
+++ b/SourceCode/AgIO/Source/Forms/FormRadio.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO.Ports;
 using System.Linq;
 using System.Windows.Forms;
+using AgIO.Controls;
 using AgLibrary.Logging;
 
 namespace AgIO
@@ -337,7 +338,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
             }
         }
     }

--- a/SourceCode/AgIO/Source/Forms/FormRadioChannel.cs
+++ b/SourceCode/AgIO/Source/Forms/FormRadioChannel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using AgIO.Controls;
 
 namespace AgIO
 {
@@ -73,7 +74,7 @@ namespace AgIO
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
             }
         }
     }

--- a/SourceCode/AgIO/Source/Forms/FormUDP.cs
+++ b/SourceCode/AgIO/Source/Forms/FormUDP.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Windows.Forms;
+using AgIO.Controls;
 using AgLibrary.Logging;
 
 namespace AgIO
@@ -290,7 +291,7 @@ namespace AgIO
 
         private void nudFirstIP_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NumericUpDown)sender, this);
+            ((NumericUpDown)sender).ShowKeypad(this);
             ipNew[0] = (byte)nudFirstIP.Value;
             ipNew[1] = (byte)nudSecndIP.Value;
             ipNew[2] = (byte)nudThirdIP.Value;

--- a/SourceCode/GPS/Controls/NudlessNumericUpDownExtensions.cs
+++ b/SourceCode/GPS/Controls/NudlessNumericUpDownExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AgOpenGPS.Controls
+{
+    public static class NudlessNumericUpDownExtensions
+    {
+        public static bool ShowKeypad(this NudlessNumericUpDown nudlessNumericUpDown, Form owner)
+        {
+            var color = nudlessNumericUpDown.BackColor;
+            nudlessNumericUpDown.BackColor = Color.Red;
+            nudlessNumericUpDown.Value = Math.Round(nudlessNumericUpDown.Value, nudlessNumericUpDown.DecimalPlaces);
+
+            using (FormNumeric form = new FormNumeric((double)nudlessNumericUpDown.Minimum, (double)nudlessNumericUpDown.Maximum, (double)nudlessNumericUpDown.Value))
+            {
+                DialogResult result = form.ShowDialog(owner);
+                if (result == DialogResult.OK)
+                {
+                    nudlessNumericUpDown.Value = (decimal)form.ReturnValue;
+                    nudlessNumericUpDown.BackColor = color;
+                    return true;
+                }
+                else if (result == DialogResult.Cancel)
+                {
+                    nudlessNumericUpDown.BackColor = color;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/SourceCode/GPS/Controls/TextBoxExtensions.cs
+++ b/SourceCode/GPS/Controls/TextBoxExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace AgOpenGPS.Controls
+{
+    public static class TextBoxExtensions
+    {
+        public static void ShowKeyboard(this TextBox textBox, Form owner)
+        {
+            var color = textBox.BackColor;
+            textBox.BackColor = Color.Red;
+            using (FormKeyboard form = new FormKeyboard(textBox.Text))
+            {
+                if (form.ShowDialog(owner) == DialogResult.OK)
+                {
+                    textBox.Text = form.ReturnString;
+                }
+            }
+            textBox.BackColor = color;
+        }
+    }
+}

--- a/SourceCode/GPS/Forms/Field/FormBoundaryPlayer.cs
+++ b/SourceCode/GPS/Forms/Field/FormBoundaryPlayer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -70,7 +71,7 @@ namespace AgOpenGPS
 
         private void nudOffset_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             btnPausePlay.Focus();
             if (mf.isMetric)
             {

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
 using System.Globalization;
@@ -37,12 +38,12 @@ namespace AgOpenGPS
 
         private void nudLatitude_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLongitude_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         public void CalcHeading()

--- a/SourceCode/GPS/Forms/Field/FormFieldDir.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldDir.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -137,7 +138,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -146,7 +147,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -155,7 +156,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -482,7 +483,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -491,7 +492,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }
@@ -500,7 +501,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -860,7 +861,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((System.Windows.Forms.TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/Field/FormFieldKML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldKML.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -70,7 +71,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnSerialCancel.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/Field/FormFlags.cs
+++ b/SourceCode/GPS/Forms/Field/FormFlags.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 
 namespace AgOpenGPS
@@ -113,7 +114,7 @@ namespace AgOpenGPS
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 btnExit.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -763,29 +763,6 @@ namespace AgOpenGPS
             }
         }
 
-        public bool KeypadToNUD(NudlessNumericUpDown sender, Form owner)
-        {
-            var colour = sender.BackColor;
-            sender.BackColor = Color.Red;
-            sender.Value = Math.Round(sender.Value, sender.DecimalPlaces);
-
-            using (FormNumeric form = new FormNumeric((double)sender.Minimum, (double)sender.Maximum, (double)sender.Value))
-            {
-                DialogResult result = form.ShowDialog(owner);
-                if (result == DialogResult.OK)
-                {
-                    sender.Value = (decimal)form.ReturnValue;
-                    sender.BackColor = colour;
-                    return true;
-                }
-                else if (result == DialogResult.Cancel)
-                {
-                    sender.BackColor = colour;
-                }
-                return false;
-            }
-        }
-
         public void KeyboardToText(TextBox sender, Form owner)
         {
             var colour = sender.BackColor;

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -763,20 +763,6 @@ namespace AgOpenGPS
             }
         }
 
-        public void KeyboardToText(TextBox sender, Form owner)
-        {
-            var colour = sender.BackColor;
-            sender.BackColor = Color.Red;
-            using (FormKeyboard form = new FormKeyboard(sender.Text))
-            {
-                if (form.ShowDialog(owner) == DialogResult.OK)
-                {
-                    sender.Text = form.ReturnString;
-                }
-            }
-            sender.BackColor = colour;
-        }
-
         //request a new job
         public void JobNew()
         {

--- a/SourceCode/GPS/Forms/FormShiftPos.cs
+++ b/SourceCode/GPS/Forms/FormShiftPos.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using System;
 using System.Windows.Forms;
 
@@ -77,13 +78,13 @@ namespace AgOpenGPS
 
         private void nudNorth_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             mf.pn.fixOffset.northing = (double)nudNorth.Value / 100;
         }
 
         private void nudEast_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             mf.pn.fixOffset.easting = (double)nudEast.Value / 100;
         }
     }

--- a/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
@@ -364,7 +364,7 @@ namespace AgOpenGPS
 
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((System.Windows.Forms.TextBox)sender, this);
+                ((System.Windows.Forms.TextBox)sender).ShowKeyboard(this);
                 
                 if (indx > -1)
                     gTemp[indx].name = tboxNameCurve.Text.Trim();

--- a/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -316,7 +317,7 @@ namespace AgOpenGPS
 
         private void nudDistance_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             btnSelectCurve.Focus();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -892,7 +893,7 @@ namespace AgOpenGPS
         {
             timer1.Enabled = false;
 
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 //original A pt. 
                 mf.ABLine.desHeading = glm.toRadians((double)nudHeading.Value);
@@ -1163,22 +1164,22 @@ namespace AgOpenGPS
 
         private void nudLatitudeA_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLongitudeA_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLatitudeB_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLongitudeB_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void btnEnter_LatLonLatLon_Click(object sender, EventArgs e)
@@ -1242,17 +1243,17 @@ namespace AgOpenGPS
 
         private void nudLatitudePlus_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLongitudePlus_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudHeadingLatLonPlus_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void btnEnter_LatLonPlus_Click(object sender, EventArgs e)
@@ -1306,12 +1307,12 @@ namespace AgOpenGPS
 
         private void nudLatitudePivot_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void nudLongitudePivot_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
 
         private void btnEnter_Pivot_Click(object sender, EventArgs e)

--- a/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
@@ -1371,7 +1371,7 @@ namespace AgOpenGPS
         private void textBox_Click(object sender, EventArgs e)
         {
             if (mf.isKeyboardOn)
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
         }
 
         private void btnAdd_Click(object sender, EventArgs e)

--- a/SourceCode/GPS/Forms/Guidance/FormHeadAche.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadAche.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -695,7 +696,7 @@ namespace AgOpenGPS
 
         private void nudSetDistance_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             btnExit.Focus();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormHeadLine.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadLine.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -691,7 +692,7 @@ namespace AgOpenGPS
 
         private void nudSetDistance_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             btnExit.Focus();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormNudge.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormNudge.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 
 namespace AgOpenGPS
@@ -84,7 +85,7 @@ namespace AgOpenGPS
 
         private void nudSnapDistance_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             snapAdj = (double)nudSnapDistance.Value * mf.inchOrCm2m;
             Properties.Settings.Default.setAS_snapDistance = snapAdj*100;
             Properties.Settings.Default.Save();

--- a/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
@@ -482,7 +482,7 @@ namespace AgOpenGPS
         private void textBox_Click(object sender, EventArgs e)
         {
             if (mf.isKeyboardOn)
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
         }
 
         private void btnAdd_Click(object sender, EventArgs e)

--- a/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
 using System.Collections.Generic;
@@ -399,7 +400,7 @@ namespace AgOpenGPS
         {
             timer1.Enabled = false;
 
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 //original A pt. 
                 mf.ABLine.desHeading = glm.toRadians((double)nudHeading.Value);

--- a/SourceCode/GPS/Forms/Guidance/FormRecordName.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormRecordName.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 
 namespace AgOpenGPS.Forms
@@ -63,7 +64,7 @@ namespace AgOpenGPS.Forms
         {
             if (mf.isKeyboardOn)
             {
-                mf.KeyboardToText((TextBox)sender, this);
+                ((TextBox)sender).ShowKeyboard(this);
                 buttonRecordCancel.Focus();
             }
         }

--- a/SourceCode/GPS/Forms/Guidance/FormRefNudge.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormRefNudge.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Helpers;
 
 namespace AgOpenGPS
@@ -62,7 +63,7 @@ namespace AgOpenGPS
 
         private void nudSnapDistance_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             snapAdj = (double)nudSnapDistance.Value * mf.inchOrCm2m;
             Properties.Settings.Default.setAS_snapDistanceRef = snapAdj*100;
             Properties.Settings.Default.Save();

--- a/SourceCode/GPS/Forms/Guidance/FormTram.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormTram.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
 using System.Windows.Forms;
@@ -154,7 +155,7 @@ namespace AgOpenGPS
 
         private void nudPasses_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
         private void btnUpTrams_Click(object sender, EventArgs e)
         {

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows.Forms;
 using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 
 namespace AgOpenGPS
 {
@@ -119,7 +120,7 @@ namespace AgOpenGPS
 
         private void nudFixJumpDistance_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setGPS_jumpFixAlarmDistance = ((int)nudFixJumpDistance.Value);
                 //mf.jumpDistanceAlarm = Properties.Settings.Default.setGPS_dualHeadingOffset;
@@ -128,7 +129,7 @@ namespace AgOpenGPS
 
         private void nudDualHeadingOffset_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setGPS_dualHeadingOffset = ((double)nudDualHeadingOffset.Value);
                 mf.pn.headingTrueDualOffset = Properties.Settings.Default.setGPS_dualHeadingOffset;
@@ -137,7 +138,7 @@ namespace AgOpenGPS
 
          private void nudDualReverseDistance_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setGPS_dualReverseDetectionDistance = ((double)nudDualReverseDistance.Value);
                 mf.dualReverseDetectionDistance = Properties.Settings.Default.setGPS_dualReverseDetectionDistance;
@@ -145,7 +146,7 @@ namespace AgOpenGPS
         }
         //private void nudMinimumFrameTime_Click(object sender, EventArgs e)
         //{
-        //    if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+        //    if (((NudlessNumericUpDown)sender).ShowKeypad(this))
         //    {
         //        Properties.Settings.Default.SetGPS_udpWatchMsec = ((int)nudMinimumFrameTime.Value);
         //        mf.udpWatchLimit = Properties.Settings.Default.SetGPS_udpWatchMsec;
@@ -182,7 +183,7 @@ namespace AgOpenGPS
 
         //private void nudForwardComp_Click(object sender, EventArgs e)
         //{
-        //    if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+        //    if (((NudlessNumericUpDown)sender).ShowKeypad(this))
         //    {
         //        Properties.Settings.Default.setGPS_forwardComp = (double)nudForwardComp.Value;
         //    }
@@ -190,7 +191,7 @@ namespace AgOpenGPS
 
         //private void nudReverseComp_Click(object sender, EventArgs e)
         //{
-        //    if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+        //    if (((NudlessNumericUpDown)sender).ShowKeypad(this))
         //    {
         //        Properties.Settings.Default.setGPS_reverseComp = (double)nudReverseComp.Value;
         //    }
@@ -198,7 +199,7 @@ namespace AgOpenGPS
 
         //private void nudAgeAlarm_Click(object sender, EventArgs e)
         //{
-        //    if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+        //    if (((NudlessNumericUpDown)sender).ShowKeypad(this))
         //    {
         //        Properties.Settings.Default.setGPS_ageAlarm = (int)nudAgeAlarm.Value;
         //    }

--- a/SourceCode/GPS/Forms/Settings/ConfigModule.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigModule.Designer.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using System;
 using System.Linq;
 using System.Text;
@@ -70,7 +71,7 @@ namespace AgOpenGPS
 
         private void nudHydLiftSecs_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -78,7 +79,7 @@ namespace AgOpenGPS
 
         private void nudRaiseTime_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -86,7 +87,7 @@ namespace AgOpenGPS
 
         private void nudLowerTime_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -94,7 +95,7 @@ namespace AgOpenGPS
 
         private void nudUser1_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -102,7 +103,7 @@ namespace AgOpenGPS
 
         private void nudUser2_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -110,7 +111,7 @@ namespace AgOpenGPS
 
         private void nudUser3_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -118,7 +119,7 @@ namespace AgOpenGPS
 
         private void nudUser4_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendMachine.Visible = true;
             }
@@ -507,7 +508,7 @@ namespace AgOpenGPS
 
         private void nudYouTurnRadius_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.yt.youTurnRadius = (double)nudYouTurnRadius.Value * mf.ftOrMtoM;
             }
@@ -515,7 +516,7 @@ namespace AgOpenGPS
 
         private void nudTurnDistanceFromBoundary_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.yt.uturnDistanceFromBoundary = (double)nudTurnDistanceFromBoundary.Value * mf.ftOrMtoM;
             }
@@ -572,7 +573,7 @@ namespace AgOpenGPS
         }
         private void nudTramWidth_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tram.tramWidth = (double)nudTramWidth.Value * mf.inchOrCm2m;
                 Properties.Settings.Default.setTram_tramWidth = mf.tram.tramWidth;

--- a/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Properties;
 using System;
@@ -213,7 +214,7 @@ namespace AgOpenGPS
 
         private void nudDrawbarLength_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.hitchLength = (double)nudDrawbarLength.Value * mf.inchOrCm2m;
                 if (!Properties.Settings.Default.setTool_isToolFront)
@@ -226,7 +227,7 @@ namespace AgOpenGPS
 
         private void nudTankHitch_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.tankTrailingHitchLength = (double)nudTankHitch.Value * -mf.inchOrCm2m;
                 Properties.Settings.Default.setVehicle_tankTrailingHitchLength = mf.tool.tankTrailingHitchLength;
@@ -235,7 +236,7 @@ namespace AgOpenGPS
 
         private void nudTrailingHitchLength_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.trailingHitchLength = (double)nudTrailingHitchLength.Value * -mf.inchOrCm2m;
                 Properties.Settings.Default.setTool_toolTrailingHitchLength = mf.tool.trailingHitchLength;
@@ -275,7 +276,7 @@ namespace AgOpenGPS
         }
         private void nudLookAhead_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (nudLookAheadOff.Value > (nudLookAhead.Value * 0.8m))
                 {
@@ -290,7 +291,7 @@ namespace AgOpenGPS
 
         private void nudLookAheadOff_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (nudLookAheadOff.Value > (nudLookAhead.Value * 0.8m))
                 {
@@ -314,7 +315,7 @@ namespace AgOpenGPS
 
         private void nudTurnOffDelay_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (nudTurnOffDelay.Value > 0)
                 {
@@ -356,7 +357,7 @@ namespace AgOpenGPS
 
         private void nudOffset_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (!rbtnToolRightPositive.Checked && !rbtnLeftNegative.Checked)
                     rbtnToolRightPositive.Checked = true;
@@ -401,7 +402,7 @@ namespace AgOpenGPS
 
         private void nudOverlap_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (!rbtnToolOverlap.Checked && !rbtnToolGap.Checked)
                     rbtnToolOverlap.Checked = true;
@@ -494,7 +495,7 @@ namespace AgOpenGPS
 
         private void nudTrailingToolToPivotLength_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (rbtnPivotBehindPos.Checked)
                     mf.tool.trailingToolToPivotLength = (double)nudTrailingToolToPivotLength.Value * mf.inchOrCm2m;
@@ -813,7 +814,7 @@ namespace AgOpenGPS
 
         private void nudZone1To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[1] = (int)nudZone1To.Value;
                 SetNudZoneVisibility(); 
@@ -822,7 +823,7 @@ namespace AgOpenGPS
 
         private void nudZone2To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[2] = (int)nudZone2To.Value;
                 SetNudZoneVisibility();
@@ -831,7 +832,7 @@ namespace AgOpenGPS
 
         private void nudZone3To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[3] = (int)nudZone3To.Value;
                 SetNudZoneVisibility();
@@ -840,7 +841,7 @@ namespace AgOpenGPS
 
         private void nudZone4To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[4] = (int)nudZone4To.Value;
                 SetNudZoneVisibility();
@@ -849,7 +850,7 @@ namespace AgOpenGPS
 
         private void nudZone5To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[5] = (int)nudZone5To.Value;
                 SetNudZoneVisibility();
@@ -858,7 +859,7 @@ namespace AgOpenGPS
 
         private void nudZone6To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[6] = (int)nudZone6To.Value;
                 SetNudZoneVisibility();
@@ -867,7 +868,7 @@ namespace AgOpenGPS
 
         private void nudZone7To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[7] = (int)nudZone7To.Value;
                 SetNudZoneVisibility();
@@ -876,7 +877,7 @@ namespace AgOpenGPS
 
         private void nudZone8To_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[8] = (int)nudZone8To.Value;
                 SetNudZoneVisibility();
@@ -1101,7 +1102,7 @@ namespace AgOpenGPS
 
         private void nudNumberOfSections_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if ((int)nudNumberOfSections.Value < mf.tool.zones)
                 {
@@ -1124,7 +1125,7 @@ namespace AgOpenGPS
 
         private void nudDefaultSectionWidth_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 defaultSectionWidth = (double)nudDefaultSectionWidth.Value * mf.inchOrCm2m;
 
@@ -1202,13 +1203,13 @@ namespace AgOpenGPS
 
         private void NudSection1_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             UpdateSpinners();
         }
 
         private void nudCutoffSpeed_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.vehicle.slowSpeedCutoff = (double)nudCutoffSpeed.Value;
                 Properties.Settings.Default.setVehicle_slowSpeedCutoff = (double)nudCutoffSpeed.Value;
@@ -1217,7 +1218,7 @@ namespace AgOpenGPS
 
         private void nudMinCoverage_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.minCoverage = (int)nudMinCoverage.Value;
                 Properties.Settings.Default.setVehicle_minCoverage = mf.tool.minCoverage;

--- a/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Properties;
 using OpenTK.Graphics.OpenGL;
@@ -404,7 +405,7 @@ namespace AgOpenGPS
 
         private void nudAntennaOffset_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if ((double)nudAntennaOffset.Value == 0)
                 {
@@ -435,7 +436,7 @@ namespace AgOpenGPS
 
         private void nudAntennaPivot_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_antennaPivot = (double)nudAntennaPivot.Value * mf.inchOrCm2m;
                 mf.vehicle.antennaPivot = Properties.Settings.Default.setVehicle_antennaPivot;
@@ -444,7 +445,7 @@ namespace AgOpenGPS
 
         private void nudAntennaHeight_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_antennaHeight = (double)nudAntennaHeight.Value * mf.inchOrCm2m;
                 mf.vehicle.antennaHeight = Properties.Settings.Default.setVehicle_antennaHeight;
@@ -487,7 +488,7 @@ namespace AgOpenGPS
 
         private void nudTractorHitchLength_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.hitchLength = (double)nudTractorHitchLength.Value * mf.inchOrCm2m;
                 if (!Properties.Settings.Default.setTool_isToolFront)
@@ -500,7 +501,7 @@ namespace AgOpenGPS
 
         private void nudWheelbase_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_wheelbase = (double)nudWheelbase.Value * mf.inchOrCm2m;
                 mf.vehicle.wheelbase = Properties.Settings.Default.setVehicle_wheelbase;
@@ -510,7 +511,7 @@ namespace AgOpenGPS
 
         private void nudVehicleTrack_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_trackWidth = (double)nudVehicleTrack.Value * mf.inchOrCm2m;
                 mf.vehicle.trackWidth = Properties.Settings.Default.setVehicle_trackWidth;

--- a/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
@@ -172,7 +172,7 @@ namespace AgOpenGPS
             {
                 if (mf.isKeyboardOn)
                 {
-                    mf.KeyboardToText((TextBox)sender, this);
+                    ((TextBox)sender).ShowKeyboard(this);
                 }
             }
             else
@@ -223,7 +223,7 @@ namespace AgOpenGPS
             {
                 if (mf.isKeyboardOn)
                 {
-                    mf.KeyboardToText((TextBox)sender, this);
+                    ((TextBox)sender).ShowKeyboard(this);
                 }
             }
             else

--- a/SourceCode/GPS/Forms/Settings/FormConfig.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.cs
@@ -1,6 +1,7 @@
 ﻿//Please, if you use this, share the improvements
 
 using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using Microsoft.Win32;
@@ -465,7 +466,7 @@ namespace AgOpenGPS
 
         private void nudNumGuideLines_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.ABLine.numGuideLines = (int)nudNumGuideLines.Value;
             }

--- a/SourceCode/GPS/Forms/Settings/FormSimCoords.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSimCoords.cs
@@ -1,4 +1,5 @@
-﻿using AgOpenGPS.Culture;
+﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Culture;
 using System;
 using System.Windows.Forms;
 
@@ -68,7 +69,7 @@ namespace AgOpenGPS
 
         private void nud_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
         }
     }
 }

--- a/SourceCode/GPS/Forms/Settings/FormSteer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSteer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using AgOpenGPS.Properties;
@@ -488,7 +489,7 @@ namespace AgOpenGPS
 
         private void nudMaxCounts_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 pboxSendSteer.Visible = true;
             }
@@ -622,7 +623,7 @@ namespace AgOpenGPS
 
         private void nudMinSteerSpeed_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setAS_minSteerSpeed = ((double)nudMinSteerSpeed.Value);
                 if (!mf.isMetric) Properties.Settings.Default.setAS_minSteerSpeed *= 1.609344;
@@ -632,7 +633,7 @@ namespace AgOpenGPS
 
         private void nudMaxSteerSpeed_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setAS_maxSteerSpeed = ((double)nudMaxSteerSpeed.Value);
                 if (!mf.isMetric) Properties.Settings.Default.setAS_maxSteerSpeed *= 1.609344;
@@ -642,7 +643,7 @@ namespace AgOpenGPS
 
         private void nudGuidanceSpeedLimit_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setAS_functionSpeedLimit = ((double)nudGuidanceSpeedLimit.Value);
                 if (!mf.isMetric) Properties.Settings.Default.setAS_functionSpeedLimit *= 1.609344;
@@ -689,7 +690,7 @@ namespace AgOpenGPS
 
         private void nudcmPerPixel_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setDisplay_lightbarCmPerPixel = ((int)nudcmPerPixel.Value);
                 mf.lightbarCmPerPixel = Properties.Settings.Default.setDisplay_lightbarCmPerPixel;
@@ -698,7 +699,7 @@ namespace AgOpenGPS
 
         private void nudLineWidth_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setDisplay_lineWidth = (int)nudLineWidth.Value;
                 mf.ABLine.lineWidth = Properties.Settings.Default.setDisplay_lineWidth;
@@ -707,7 +708,7 @@ namespace AgOpenGPS
 
         private void nudSnapDistance_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setAS_snapDistance = ((double)nudSnapDistance.Value * mf.inOrCm2Cm);
                 mf.ABLine.snapDistance = Properties.Settings.Default.setAS_snapDistance;
@@ -716,7 +717,7 @@ namespace AgOpenGPS
 
         private void nudGuidanceLookAhead_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setAS_guidanceLookAheadTime = ((double)nudGuidanceLookAhead.Value);
                 mf.guidanceLookAheadTime = Properties.Settings.Default.setAS_guidanceLookAheadTime;
@@ -911,13 +912,13 @@ namespace AgOpenGPS
 
         private void nudDeadZoneHeading_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             mf.vehicle.deadZoneHeading = (int)(nudDeadZoneHeading.Value * 100);
         }
 
         private void nudDeadZoneDelay_Click(object sender, EventArgs e)
         {
-            mf.KeypadToNUD((NudlessNumericUpDown)sender, this);
+            ((NudlessNumericUpDown)sender).ShowKeypad(this);
             mf.vehicle.deadZoneDelay = (int)(nudDeadZoneDelay.Value);
         }
 

--- a/SourceCode/GPS/Forms/Settings/FormSteerWiz.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSteerWiz.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Controls;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
@@ -626,7 +627,7 @@ namespace AgOpenGPS
 
         private void nudMaxCounts_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 if (isWizardStarted)
                 {
@@ -1162,7 +1163,7 @@ namespace AgOpenGPS
 
         private void nudWheelbase_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_wheelbase = (double)nudWheelbase.Value * mf.inchOrCm2m;
                 mf.vehicle.wheelbase = Properties.Settings.Default.setVehicle_wheelbase;
@@ -1172,7 +1173,7 @@ namespace AgOpenGPS
 
         private void nudVehicleTrack_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_trackWidth = (double)nudVehicleTrack.Value * mf.inchOrCm2m;
                 mf.vehicle.trackWidth = Properties.Settings.Default.setVehicle_trackWidth;
@@ -1183,7 +1184,7 @@ namespace AgOpenGPS
 
         private void nudAntennaPivot_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_antennaPivot = (double)nudAntennaPivot.Value * mf.inchOrCm2m;
                 mf.vehicle.antennaPivot = Properties.Settings.Default.setVehicle_antennaPivot;
@@ -1227,7 +1228,7 @@ namespace AgOpenGPS
 
         private void nudAntennaHeight_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_antennaHeight = (double)nudAntennaHeight.Value * mf.inchOrCm2m;
                 mf.vehicle.antennaHeight = Properties.Settings.Default.setVehicle_antennaHeight;
@@ -1237,7 +1238,7 @@ namespace AgOpenGPS
 
         private void nudAntennaOffset_Click(object sender, EventArgs e)
         {
-            if (mf.KeypadToNUD((NudlessNumericUpDown)sender, this))
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 Properties.Settings.Default.setVehicle_antennaOffset = (double)nudAntennaOffset.Value * mf.inchOrCm2m;
                 mf.vehicle.antennaOffset = Properties.Settings.Default.setVehicle_antennaOffset;


### PR DESCRIPTION
This removes the dependency to the main forms (`FormLoop` & `FormGPS`).