### PR TITLE
Fix AgIO not responding with wrong baud rate

### DIFF
--- a/SourceCode/AgIO/Source/AgIO.csproj
+++ b/SourceCode/AgIO/Source/AgIO.csproj
@@ -21,6 +21,7 @@
       <HintPath>..\..\References\RepeatButtonControl.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AgLibrary\AgLibrary.csproj" />

--- a/SourceCode/AgIO/Source/Forms/FormSerialMonitor.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSerialMonitor.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.IO;
 using System.IO.Ports;
 using System.Windows.Forms;
+using System.Windows.Threading;
 using AgLibrary.Logging;
 
 namespace AgIO
@@ -17,6 +18,7 @@ namespace AgIO
 
         public string recvSentence = "GPS";
         public SerialPort sp = new SerialPort(portName, baudRate, Parity.None, 8, StopBits.One);
+        private readonly Dispatcher _dispatcher;
 
         private bool logOn = false;
 
@@ -24,6 +26,7 @@ namespace AgIO
         {
             //get copy of the calling main form
             mf = callingForm as FormLoop;
+            _dispatcher = Dispatcher.CurrentDispatcher;
             InitializeComponent();
         }
 
@@ -98,7 +101,7 @@ namespace AgIO
                 try
                 {
                     string sentence = sp.ReadExisting();
-                    BeginInvoke((MethodInvoker)(() => ReceivePort(sentence)));
+                    _dispatcher.BeginInvoke(DispatcherPriority.Background, (MethodInvoker)(() => ReceivePort(sentence)));
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
The issue seems to be, that the message queue for the UI thread is being filled up with messages from the `BeginInvoke` call. The subsequent click on "Disconnect" then only triggers after all pending messages have been processed.
By using a lower `DispatcherPriority`, appending the message to the text box has a lower priority than clicking "Disconnect".
However, I am not a WinForms expert and I'm not sure if this is an optimal solution.