### PR TITLE
Autoswitch Dual to Fix speed based

### DIFF
--- a/SourceCode/GPS/Classes/CAHRS.cs
+++ b/SourceCode/GPS/Classes/CAHRS.cs
@@ -16,7 +16,11 @@
         public double rollFilter;
 
         //is the auto steer in auto turn on mode or not
-        public bool isAutoSteerAuto, isRollInvert, autoswitchDualFix2FixOn, isDualAsIMU, isReverseOn;
+        public bool isAutoSteerAuto, isRollInvert, isDualAsIMU, isReverseOn;
+
+        // AutoswitchDualFix 
+        public bool autoSwitchDualFixOn;
+        public double autoSwitchDualFixSpeed;
 
         //the factor for fusion of GPS and IMU
         public double forwardComp, reverseComp, fusionWeight;
@@ -41,7 +45,9 @@
 
             isReverseOn = Properties.Settings.Default.setIMU_isReverseOn;
 
-            autoswitchDualFix2FixOn = Properties.Settings.Default.setAutoswitchDualFix2FixOn;
+            autoSwitchDualFixOn = Properties.Settings.Default.setAutoSwitchDualFixOn;
+
+            autoSwitchDualFixSpeed = Properties.Settings.Default.setAutoSwitchDualFixSpeed;
         }
     }
 }

--- a/SourceCode/GPS/Classes/CAHRS.cs
+++ b/SourceCode/GPS/Classes/CAHRS.cs
@@ -16,7 +16,7 @@
         public double rollFilter;
 
         //is the auto steer in auto turn on mode or not
-        public bool isAutoSteerAuto, isRollInvert, isReverseOn;
+        public bool isAutoSteerAuto, isRollInvert, autoswitchDualFix2FixOn, isDualAsIMU, isReverseOn;
 
         //the factor for fusion of GPS and IMU
         public double forwardComp, reverseComp, fusionWeight;
@@ -40,6 +40,8 @@
             isRollInvert = Properties.Settings.Default.setIMU_invertRoll;
 
             isReverseOn = Properties.Settings.Default.setIMU_isReverseOn;
+
+            autoswitchDualFix2FixOn = Properties.Settings.Default.setAutoswitchDualFix2FixOn;
         }
     }
 }

