### PR TITLE
Add new `AgOpenGPS.Core` project

### DIFF
--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!-- Only write to build log in one project (AgOpenGPS), otherwise GitVersion will fail -->
+    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.Core/Properties/AssemblyInfo.cs
+++ b/SourceCode/AgOpenGPS.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AgOpenGPS.Core")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AgOpenGPS.Core")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("104C83B2-A4DD-4C4E-9D3B-754BA0C4F78E")]
+
+// Versioning is handled by the GitVersion.MsBuild NuGet package

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgLibrary", "AgLibrary\AgLi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgLibrary.Tests", "AgLibrary.Tests\AgLibrary.Tests.csproj", "{69DD4FB4-9119-4ABA-A7E4-5B789C49DC6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Core", "AgOpenGPS.Core\AgOpenGPS.Core.csproj", "{F2486554-D063-4CB0-8220-52883AFEF238}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,16 +58,20 @@ Global
 		{69DD4FB4-9119-4ABA-A7E4-5B789C49DC6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69DD4FB4-9119-4ABA-A7E4-5B789C49DC6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69DD4FB4-9119-4ABA-A7E4-5B789C49DC6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2486554-D063-4CB0-8220-52883AFEF238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2486554-D063-4CB0-8220-52883AFEF238}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2486554-D063-4CB0-8220-52883AFEF238}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2486554-D063-4CB0-8220-52883AFEF238}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_ConfirmAddLanguageFile = True
-		RESX_NeutralResourcesLanguage = en-US
-		RESX_SortFileContentOnSave = True
-		RESX_ShowErrorsInErrorList = False
-		SolutionGuid = {31C86FEF-A77A-49A7-9088-8E0D8AD2ACA5}
 		RESX_ResXSortingComparison = Ordinal
+		SolutionGuid = {31C86FEF-A77A-49A7-9088-8E0D8AD2ACA5}
+		RESX_ShowErrorsInErrorList = False
+		RESX_SortFileContentOnSave = True
+		RESX_NeutralResourcesLanguage = en-US
+		RESX_ConfirmAddLanguageFile = True
 	EndGlobalSection
 EndGlobal

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
+    <ProjectReference Include="..\AgOpenGPS.Core\AgOpenGPS.Core.csproj" />
     <ProjectReference Include="..\Keypad\Keypad.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The new `AgOpenGPS.Core` project will contain any future code that is specific to AgOpenGPS (not AgIO) but does not depend on WinForms.