--- a/SourceCode/GPS/Culture/gStr.Designer.cs
+++ b/SourceCode/GPS/Culture/gStr.Designer.cs
@@ -241,6 +241,24 @@ namespace AgOpenGPS.Culture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto Dual &lt;&gt; Fix.
+        /// </summary>
+        public static string gsAutoSwitchDualFix {
+            get {
+                return ResourceManager.GetString("gsAutoSwitchDualFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch speed (km/h).
+        /// </summary>
+        public static string gsAutoSwitchDualFixSpeed {
+            get {
+                return ResourceManager.GetString("gsAutoSwitchDualFixSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Background.
         /// </summary>
         public static string gsBackground {

--- a/SourceCode/GPS/Culture/gStr.resx
+++ b/SourceCode/GPS/Culture/gStr.resx
@@ -969,4 +969,10 @@ USE AT OWN RISK.</value>
   <data name="v_SteerSettingsForm" xml:space="preserve">
     <value>https://www.youtube.com/watch?v=3SdvYgx8HHc</value>
   </data>
+  <data name="gsAutoSwitchDualFix" xml:space="preserve">
+    <value>Auto Dual &lt;&gt; Fix</value>
+  </data>
+  <data name="gsAutoSwitchDualFixSpeed" xml:space="preserve">
+    <value>Switch speed (km/h)</value>
+  </data>
 </root>

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -150,10 +150,9 @@ namespace AgOpenGPS
             pn.speed = pn.vtgSpeed;
             pn.AverageTheSpeed();
 
-            // FOR AUTOSWITCH DUALFIX START
-            if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
+            if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn)
             {
-                if (pn.speed > ahrs.autoSwitchDualFixSpeed || pn.speed < (ahrs.autoSwitchDualFixSpeed * -1))
+                if (Math.Abs(pn.speed) > ahrs.autoSwitchDualFixSpeed)
                 {
                     headingFromSource = "Fix";
                     ahrs.isDualAsIMU = true;
@@ -165,7 +164,6 @@ namespace AgOpenGPS
                     ahrs.imuHeading = 99999;
                 }
             }
-            // FOR AUTOSWITCH DUALFIX END
 
             #region Heading
             switch (headingFromSource)
@@ -175,12 +173,10 @@ namespace AgOpenGPS
                     {
                         #region Start
 
-                        // FOR AUTOSWITCH DUALFIX START
-                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn)
                         {
                             lblSpeed.ForeColor = System.Drawing.Color.Red;
                         }
-                        // FOR AUTOSWITCH DUALFIX END
 
                         distanceCurrentStepFixDisplay = glm.Distance(prevDistFix, pn.fix);
                         distanceCurrentStepFixDisplay *= 100;
@@ -686,13 +682,11 @@ namespace AgOpenGPS
 
                 case "Dual":
                     {
-                        // FOR AUTOSWITCH DUALFIX START
-                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn)
                         {
                             lblSpeed.ForeColor = System.Drawing.Color.Green;
                             isChangingDirection = false;
                         }
-                        // FOR AUTOSWITCH DUALFIX END
 
                         isFirstHeadingSet = true;
                         //use Dual Antenna heading for camera and tractor graphic

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -150,10 +150,10 @@ namespace AgOpenGPS
             pn.speed = pn.vtgSpeed;
             pn.AverageTheSpeed();
 
-            // FOR AUTOSWITCH DUALFIX2FIX START
-            if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+            // FOR AUTOSWITCH DUALFIX START
+            if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
             {
-                if (pn.speed > 2 || pn.speed < -2)
+                if (pn.speed > ahrs.autoSwitchDualFixSpeed || pn.speed < (ahrs.autoSwitchDualFixSpeed * -1))
                 {
                     headingFromSource = "Fix";
                     ahrs.isDualAsIMU = true;
@@ -165,7 +165,7 @@ namespace AgOpenGPS
                     ahrs.imuHeading = 99999;
                 }
             }
-            // FOR AUTOSWITCH DUALFIX2FIX END
+            // FOR AUTOSWITCH DUALFIX END
 
             #region Heading
             switch (headingFromSource)
@@ -175,12 +175,12 @@ namespace AgOpenGPS
                     {
                         #region Start
 
-                        // FOR AUTOSWITCH DUALFIX2FIX START
-                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+                        // FOR AUTOSWITCH DUALFIX START
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
                         {
                             lblSpeed.ForeColor = System.Drawing.Color.Red;
                         }
-                        // FOR AUTOSWITCH DUALFIX2FIX END
+                        // FOR AUTOSWITCH DUALFIX END
 
                         distanceCurrentStepFixDisplay = glm.Distance(prevDistFix, pn.fix);
                         distanceCurrentStepFixDisplay *= 100;
@@ -686,13 +686,13 @@ namespace AgOpenGPS
 
                 case "Dual":
                     {
-                        // FOR AUTOSWITCH DUALFIX2FIX START
-                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+                        // FOR AUTOSWITCH DUALFIX START
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoSwitchDualFixOn == true)
                         {
                             lblSpeed.ForeColor = System.Drawing.Color.Green;
                             isChangingDirection = false;
                         }
-                        // FOR AUTOSWITCH DUALFIX2FIX END
+                        // FOR AUTOSWITCH DUALFIX END
 
                         isFirstHeadingSet = true;
                         //use Dual Antenna heading for camera and tractor graphic

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -150,6 +150,23 @@ namespace AgOpenGPS
             pn.speed = pn.vtgSpeed;
             pn.AverageTheSpeed();
 
+            // FOR AUTOSWITCH DUALFIX2FIX START
+            if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+            {
+                if (pn.speed > 2 || pn.speed < -2)
+                {
+                    headingFromSource = "Fix";
+                    ahrs.isDualAsIMU = true;
+                }
+                else
+                {
+                    headingFromSource = "Dual";
+                    ahrs.isDualAsIMU = false;
+                    ahrs.imuHeading = 99999;
+                }
+            }
+            // FOR AUTOSWITCH DUALFIX2FIX END
+
             #region Heading
             switch (headingFromSource)
             {
@@ -157,6 +174,13 @@ namespace AgOpenGPS
                 case "Fix":
                     {
                         #region Start
+
+                        // FOR AUTOSWITCH DUALFIX2FIX START
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+                        {
+                            lblSpeed.ForeColor = System.Drawing.Color.Red;
+                        }
+                        // FOR AUTOSWITCH DUALFIX2FIX END
 
                         distanceCurrentStepFixDisplay = glm.Distance(prevDistFix, pn.fix);
                         distanceCurrentStepFixDisplay *= 100;
@@ -346,6 +370,7 @@ namespace AgOpenGPS
                         //imu on board
                         if (ahrs.imuHeading != 99999)
                         {
+                            isChangingDirection = false;
 
                             if (ahrs.isReverseOn)
                             {
@@ -480,6 +505,7 @@ namespace AgOpenGPS
                             else
                             {
                                 isReverse = false;
+                                isChangingDirection = false;
                             }
 
                             //set the headings
@@ -660,6 +686,14 @@ namespace AgOpenGPS
 
                 case "Dual":
                     {
+                        // FOR AUTOSWITCH DUALFIX2FIX START
+                        if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual" && ahrs.autoswitchDualFix2FixOn == true)
+                        {
+                            lblSpeed.ForeColor = System.Drawing.Color.Green;
+                            isChangingDirection = false;
+                        }
+                        // FOR AUTOSWITCH DUALFIX2FIX END
+
                         isFirstHeadingSet = true;
                         //use Dual Antenna heading for camera and tractor graphic
                         fixHeading = glm.toRadians(pn.headingTrueDual);
@@ -740,6 +774,14 @@ namespace AgOpenGPS
                         else if (smoothCamHeading < -glm.twoPI) smoothCamHeading += glm.twoPI;
 
                         camHeading = glm.toDegrees(smoothCamHeading);
+
+                        // FOR AUTOSWITCH DUALFIX2FIX START
+                        // save current fix and set as valid to make switch dual to fix2fix fluid
+                        for (int i = totalFixSteps - 1; i > 0; i--) stepFixPts[i] = stepFixPts[i - 1];
+                        stepFixPts[0].easting = pn.fix.easting;
+                        stepFixPts[0].northing = pn.fix.northing;
+                        stepFixPts[0].isSet = 1;
+                        // FOR AUTOSWITCH DUALFIX2FIX END
 
                         TheRest();
 

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -18,7 +18,7 @@ namespace AgOpenGPS
             
             if (rbtnHeadingHDT.Checked)
             {
-                if (Properties.Settings.Default.setAutoSwitchDualFixOn == true)
+                if (Properties.Settings.Default.setAutoSwitchDualFixOn)
                 {
                     rbtnHeadingFix.Enabled = false;
                     labelGboxSingle.Enabled = true;
@@ -49,7 +49,7 @@ namespace AgOpenGPS
 
             cboxIsReverseOn.Checked = Properties.Settings.Default.setIMU_isReverseOn;
             cboxIsAutoSwitchDualFixOn.Checked = Properties.Settings.Default.setAutoSwitchDualFixOn;
-            nudAutoSwitchDualFixSpeed.Value = Properties.Settings.Default.setAutoSwitchDualFixSpeed;
+            nudAutoSwitchDualFixSpeed.Value = (decimal)Properties.Settings.Default.setAutoSwitchDualFixSpeed;
 
             if (Properties.Settings.Default.setF_minHeadingStepDistance == 1.0)
                 cboxMinGPSStep.Checked = true;
@@ -80,11 +80,9 @@ namespace AgOpenGPS
                 hsbarFusion.Enabled = false;
             }
 
-            // FOR AUTOSWITCH DUALFIX START
-            if (cboxIsAutoSwitchDualFixOn.Checked == true) { 
+            if (cboxIsAutoSwitchDualFixOn.Checked) { 
                 hsbarFusion.Enabled = true;
             }
-            // FOR AUTOSWITCH DUALFIX STOP
 
             //nudMinimumFrameTime.Value = Properties.Settings.Default.SetGPS_udpWatchMsec;
 
@@ -126,18 +124,7 @@ namespace AgOpenGPS
 
             if (rbtnHeadingHDT.Checked)
             {
-                if (cboxIsAutoSwitchDualFixOn.Checked == true)
-                {
-                    rbtnHeadingFix.Enabled = false;
-                    labelGboxSingle.Enabled = true;
-                    labelGboxDual.Enabled = true;
-                }
-                else
-                {
-                    rbtnHeadingFix.Enabled = true;
-                    labelGboxSingle.Enabled = false;
-                    labelGboxDual.Enabled = true;
-                }
+                this.setAutoSwitchDualFixPanelOptions();
             }
             else
             {
@@ -212,25 +199,31 @@ namespace AgOpenGPS
 
         private void cboxIsAutoSwitchDualFixOn_CheckedChanged(object sender, EventArgs e)
         {
-            if (cboxIsAutoSwitchDualFixOn.Checked == true)
-            {
-                rbtnHeadingFix.Enabled = false;
-                labelGboxSingle.Enabled = true;
-                labelGboxDual.Enabled = true;
-            } else
-            {
-                rbtnHeadingFix.Enabled = true;
-                labelGboxSingle.Enabled = false;
-                labelGboxDual.Enabled = true;
-            }
+            this.setAutoSwitchDualFixPanelOptions();
         }
 
         private void nudAutoSwitchDualFixSpeed_Click(object sender, EventArgs e)
         {
             if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
-                Properties.Settings.Default.setAutoSwitchDualFixSpeed = ((int)nudAutoSwitchDualFixSpeed.Value);
+                Properties.Settings.Default.setAutoSwitchDualFixSpeed = ((double)nudAutoSwitchDualFixSpeed.Value);
                 mf.ahrs.autoSwitchDualFixSpeed = Properties.Settings.Default.setAutoSwitchDualFixSpeed;
+            }
+        }
+
+        private void setAutoSwitchDualFixPanelOptions()
+        {
+            if (cboxIsAutoSwitchDualFixOn.Checked)
+            {
+                rbtnHeadingFix.Enabled = false;
+                labelGboxSingle.Enabled = true;
+                labelGboxDual.Enabled = true;
+            }
+            else
+            {
+                rbtnHeadingFix.Enabled = true;
+                labelGboxSingle.Enabled = false;
+                labelGboxDual.Enabled = true;
             }
         }
 

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -40,6 +40,7 @@ namespace AgOpenGPS
             nudFixJumpDistance.Value = Properties.Settings.Default.setGPS_jumpFixAlarmDistance;
 
             cboxIsReverseOn.Checked = Properties.Settings.Default.setIMU_isReverseOn;
+            cboxIsAutoSwitchDualFix2FixOn.Checked = Properties.Settings.Default.setAutoswitchDualFix2FixOn;
 
             if (Properties.Settings.Default.setF_minHeadingStepDistance == 1.0)
                 cboxMinGPSStep.Checked = true;
@@ -70,6 +71,10 @@ namespace AgOpenGPS
                 hsbarFusion.Enabled = false;
             }
 
+            // FOR AUTOSWITCH DUALFIX2FIX START
+            hsbarFusion.Enabled = true;
+            // FOR AUTOSWITCH DUALFIX2FIX STOP
+
             //nudMinimumFrameTime.Value = Properties.Settings.Default.SetGPS_udpWatchMsec;
 
             //nudForwardComp.Value = (decimal)(Properties.Settings.Default.setGPS_forwardComp);
@@ -85,6 +90,8 @@ namespace AgOpenGPS
             Properties.Settings.Default.setGPS_isRTK = mf.isRTK_AlarmOn = cboxIsRTK.Checked;
 
             Properties.Settings.Default.setIMU_isReverseOn = mf.ahrs.isReverseOn = cboxIsReverseOn.Checked;
+            Properties.Settings.Default.setAutoswitchDualFix2FixOn = mf.ahrs.autoswitchDualFix2FixOn = cboxIsAutoSwitchDualFix2FixOn.Checked;
+
             Properties.Settings.Default.setGPS_isRTK_KillAutoSteer = mf.isRTK_KillAutosteer = cboxIsRTK_KillAutoSteer.Checked;
 
             if (cboxMinGPSStep.Checked)

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -18,8 +18,16 @@ namespace AgOpenGPS
             
             if (rbtnHeadingHDT.Checked)
             {
-                labelGboxSingle.Enabled = false;
-                labelGboxDual.Enabled = true;
+                if (Properties.Settings.Default.setAutoSwitchDualFixOn == true)
+                {
+                    rbtnHeadingFix.Enabled = false;
+                    labelGboxSingle.Enabled = true;
+                    labelGboxDual.Enabled = true;
+                } else
+                {
+                    labelGboxSingle.Enabled = false;
+                    labelGboxDual.Enabled = true;
+                }
             }
             else
             {
@@ -40,7 +48,8 @@ namespace AgOpenGPS
             nudFixJumpDistance.Value = Properties.Settings.Default.setGPS_jumpFixAlarmDistance;
 
             cboxIsReverseOn.Checked = Properties.Settings.Default.setIMU_isReverseOn;
-            cboxIsAutoSwitchDualFix2FixOn.Checked = Properties.Settings.Default.setAutoswitchDualFix2FixOn;
+            cboxIsAutoSwitchDualFixOn.Checked = Properties.Settings.Default.setAutoSwitchDualFixOn;
+            nudAutoSwitchDualFixSpeed.Value = Properties.Settings.Default.setAutoSwitchDualFixSpeed;
 
             if (Properties.Settings.Default.setF_minHeadingStepDistance == 1.0)
                 cboxMinGPSStep.Checked = true;
@@ -71,9 +80,11 @@ namespace AgOpenGPS
                 hsbarFusion.Enabled = false;
             }
 
-            // FOR AUTOSWITCH DUALFIX2FIX START
-            hsbarFusion.Enabled = true;
-            // FOR AUTOSWITCH DUALFIX2FIX STOP
+            // FOR AUTOSWITCH DUALFIX START
+            if (cboxIsAutoSwitchDualFixOn.Checked == true) { 
+                hsbarFusion.Enabled = true;
+            }
+            // FOR AUTOSWITCH DUALFIX STOP
 
             //nudMinimumFrameTime.Value = Properties.Settings.Default.SetGPS_udpWatchMsec;
 
@@ -90,7 +101,7 @@ namespace AgOpenGPS
             Properties.Settings.Default.setGPS_isRTK = mf.isRTK_AlarmOn = cboxIsRTK.Checked;
 
             Properties.Settings.Default.setIMU_isReverseOn = mf.ahrs.isReverseOn = cboxIsReverseOn.Checked;
-            Properties.Settings.Default.setAutoswitchDualFix2FixOn = mf.ahrs.autoswitchDualFix2FixOn = cboxIsAutoSwitchDualFix2FixOn.Checked;
+            Properties.Settings.Default.setAutoSwitchDualFixOn = mf.ahrs.autoSwitchDualFixOn = cboxIsAutoSwitchDualFixOn.Checked;
 
             Properties.Settings.Default.setGPS_isRTK_KillAutoSteer = mf.isRTK_KillAutosteer = cboxIsRTK_KillAutoSteer.Checked;
 
@@ -115,11 +126,22 @@ namespace AgOpenGPS
 
             if (rbtnHeadingHDT.Checked)
             {
-                labelGboxSingle.Enabled = false;
-                labelGboxDual.Enabled = true;
+                if (cboxIsAutoSwitchDualFixOn.Checked == true)
+                {
+                    rbtnHeadingFix.Enabled = false;
+                    labelGboxSingle.Enabled = true;
+                    labelGboxDual.Enabled = true;
+                }
+                else
+                {
+                    rbtnHeadingFix.Enabled = true;
+                    labelGboxSingle.Enabled = false;
+                    labelGboxDual.Enabled = true;
+                }
             }
             else
             {
+                rbtnHeadingFix.Enabled = true;
                 labelGboxSingle.Enabled = true;
                 labelGboxDual.Enabled= false;
             }
@@ -186,6 +208,30 @@ namespace AgOpenGPS
             lblFusionIMU.Text = (100 - hsbarFusion.Value).ToString()+"%";
 
             mf.ahrs.fusionWeight = (double)hsbarFusion.Value * 0.002;
+        }
+
+        private void cboxIsAutoSwitchDualFixOn_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cboxIsAutoSwitchDualFixOn.Checked == true)
+            {
+                rbtnHeadingFix.Enabled = false;
+                labelGboxSingle.Enabled = true;
+                labelGboxDual.Enabled = true;
+            } else
+            {
+                rbtnHeadingFix.Enabled = true;
+                labelGboxSingle.Enabled = false;
+                labelGboxDual.Enabled = true;
+            }
+        }
+
+        private void nudAutoSwitchDualFixSpeed_Click(object sender, EventArgs e)
+        {
+            if (((NudlessNumericUpDown)sender).ShowKeypad(this))
+            {
+                Properties.Settings.Default.setAutoSwitchDualFixSpeed = ((int)nudAutoSwitchDualFixSpeed.Value);
+                mf.ahrs.autoSwitchDualFixSpeed = Properties.Settings.Default.setAutoSwitchDualFixSpeed;
+            }
         }
 
         //private void nudForwardComp_Click(object sender, EventArgs e)

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -124,7 +124,7 @@ namespace AgOpenGPS
 
             if (rbtnHeadingHDT.Checked)
             {
-                this.setAutoSwitchDualFixPanelOptions();
+                SetAutoSwitchDualFixPanelOptions();
             }
             else
             {
@@ -199,7 +199,7 @@ namespace AgOpenGPS
 
         private void cboxIsAutoSwitchDualFixOn_CheckedChanged(object sender, EventArgs e)
         {
-            this.setAutoSwitchDualFixPanelOptions();
+            SetAutoSwitchDualFixPanelOptions();
         }
 
         private void nudAutoSwitchDualFixSpeed_Click(object sender, EventArgs e)
@@ -211,7 +211,7 @@ namespace AgOpenGPS
             }
         }
 
-        private void setAutoSwitchDualFixPanelOptions()
+        private void SetAutoSwitchDualFixPanelOptions()
         {
             if (cboxIsAutoSwitchDualFixOn.Checked)
             {

--- a/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
@@ -170,10 +170,10 @@ namespace AgOpenGPS
             this.tabTHitch = new System.Windows.Forms.TabPage();
             this.label112 = new System.Windows.Forms.Label();
             this.labelTractorUnits = new System.Windows.Forms.Label();
+            this.picboxToolHitch = new System.Windows.Forms.PictureBox();
             this.nudTrailingHitchLength = new AgOpenGPS.NudlessNumericUpDown();
             this.nudDrawbarLength = new AgOpenGPS.NudlessNumericUpDown();
             this.nudTankHitch = new AgOpenGPS.NudlessNumericUpDown();
-            this.picboxToolHitch = new System.Windows.Forms.PictureBox();
             this.tabToolOffset = new System.Windows.Forms.TabPage();
             this.btnZeroOverlap = new System.Windows.Forms.Button();
             this.btnZeroToolOffset = new System.Windows.Forms.Button();
@@ -309,6 +309,9 @@ namespace AgOpenGPS
             this.label113 = new System.Windows.Forms.Label();
             this.labelFixAlarm = new System.Windows.Forms.Label();
             this.labelGboxDual = new System.Windows.Forms.GroupBox();
+            this.labelAutoSwitchDualFixSpeed = new System.Windows.Forms.Label();
+            this.nudAutoSwitchDualFixSpeed = new AgOpenGPS.NudlessNumericUpDown();
+            this.cboxIsAutoSwitchDualFixOn = new System.Windows.Forms.CheckBox();
             this.labelReverseDistance = new System.Windows.Forms.Label();
             this.nudDualReverseDistance = new AgOpenGPS.NudlessNumericUpDown();
             this.pictureBox13 = new System.Windows.Forms.PictureBox();
@@ -546,7 +549,6 @@ namespace AgOpenGPS
             this.btnOK = new System.Windows.Forms.Button();
             this.labelUnitsBottom = new System.Windows.Forms.Label();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.cboxIsAutoSwitchDualFix2FixOn = new System.Windows.Forms.CheckBox();
             this.panelLeftSideMenu.SuspendLayout();
             this.panelArduinoSubMenu.SuspendLayout();
             this.panelDataSourcesSubMenu.SuspendLayout();
@@ -563,23 +565,23 @@ namespace AgOpenGPS
             ((System.ComponentModel.ISupportInitialize)(this.pboxAlpha)).BeginInit();
             this.tabVAntenna.SuspendLayout();
             this.labelAntOffset.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pboxAntenna)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaOffset)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaHeight)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaPivot)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pboxAntenna)).BeginInit();
             this.tabVDimensions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTractorHitchLength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudVehicleTrack)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudWheelbase)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.tabTConfig.SuspendLayout();
             this.labelBoxAttachmentStyle.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pboxConfigHarvester)).BeginInit();
             this.tabTHitch.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picboxToolHitch)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTrailingHitchLength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDrawbarLength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTankHitch)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.picboxToolHitch)).BeginInit();
             this.tabToolOffset.SuspendLayout();
             this.labelOverlapGap.SuspendLayout();
             this.labelToolOffset.SuspendLayout();
@@ -630,6 +632,7 @@ namespace AgOpenGPS
             ((System.ComponentModel.ISupportInitialize)(this.nudLookAhead)).BeginInit();
             this.tabDHeading.SuspendLayout();
             this.labelGboxDual.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoSwitchDualFixSpeed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDualReverseDistance)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox13)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDualHeadingOffset)).BeginInit();
@@ -2401,10 +2404,10 @@ namespace AgOpenGPS
             this.tabVAntenna.Controls.Add(this.label100);
             this.tabVAntenna.Controls.Add(this.label99);
             this.tabVAntenna.Controls.Add(this.label98);
+            this.tabVAntenna.Controls.Add(this.pboxAntenna);
             this.tabVAntenna.Controls.Add(this.nudAntennaOffset);
             this.tabVAntenna.Controls.Add(this.nudAntennaHeight);
             this.tabVAntenna.Controls.Add(this.nudAntennaPivot);
-            this.tabVAntenna.Controls.Add(this.pboxAntenna);
             this.tabVAntenna.Location = new System.Drawing.Point(4, 44);
             this.tabVAntenna.Name = "tabVAntenna";
             this.tabVAntenna.Size = new System.Drawing.Size(859, 584);
@@ -2582,6 +2585,16 @@ namespace AgOpenGPS
             this.label98.Text = "cm";
             this.label98.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
+            // pboxAntenna
+            // 
+            this.pboxAntenna.BackgroundImage = global::AgOpenGPS.Properties.Resources.AntennaTractor;
+            this.pboxAntenna.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.pboxAntenna.Location = new System.Drawing.Point(22, 106);
+            this.pboxAntenna.Name = "pboxAntenna";
+            this.pboxAntenna.Size = new System.Drawing.Size(514, 446);
+            this.pboxAntenna.TabIndex = 48;
+            this.pboxAntenna.TabStop = false;
+            // 
             // nudAntennaOffset
             // 
             this.nudAntennaOffset.BackColor = System.Drawing.Color.AliceBlue;
@@ -2658,16 +2671,6 @@ namespace AgOpenGPS
             0});
             this.nudAntennaPivot.Click += new System.EventHandler(this.nudAntennaPivot_Click);
             // 
-            // pboxAntenna
-            // 
-            this.pboxAntenna.BackgroundImage = global::AgOpenGPS.Properties.Resources.AntennaTractor;
-            this.pboxAntenna.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.pboxAntenna.Location = new System.Drawing.Point(22, 106);
-            this.pboxAntenna.Name = "pboxAntenna";
-            this.pboxAntenna.Size = new System.Drawing.Size(514, 446);
-            this.pboxAntenna.TabIndex = 48;
-            this.pboxAntenna.TabStop = false;
-            // 
             // tabVDimensions
             // 
             this.tabVDimensions.BackColor = System.Drawing.Color.WhiteSmoke;
@@ -2677,10 +2680,10 @@ namespace AgOpenGPS
             this.tabVDimensions.Controls.Add(this.labelHitchLength);
             this.tabVDimensions.Controls.Add(this.labelTrack);
             this.tabVDimensions.Controls.Add(this.labelWheelBase2);
+            this.tabVDimensions.Controls.Add(this.pictureBox1);
             this.tabVDimensions.Controls.Add(this.nudTractorHitchLength);
             this.tabVDimensions.Controls.Add(this.nudVehicleTrack);
             this.tabVDimensions.Controls.Add(this.nudWheelbase);
-            this.tabVDimensions.Controls.Add(this.pictureBox1);
             this.tabVDimensions.Location = new System.Drawing.Point(4, 44);
             this.tabVDimensions.Name = "tabVDimensions";
             this.tabVDimensions.Size = new System.Drawing.Size(859, 584);
@@ -2756,6 +2759,17 @@ namespace AgOpenGPS
             this.labelWheelBase2.Size = new System.Drawing.Size(70, 16);
             this.labelWheelBase2.TabIndex = 475;
             this.labelWheelBase2.Text = "Wheelbase";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = global::AgOpenGPS.Properties.Resources.RadiusWheelBase;
+            this.pictureBox1.InitialImage = null;
+            this.pictureBox1.Location = new System.Drawing.Point(4, 22);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(814, 545);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 32;
+            this.pictureBox1.TabStop = false;
             // 
             // nudTractorHitchLength
             // 
@@ -2838,17 +2852,6 @@ namespace AgOpenGPS
             0,
             0});
             this.nudWheelbase.Click += new System.EventHandler(this.nudWheelbase_Click);
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Image = global::AgOpenGPS.Properties.Resources.RadiusWheelBase;
-            this.pictureBox1.InitialImage = null;
-            this.pictureBox1.Location = new System.Drawing.Point(4, 22);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(814, 545);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox1.TabIndex = 32;
-            this.pictureBox1.TabStop = false;
             // 
             // tabVGuidance
             // 
@@ -2967,10 +2970,10 @@ namespace AgOpenGPS
             this.tabTHitch.BackColor = System.Drawing.Color.WhiteSmoke;
             this.tabTHitch.Controls.Add(this.label112);
             this.tabTHitch.Controls.Add(this.labelTractorUnits);
+            this.tabTHitch.Controls.Add(this.picboxToolHitch);
             this.tabTHitch.Controls.Add(this.nudTrailingHitchLength);
             this.tabTHitch.Controls.Add(this.nudDrawbarLength);
             this.tabTHitch.Controls.Add(this.nudTankHitch);
-            this.tabTHitch.Controls.Add(this.picboxToolHitch);
             this.tabTHitch.Location = new System.Drawing.Point(4, 44);
             this.tabTHitch.Name = "tabTHitch";
             this.tabTHitch.Size = new System.Drawing.Size(859, 584);
@@ -3004,6 +3007,16 @@ namespace AgOpenGPS
             this.labelTractorUnits.TabIndex = 485;
             this.labelTractorUnits.Text = "Units:";
             this.labelTractorUnits.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // picboxToolHitch
+            // 
+            this.picboxToolHitch.BackgroundImage = global::AgOpenGPS.Properties.Resources.ToolHitchPageFront;
+            this.picboxToolHitch.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.picboxToolHitch.Location = new System.Drawing.Point(13, 12);
+            this.picboxToolHitch.Name = "picboxToolHitch";
+            this.picboxToolHitch.Size = new System.Drawing.Size(838, 407);
+            this.picboxToolHitch.TabIndex = 0;
+            this.picboxToolHitch.TabStop = false;
             // 
             // nudTrailingHitchLength
             // 
@@ -3084,16 +3097,6 @@ namespace AgOpenGPS
             0,
             0});
             this.nudTankHitch.Click += new System.EventHandler(this.nudTankHitch_Click);
-            // 
-            // picboxToolHitch
-            // 
-            this.picboxToolHitch.BackgroundImage = global::AgOpenGPS.Properties.Resources.ToolHitchPageFront;
-            this.picboxToolHitch.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.picboxToolHitch.Location = new System.Drawing.Point(13, 12);
-            this.picboxToolHitch.Name = "picboxToolHitch";
-            this.picboxToolHitch.Size = new System.Drawing.Size(838, 407);
-            this.picboxToolHitch.TabIndex = 0;
-            this.picboxToolHitch.TabStop = false;
             // 
             // tabToolOffset
             // 
@@ -5437,7 +5440,7 @@ namespace AgOpenGPS
             this.labelFixAlarmStop.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelFixAlarmStop.ForeColor = System.Drawing.Color.Black;
             this.labelFixAlarmStop.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelFixAlarmStop.Location = new System.Drawing.Point(187, 395);
+            this.labelFixAlarmStop.Location = new System.Drawing.Point(200, 438);
             this.labelFixAlarmStop.Name = "labelFixAlarmStop";
             this.labelFixAlarmStop.Size = new System.Drawing.Size(142, 53);
             this.labelFixAlarmStop.TabIndex = 478;
@@ -5479,7 +5482,7 @@ namespace AgOpenGPS
             this.labelFixAlarm.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelFixAlarm.ForeColor = System.Drawing.Color.Black;
             this.labelFixAlarm.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelFixAlarm.Location = new System.Drawing.Point(34, 422);
+            this.labelFixAlarm.Location = new System.Drawing.Point(47, 465);
             this.labelFixAlarm.Name = "labelFixAlarm";
             this.labelFixAlarm.Size = new System.Drawing.Size(127, 28);
             this.labelFixAlarm.TabIndex = 471;
@@ -5489,7 +5492,9 @@ namespace AgOpenGPS
             // labelGboxDual
             // 
             this.labelGboxDual.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.labelGboxDual.Controls.Add(this.cboxIsAutoSwitchDualFix2FixOn);
+            this.labelGboxDual.Controls.Add(this.labelAutoSwitchDualFixSpeed);
+            this.labelGboxDual.Controls.Add(this.nudAutoSwitchDualFixSpeed);
+            this.labelGboxDual.Controls.Add(this.cboxIsAutoSwitchDualFixOn);
             this.labelGboxDual.Controls.Add(this.labelReverseDistance);
             this.labelGboxDual.Controls.Add(this.nudDualReverseDistance);
             this.labelGboxDual.Controls.Add(this.pictureBox13);
@@ -5498,10 +5503,72 @@ namespace AgOpenGPS
             this.labelGboxDual.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelGboxDual.Location = new System.Drawing.Point(3, 116);
             this.labelGboxDual.Name = "labelGboxDual";
-            this.labelGboxDual.Size = new System.Drawing.Size(385, 276);
+            this.labelGboxDual.Size = new System.Drawing.Size(385, 304);
             this.labelGboxDual.TabIndex = 471;
             this.labelGboxDual.TabStop = false;
             this.labelGboxDual.Text = "Dual Antenna Settings";
+            // 
+            // labelAutoSwitchDualFixSpeed
+            // 
+            this.labelAutoSwitchDualFixSpeed.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.labelAutoSwitchDualFixSpeed.AutoSize = true;
+            this.labelAutoSwitchDualFixSpeed.BackColor = System.Drawing.Color.Transparent;
+            this.labelAutoSwitchDualFixSpeed.Font = new System.Drawing.Font("Tahoma", 14.25F);
+            this.labelAutoSwitchDualFixSpeed.ForeColor = System.Drawing.Color.Black;
+            this.labelAutoSwitchDualFixSpeed.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.labelAutoSwitchDualFixSpeed.Location = new System.Drawing.Point(201, 225);
+            this.labelAutoSwitchDualFixSpeed.Name = "labelAutoSwitchDualFixSpeed";
+            this.labelAutoSwitchDualFixSpeed.Size = new System.Drawing.Size(184, 23);
+            this.labelAutoSwitchDualFixSpeed.TabIndex = 485;
+            this.labelAutoSwitchDualFixSpeed.Text = "Switch speed (km/h)";
+            this.labelAutoSwitchDualFixSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // nudAutoSwitchDualFixSpeed
+            // 
+            this.nudAutoSwitchDualFixSpeed.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.nudAutoSwitchDualFixSpeed.AutoSize = true;
+            this.nudAutoSwitchDualFixSpeed.BackColor = System.Drawing.Color.AliceBlue;
+            this.nudAutoSwitchDualFixSpeed.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold);
+            this.nudAutoSwitchDualFixSpeed.InterceptArrowKeys = false;
+            this.nudAutoSwitchDualFixSpeed.Location = new System.Drawing.Point(230, 254);
+            this.nudAutoSwitchDualFixSpeed.Maximum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.nudAutoSwitchDualFixSpeed.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudAutoSwitchDualFixSpeed.Name = "nudAutoSwitchDualFixSpeed";
+            this.nudAutoSwitchDualFixSpeed.ReadOnly = true;
+            this.nudAutoSwitchDualFixSpeed.Size = new System.Drawing.Size(144, 33);
+            this.nudAutoSwitchDualFixSpeed.TabIndex = 484;
+            this.nudAutoSwitchDualFixSpeed.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.nudAutoSwitchDualFixSpeed.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.nudAutoSwitchDualFixSpeed.Click += new System.EventHandler(this.nudAutoSwitchDualFixSpeed_Click);
+            // 
+            // cboxIsAutoSwitchDualFixOn
+            // 
+            this.cboxIsAutoSwitchDualFixOn.Appearance = System.Windows.Forms.Appearance.Button;
+            this.cboxIsAutoSwitchDualFixOn.BackColor = System.Drawing.Color.AliceBlue;
+            this.cboxIsAutoSwitchDualFixOn.FlatAppearance.CheckedBackColor = System.Drawing.Color.LightGreen;
+            this.cboxIsAutoSwitchDualFixOn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cboxIsAutoSwitchDualFixOn.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboxIsAutoSwitchDualFixOn.ForeColor = System.Drawing.Color.Black;
+            this.cboxIsAutoSwitchDualFixOn.Location = new System.Drawing.Point(15, 254);
+            this.cboxIsAutoSwitchDualFixOn.Name = "cboxIsAutoSwitchDualFixOn";
+            this.cboxIsAutoSwitchDualFixOn.Size = new System.Drawing.Size(209, 33);
+            this.cboxIsAutoSwitchDualFixOn.TabIndex = 483;
+            this.cboxIsAutoSwitchDualFixOn.Text = "Auto Dual <-> Fix";
+            this.cboxIsAutoSwitchDualFixOn.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.cboxIsAutoSwitchDualFixOn.UseVisualStyleBackColor = false;
+            this.cboxIsAutoSwitchDualFixOn.CheckedChanged += new System.EventHandler(this.cboxIsAutoSwitchDualFixOn_CheckedChanged);
             // 
             // labelReverseDistance
             // 
@@ -5511,7 +5578,7 @@ namespace AgOpenGPS
             this.labelReverseDistance.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelReverseDistance.ForeColor = System.Drawing.Color.Black;
             this.labelReverseDistance.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelReverseDistance.Location = new System.Drawing.Point(183, 143);
+            this.labelReverseDistance.Location = new System.Drawing.Point(182, 136);
             this.labelReverseDistance.Name = "labelReverseDistance";
             this.labelReverseDistance.Size = new System.Drawing.Size(189, 23);
             this.labelReverseDistance.TabIndex = 473;
@@ -5526,7 +5593,7 @@ namespace AgOpenGPS
             this.nudDualReverseDistance.DecimalPlaces = 2;
             this.nudDualReverseDistance.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.nudDualReverseDistance.InterceptArrowKeys = false;
-            this.nudDualReverseDistance.Location = new System.Drawing.Point(201, 173);
+            this.nudDualReverseDistance.Location = new System.Drawing.Point(200, 166);
             this.nudDualReverseDistance.Maximum = new decimal(new int[] {
             9,
             0,
@@ -5567,7 +5634,7 @@ namespace AgOpenGPS
             this.nudDualHeadingOffset.DecimalPlaces = 1;
             this.nudDualHeadingOffset.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.nudDualHeadingOffset.InterceptArrowKeys = false;
-            this.nudDualHeadingOffset.Location = new System.Drawing.Point(201, 82);
+            this.nudDualHeadingOffset.Location = new System.Drawing.Point(200, 75);
             this.nudDualHeadingOffset.Minimum = new decimal(new int[] {
             100,
             0,
@@ -5593,7 +5660,7 @@ namespace AgOpenGPS
             this.labelHeadingOffset.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelHeadingOffset.ForeColor = System.Drawing.Color.Black;
             this.labelHeadingOffset.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelHeadingOffset.Location = new System.Drawing.Point(156, 48);
+            this.labelHeadingOffset.Location = new System.Drawing.Point(155, 41);
             this.labelHeadingOffset.Name = "labelHeadingOffset";
             this.labelHeadingOffset.Size = new System.Drawing.Size(216, 23);
             this.labelHeadingOffset.TabIndex = 469;
@@ -5839,7 +5906,7 @@ namespace AgOpenGPS
             this.cboxIsRTK_KillAutoSteer.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cboxIsRTK_KillAutoSteer.ForeColor = System.Drawing.Color.Black;
             this.cboxIsRTK_KillAutoSteer.Image = global::AgOpenGPS.Properties.Resources.AutoSteerOff;
-            this.cboxIsRTK_KillAutoSteer.Location = new System.Drawing.Point(205, 451);
+            this.cboxIsRTK_KillAutoSteer.Location = new System.Drawing.Point(218, 494);
             this.cboxIsRTK_KillAutoSteer.Name = "cboxIsRTK_KillAutoSteer";
             this.cboxIsRTK_KillAutoSteer.Size = new System.Drawing.Size(103, 69);
             this.cboxIsRTK_KillAutoSteer.TabIndex = 477;
@@ -5856,7 +5923,7 @@ namespace AgOpenGPS
             this.cboxIsRTK.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cboxIsRTK.ForeColor = System.Drawing.Color.Black;
             this.cboxIsRTK.Image = global::AgOpenGPS.Properties.Resources.Con_SourcesRTKAlarm;
-            this.cboxIsRTK.Location = new System.Drawing.Point(46, 451);
+            this.cboxIsRTK.Location = new System.Drawing.Point(59, 494);
             this.cboxIsRTK.Name = "cboxIsRTK";
             this.cboxIsRTK.Size = new System.Drawing.Size(103, 69);
             this.cboxIsRTK.TabIndex = 309;
@@ -9712,24 +9779,6 @@ namespace AgOpenGPS
             this.timer1.Interval = 1000;
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
-            // cboxIsAutoSwitchDualFix2FixOn
-            // 
-            this.cboxIsAutoSwitchDualFix2FixOn.Appearance = System.Windows.Forms.Appearance.Button;
-            this.cboxIsAutoSwitchDualFix2FixOn.BackColor = System.Drawing.Color.AliceBlue;
-            this.cboxIsAutoSwitchDualFix2FixOn.Checked = true;
-            this.cboxIsAutoSwitchDualFix2FixOn.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cboxIsAutoSwitchDualFix2FixOn.FlatAppearance.CheckedBackColor = System.Drawing.Color.LightGreen;
-            this.cboxIsAutoSwitchDualFix2FixOn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.cboxIsAutoSwitchDualFix2FixOn.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cboxIsAutoSwitchDualFix2FixOn.ForeColor = System.Drawing.Color.Black;
-            this.cboxIsAutoSwitchDualFix2FixOn.Location = new System.Drawing.Point(19, 233);
-            this.cboxIsAutoSwitchDualFix2FixOn.Name = "cboxIsAutoSwitchDualFix2FixOn";
-            this.cboxIsAutoSwitchDualFix2FixOn.Size = new System.Drawing.Size(343, 37);
-            this.cboxIsAutoSwitchDualFix2FixOn.TabIndex = 483;
-            this.cboxIsAutoSwitchDualFix2FixOn.Text = "Autoswitch Dual Fix2Fix";
-            this.cboxIsAutoSwitchDualFix2FixOn.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.cboxIsAutoSwitchDualFix2FixOn.UseVisualStyleBackColor = false;
-            // 
             // FormConfig
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -9771,25 +9820,25 @@ namespace AgOpenGPS
             this.tabVAntenna.ResumeLayout(false);
             this.tabVAntenna.PerformLayout();
             this.labelAntOffset.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pboxAntenna)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaOffset)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaHeight)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudAntennaPivot)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pboxAntenna)).EndInit();
             this.tabVDimensions.ResumeLayout(false);
             this.tabVDimensions.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTractorHitchLength)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudVehicleTrack)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudWheelbase)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.tabTConfig.ResumeLayout(false);
             this.labelBoxAttachmentStyle.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pboxConfigHarvester)).EndInit();
             this.tabTHitch.ResumeLayout(false);
             this.tabTHitch.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picboxToolHitch)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTrailingHitchLength)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDrawbarLength)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTankHitch)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.picboxToolHitch)).EndInit();
             this.tabToolOffset.ResumeLayout(false);
             this.tabToolOffset.PerformLayout();
             this.labelOverlapGap.ResumeLayout(false);
@@ -9848,6 +9897,7 @@ namespace AgOpenGPS
             this.tabDHeading.PerformLayout();
             this.labelGboxDual.ResumeLayout(false);
             this.labelGboxDual.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoSwitchDualFixSpeed)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDualReverseDistance)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox13)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudDualHeadingOffset)).EndInit();
@@ -10409,6 +10459,8 @@ namespace AgOpenGPS
         private System.Windows.Forms.Button btnVehicleNewSave;
         private System.Windows.Forms.TextBox tboxCreateNewVehicle;
         private System.Windows.Forms.Label labelNew;
-        private System.Windows.Forms.CheckBox cboxIsAutoSwitchDualFix2FixOn;
+        private System.Windows.Forms.CheckBox cboxIsAutoSwitchDualFixOn;
+        private System.Windows.Forms.Label labelAutoSwitchDualFixSpeed;
+        private NudlessNumericUpDown nudAutoSwitchDualFixSpeed;
     }
 }

--- a/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
@@ -546,6 +546,7 @@ namespace AgOpenGPS
             this.btnOK = new System.Windows.Forms.Button();
             this.labelUnitsBottom = new System.Windows.Forms.Label();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.cboxIsAutoSwitchDualFix2FixOn = new System.Windows.Forms.CheckBox();
             this.panelLeftSideMenu.SuspendLayout();
             this.panelArduinoSubMenu.SuspendLayout();
             this.panelDataSourcesSubMenu.SuspendLayout();
@@ -1844,7 +1845,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDHolder.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDHolder.TabIndex = 136;
             this.rbtnBrand4WDHolder.TabStop = true;
-            this.rbtnBrand4WDHolder.Tag = WDBrand.Holder;
+            this.rbtnBrand4WDHolder.Tag = AgOpenGPS.WDBrand.Holder;
             this.rbtnBrand4WDHolder.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDHolder.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1861,7 +1862,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDAgOpenGPS.Name = "rbtnBrand4WDAgOpenGPS";
             this.rbtnBrand4WDAgOpenGPS.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDAgOpenGPS.TabIndex = 131;
-            this.rbtnBrand4WDAgOpenGPS.Tag = WDBrand.AgOpenGPS;
+            this.rbtnBrand4WDAgOpenGPS.Tag = AgOpenGPS.WDBrand.AgOpenGPS;
             this.rbtnBrand4WDAgOpenGPS.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDAgOpenGPS.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1880,7 +1881,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDChallenger.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDChallenger.TabIndex = 132;
             this.rbtnBrand4WDChallenger.TabStop = true;
-            this.rbtnBrand4WDChallenger.Tag = WDBrand.Challenger;
+            this.rbtnBrand4WDChallenger.Tag = AgOpenGPS.WDBrand.Challenger;
             this.rbtnBrand4WDChallenger.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDChallenger.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1899,7 +1900,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDCase.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDCase.TabIndex = 133;
             this.rbtnBrand4WDCase.TabStop = true;
-            this.rbtnBrand4WDCase.Tag = WDBrand.Case;
+            this.rbtnBrand4WDCase.Tag = AgOpenGPS.WDBrand.Case;
             this.rbtnBrand4WDCase.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDCase.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1918,7 +1919,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDNH.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDNH.TabIndex = 135;
             this.rbtnBrand4WDNH.TabStop = true;
-            this.rbtnBrand4WDNH.Tag = WDBrand.NewHolland;
+            this.rbtnBrand4WDNH.Tag = AgOpenGPS.WDBrand.NewHolland;
             this.rbtnBrand4WDNH.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDNH.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1937,7 +1938,7 @@ namespace AgOpenGPS
             this.rbtnBrand4WDJDeere.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrand4WDJDeere.TabIndex = 134;
             this.rbtnBrand4WDJDeere.TabStop = true;
-            this.rbtnBrand4WDJDeere.Tag = WDBrand.JDeere;
+            this.rbtnBrand4WDJDeere.Tag = AgOpenGPS.WDBrand.JDeere;
             this.rbtnBrand4WDJDeere.UseVisualStyleBackColor = true;
             this.rbtnBrand4WDJDeere.CheckedChanged += new System.EventHandler(this.Brand4WDCheckedChanged);
             // 
@@ -1979,7 +1980,7 @@ namespace AgOpenGPS
             this.rbtnBrandHAgOpenGPS.Name = "rbtnBrandHAgOpenGPS";
             this.rbtnBrandHAgOpenGPS.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandHAgOpenGPS.TabIndex = 127;
-            this.rbtnBrandHAgOpenGPS.Tag = HBrand.AgOpenGPS;
+            this.rbtnBrandHAgOpenGPS.Tag = AgOpenGPS.HBrand.AgOpenGPS;
             this.rbtnBrandHAgOpenGPS.UseVisualStyleBackColor = true;
             this.rbtnBrandHAgOpenGPS.CheckedChanged += new System.EventHandler(this.HarvesterBrandCheckedChanged);
             // 
@@ -1998,7 +1999,7 @@ namespace AgOpenGPS
             this.rbtnBrandHCase.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandHCase.TabIndex = 114;
             this.rbtnBrandHCase.TabStop = true;
-            this.rbtnBrandHCase.Tag = HBrand.Case;
+            this.rbtnBrandHCase.Tag = AgOpenGPS.HBrand.Case;
             this.rbtnBrandHCase.UseVisualStyleBackColor = true;
             this.rbtnBrandHCase.CheckedChanged += new System.EventHandler(this.HarvesterBrandCheckedChanged);
             // 
@@ -2017,7 +2018,7 @@ namespace AgOpenGPS
             this.rbtnBrandHClaas.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandHClaas.TabIndex = 116;
             this.rbtnBrandHClaas.TabStop = true;
-            this.rbtnBrandHClaas.Tag = HBrand.Claas;
+            this.rbtnBrandHClaas.Tag = AgOpenGPS.HBrand.Claas;
             this.rbtnBrandHClaas.UseVisualStyleBackColor = true;
             this.rbtnBrandHClaas.CheckedChanged += new System.EventHandler(this.HarvesterBrandCheckedChanged);
             // 
@@ -2036,7 +2037,7 @@ namespace AgOpenGPS
             this.rbtnBrandHJDeere.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandHJDeere.TabIndex = 129;
             this.rbtnBrandHJDeere.TabStop = true;
-            this.rbtnBrandHJDeere.Tag = HBrand.JDeere;
+            this.rbtnBrandHJDeere.Tag = AgOpenGPS.HBrand.JDeere;
             this.rbtnBrandHJDeere.UseVisualStyleBackColor = true;
             this.rbtnBrandHJDeere.CheckedChanged += new System.EventHandler(this.HarvesterBrandCheckedChanged);
             // 
@@ -2055,7 +2056,7 @@ namespace AgOpenGPS
             this.rbtnBrandHNH.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandHNH.TabIndex = 130;
             this.rbtnBrandHNH.TabStop = true;
-            this.rbtnBrandHNH.Tag = HBrand.NewHolland;
+            this.rbtnBrandHNH.Tag = AgOpenGPS.HBrand.NewHolland;
             this.rbtnBrandHNH.UseVisualStyleBackColor = true;
             this.rbtnBrandHNH.CheckedChanged += new System.EventHandler(this.HarvesterBrandCheckedChanged);
             // 
@@ -2094,7 +2095,7 @@ namespace AgOpenGPS
             this.rbtnBrandTAgOpenGPS.Name = "rbtnBrandTAgOpenGPS";
             this.rbtnBrandTAgOpenGPS.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTAgOpenGPS.TabIndex = 126;
-            this.rbtnBrandTAgOpenGPS.Tag = TBrand.AGOpenGPS;
+            this.rbtnBrandTAgOpenGPS.Tag = AgOpenGPS.TBrand.AGOpenGPS;
             this.rbtnBrandTAgOpenGPS.UseVisualStyleBackColor = true;
             this.rbtnBrandTAgOpenGPS.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2111,7 +2112,7 @@ namespace AgOpenGPS
             this.rbtnBrandTCase.Name = "rbtnBrandTCase";
             this.rbtnBrandTCase.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTCase.TabIndex = 114;
-            this.rbtnBrandTCase.Tag = TBrand.Case;
+            this.rbtnBrandTCase.Tag = AgOpenGPS.TBrand.Case;
             this.rbtnBrandTCase.UseVisualStyleBackColor = true;
             this.rbtnBrandTCase.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2128,7 +2129,7 @@ namespace AgOpenGPS
             this.rbtnBrandTClaas.Name = "rbtnBrandTClaas";
             this.rbtnBrandTClaas.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTClaas.TabIndex = 115;
-            this.rbtnBrandTClaas.Tag = TBrand.Claas;
+            this.rbtnBrandTClaas.Tag = AgOpenGPS.TBrand.Claas;
             this.rbtnBrandTClaas.UseVisualStyleBackColor = true;
             this.rbtnBrandTClaas.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2145,7 +2146,7 @@ namespace AgOpenGPS
             this.rbtnBrandTDeutz.Name = "rbtnBrandTDeutz";
             this.rbtnBrandTDeutz.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTDeutz.TabIndex = 116;
-            this.rbtnBrandTDeutz.Tag = TBrand.Deutz;
+            this.rbtnBrandTDeutz.Tag = AgOpenGPS.TBrand.Deutz;
             this.rbtnBrandTDeutz.UseVisualStyleBackColor = true;
             this.rbtnBrandTDeutz.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2162,7 +2163,7 @@ namespace AgOpenGPS
             this.rbtnBrandTFendt.Name = "rbtnBrandTFendt";
             this.rbtnBrandTFendt.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTFendt.TabIndex = 117;
-            this.rbtnBrandTFendt.Tag = TBrand.Fendt;
+            this.rbtnBrandTFendt.Tag = AgOpenGPS.TBrand.Fendt;
             this.rbtnBrandTFendt.UseVisualStyleBackColor = true;
             this.rbtnBrandTFendt.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2179,7 +2180,7 @@ namespace AgOpenGPS
             this.rbtnBrandTJDeere.Name = "rbtnBrandTJDeere";
             this.rbtnBrandTJDeere.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTJDeere.TabIndex = 118;
-            this.rbtnBrandTJDeere.Tag = TBrand.JDeere;
+            this.rbtnBrandTJDeere.Tag = AgOpenGPS.TBrand.JDeere;
             this.rbtnBrandTJDeere.UseVisualStyleBackColor = true;
             this.rbtnBrandTJDeere.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2196,7 +2197,7 @@ namespace AgOpenGPS
             this.rbtnBrandTKubota.Name = "rbtnBrandTKubota";
             this.rbtnBrandTKubota.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTKubota.TabIndex = 119;
-            this.rbtnBrandTKubota.Tag = TBrand.Kubota;
+            this.rbtnBrandTKubota.Tag = AgOpenGPS.TBrand.Kubota;
             this.rbtnBrandTKubota.UseVisualStyleBackColor = true;
             this.rbtnBrandTKubota.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2213,7 +2214,7 @@ namespace AgOpenGPS
             this.rbtnBrandTMassey.Name = "rbtnBrandTMassey";
             this.rbtnBrandTMassey.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTMassey.TabIndex = 120;
-            this.rbtnBrandTMassey.Tag = TBrand.Massey;
+            this.rbtnBrandTMassey.Tag = AgOpenGPS.TBrand.Massey;
             this.rbtnBrandTMassey.UseVisualStyleBackColor = true;
             this.rbtnBrandTMassey.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2230,7 +2231,7 @@ namespace AgOpenGPS
             this.rbtnBrandTNH.Name = "rbtnBrandTNH";
             this.rbtnBrandTNH.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTNH.TabIndex = 121;
-            this.rbtnBrandTNH.Tag = TBrand.NewHolland;
+            this.rbtnBrandTNH.Tag = AgOpenGPS.TBrand.NewHolland;
             this.rbtnBrandTNH.UseVisualStyleBackColor = true;
             this.rbtnBrandTNH.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2247,7 +2248,7 @@ namespace AgOpenGPS
             this.rbtnBrandTSame.Name = "rbtnBrandTSame";
             this.rbtnBrandTSame.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTSame.TabIndex = 122;
-            this.rbtnBrandTSame.Tag = TBrand.Same;
+            this.rbtnBrandTSame.Tag = AgOpenGPS.TBrand.Same;
             this.rbtnBrandTSame.UseVisualStyleBackColor = true;
             this.rbtnBrandTSame.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2264,7 +2265,7 @@ namespace AgOpenGPS
             this.rbtnBrandTSteyr.Name = "rbtnBrandTSteyr";
             this.rbtnBrandTSteyr.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTSteyr.TabIndex = 123;
-            this.rbtnBrandTSteyr.Tag = TBrand.Steyr;
+            this.rbtnBrandTSteyr.Tag = AgOpenGPS.TBrand.Steyr;
             this.rbtnBrandTSteyr.UseVisualStyleBackColor = true;
             this.rbtnBrandTSteyr.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2281,7 +2282,7 @@ namespace AgOpenGPS
             this.rbtnBrandTValtra.Name = "rbtnBrandTValtra";
             this.rbtnBrandTValtra.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTValtra.TabIndex = 125;
-            this.rbtnBrandTValtra.Tag = TBrand.Valtra;
+            this.rbtnBrandTValtra.Tag = AgOpenGPS.TBrand.Valtra;
             this.rbtnBrandTValtra.UseVisualStyleBackColor = true;
             this.rbtnBrandTValtra.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -2298,7 +2299,7 @@ namespace AgOpenGPS
             this.rbtnBrandTUrsus.Name = "rbtnBrandTUrsus";
             this.rbtnBrandTUrsus.Size = new System.Drawing.Size(64, 64);
             this.rbtnBrandTUrsus.TabIndex = 124;
-            this.rbtnBrandTUrsus.Tag = TBrand.Ursus;
+            this.rbtnBrandTUrsus.Tag = AgOpenGPS.TBrand.Ursus;
             this.rbtnBrandTUrsus.UseVisualStyleBackColor = true;
             this.rbtnBrandTUrsus.CheckedChanged += new System.EventHandler(this.TractorBrandCheckedChanged);
             // 
@@ -5488,6 +5489,7 @@ namespace AgOpenGPS
             // labelGboxDual
             // 
             this.labelGboxDual.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.labelGboxDual.Controls.Add(this.cboxIsAutoSwitchDualFix2FixOn);
             this.labelGboxDual.Controls.Add(this.labelReverseDistance);
             this.labelGboxDual.Controls.Add(this.nudDualReverseDistance);
             this.labelGboxDual.Controls.Add(this.pictureBox13);
@@ -5496,7 +5498,7 @@ namespace AgOpenGPS
             this.labelGboxDual.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelGboxDual.Location = new System.Drawing.Point(3, 116);
             this.labelGboxDual.Name = "labelGboxDual";
-            this.labelGboxDual.Size = new System.Drawing.Size(385, 228);
+            this.labelGboxDual.Size = new System.Drawing.Size(385, 276);
             this.labelGboxDual.TabIndex = 471;
             this.labelGboxDual.TabStop = false;
             this.labelGboxDual.Text = "Dual Antenna Settings";
@@ -5509,7 +5511,7 @@ namespace AgOpenGPS
             this.labelReverseDistance.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelReverseDistance.ForeColor = System.Drawing.Color.Black;
             this.labelReverseDistance.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelReverseDistance.Location = new System.Drawing.Point(173, 137);
+            this.labelReverseDistance.Location = new System.Drawing.Point(183, 143);
             this.labelReverseDistance.Name = "labelReverseDistance";
             this.labelReverseDistance.Size = new System.Drawing.Size(189, 23);
             this.labelReverseDistance.TabIndex = 473;
@@ -5524,7 +5526,7 @@ namespace AgOpenGPS
             this.nudDualReverseDistance.DecimalPlaces = 2;
             this.nudDualReverseDistance.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.nudDualReverseDistance.InterceptArrowKeys = false;
-            this.nudDualReverseDistance.Location = new System.Drawing.Point(191, 167);
+            this.nudDualReverseDistance.Location = new System.Drawing.Point(201, 173);
             this.nudDualReverseDistance.Maximum = new decimal(new int[] {
             9,
             0,
@@ -5565,7 +5567,7 @@ namespace AgOpenGPS
             this.nudDualHeadingOffset.DecimalPlaces = 1;
             this.nudDualHeadingOffset.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.nudDualHeadingOffset.InterceptArrowKeys = false;
-            this.nudDualHeadingOffset.Location = new System.Drawing.Point(191, 63);
+            this.nudDualHeadingOffset.Location = new System.Drawing.Point(201, 82);
             this.nudDualHeadingOffset.Minimum = new decimal(new int[] {
             100,
             0,
@@ -5591,7 +5593,7 @@ namespace AgOpenGPS
             this.labelHeadingOffset.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.labelHeadingOffset.ForeColor = System.Drawing.Color.Black;
             this.labelHeadingOffset.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelHeadingOffset.Location = new System.Drawing.Point(146, 29);
+            this.labelHeadingOffset.Location = new System.Drawing.Point(156, 48);
             this.labelHeadingOffset.Name = "labelHeadingOffset";
             this.labelHeadingOffset.Size = new System.Drawing.Size(216, 23);
             this.labelHeadingOffset.TabIndex = 469;
@@ -9710,6 +9712,24 @@ namespace AgOpenGPS
             this.timer1.Interval = 1000;
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
+            // cboxIsAutoSwitchDualFix2FixOn
+            // 
+            this.cboxIsAutoSwitchDualFix2FixOn.Appearance = System.Windows.Forms.Appearance.Button;
+            this.cboxIsAutoSwitchDualFix2FixOn.BackColor = System.Drawing.Color.AliceBlue;
+            this.cboxIsAutoSwitchDualFix2FixOn.Checked = true;
+            this.cboxIsAutoSwitchDualFix2FixOn.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cboxIsAutoSwitchDualFix2FixOn.FlatAppearance.CheckedBackColor = System.Drawing.Color.LightGreen;
+            this.cboxIsAutoSwitchDualFix2FixOn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cboxIsAutoSwitchDualFix2FixOn.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboxIsAutoSwitchDualFix2FixOn.ForeColor = System.Drawing.Color.Black;
+            this.cboxIsAutoSwitchDualFix2FixOn.Location = new System.Drawing.Point(19, 233);
+            this.cboxIsAutoSwitchDualFix2FixOn.Name = "cboxIsAutoSwitchDualFix2FixOn";
+            this.cboxIsAutoSwitchDualFix2FixOn.Size = new System.Drawing.Size(343, 37);
+            this.cboxIsAutoSwitchDualFix2FixOn.TabIndex = 483;
+            this.cboxIsAutoSwitchDualFix2FixOn.Text = "Autoswitch Dual Fix2Fix";
+            this.cboxIsAutoSwitchDualFix2FixOn.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.cboxIsAutoSwitchDualFix2FixOn.UseVisualStyleBackColor = false;
+            // 
             // FormConfig
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -10389,5 +10409,6 @@ namespace AgOpenGPS
         private System.Windows.Forms.Button btnVehicleNewSave;
         private System.Windows.Forms.TextBox tboxCreateNewVehicle;
         private System.Windows.Forms.Label labelNew;
+        private System.Windows.Forms.CheckBox cboxIsAutoSwitchDualFix2FixOn;
     }
 }

--- a/SourceCode/GPS/Forms/Settings/FormConfig.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.cs
@@ -266,6 +266,8 @@ namespace AgOpenGPS
             labelSectionLinesOnOff.Text = gStr.gsSectionLines;
             labelElevationOnOff.Text = gStr.gsElevationlog;
             unitsGroupBox.Text = gStr.gsUnits;
+            cboxIsAutoSwitchDualFixOn.Text = gStr.gsAutoSwitchDualFix;
+            labelAutoSwitchDualFixSpeed.Text = gStr.gsAutoSwitchDualFixSpeed;
 
             UpdateSummary();
 

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -85,6 +85,8 @@ namespace AgOpenGPS
                                     pn.headingTrueDual = temp + pn.headingTrueDualOffset;
                                     if (pn.headingTrueDual >= 360) pn.headingTrueDual -= 360;
                                     else if (pn.headingTrueDual < 0) pn.headingTrueDual += 360;
+
+                                    if (ahrs.isDualAsIMU) ahrs.imuHeading = pn.headingTrueDual;
                                 }
 
                                 //from single antenna sentences (VTG,RMC)

--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -275,7 +275,7 @@ namespace AgOpenGPS.Properties
         public bool setDisplay_isLineSmooth = false;
         public Size setWindow_tramLineSize = new Size(921, 676);
         public bool setAutoSwitchDualFixOn = false;
-        public int setAutoSwitchDualFixSpeed = 2;
+        public double setAutoSwitchDualFixSpeed = 2.0;
 
         public LoadResult Load()
         {

--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -274,6 +274,7 @@ namespace AgOpenGPS.Properties
         public bool setDisplay_isSectionLinesOn = true;
         public bool setDisplay_isLineSmooth = false;
         public Size setWindow_tramLineSize = new Size(921, 676);
+        public bool setAutoswitchDualFix2FixOn = true;
 
         public LoadResult Load()
         {

--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -274,7 +274,8 @@ namespace AgOpenGPS.Properties
         public bool setDisplay_isSectionLinesOn = true;
         public bool setDisplay_isLineSmooth = false;
         public Size setWindow_tramLineSize = new Size(921, 676);
-        public bool setAutoswitchDualFix2FixOn = true;
+        public bool setAutoSwitchDualFixOn = false;
+        public int setAutoSwitchDualFixSpeed = 2;
 
         public LoadResult Load()
         {


### PR DESCRIPTION
Driving with Dual ensures that you know your driving direction quickly (almost) from a standstill. Perfect for starting from a standstill, or for turning well into the planting beds on small plots. The disadvantage for us is that with certain soil cultivation and driving on loose ploughed land, the tractor starts driving crooked and becomes restless at high speed. The direction that the Dual transmits is then no longer the actual driving direction. Here is a proposal to combine the best of both worlds. AG to automatically switch from Dual to Fix based on speed. For a quickly available driving direction, start with Dual and when you are driving above 2 km/h, switch to Fix for the correct driving direction.