### PR TITLE
Enable building of AgOpenGPS without cloning with Git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,16 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
 
+    - name: Setup GitVersion
+      uses: gittools/actions/gitversion/setup@v3.1.11
+      with:
+        versionSpec: '5.12.x'
+
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v3.1.11
+      with:
+        updateAssemblyInfo: true
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
 
+    - name: Setup GitVersion
+      uses: gittools/actions/gitversion/setup@v3.1.11
+      with:
+        versionSpec: '5.12.x'
+
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v3.1.11
+      with:
+        updateAssemblyInfo: true
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ See the PCB repo for PCB layouts, firmware for steering and rate control, machin
 Even on your desktop
 3. Run AgOpenGPS.exe
 
-## Add your own code
+## Building
 
 1. Clone this repository (e.g. use Visual Studio to do so)
-2. When succesfully cloned it create a git structure which is necessary to build the program.
-3. add your code and (re)build.
+2. Open the solution (`SourceCode/AgOpenGPS.sln`) in Visual Studio
+3. Add your code and (re)build
 
 ## Contributing
 

--- a/SourceCode/AgIO/Source/AgIO.csproj
+++ b/SourceCode/AgIO/Source/AgIO.csproj
@@ -9,8 +9,6 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
-    <!-- Only write to build log in one project (AgOpenGPS), otherwise GitVersion will fail -->
-    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -26,9 +24,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\AgLibrary\AgLibrary.csproj" />
     <ProjectReference Include="..\..\Keypad\Keypad.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Forms\Controls.Designer.cs">

--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -288,7 +288,7 @@ namespace AgIO
                     Environment.Exit(0);
                 }
             }
-            this.Text = "AgIO  v" + GitVersionInformation.MajorMinorPatch + "   Using Profile: " 
+            this.Text = "AgIO  v" + Program.Version + "   Using Profile: " 
                 + RegistrySettings.profileName;
         }
 

--- a/SourceCode/AgIO/Source/Forms/FormLoop.cs
+++ b/SourceCode/AgIO/Source/Forms/FormLoop.cs
@@ -259,7 +259,7 @@ namespace AgIO
             cboxAutoRunGPS_Out.Checked = Properties.Settings.Default.setDisplay_isAutoRunGPS_Out;
             
             this.Text =
-            "AgIO  v" + GitVersionInformation.MajorMinorPatch + " Profile: " + RegistrySettings.profileName;
+            "AgIO  v" + Program.Version + " Profile: " + RegistrySettings.profileName;
 
             if (RegistrySettings.profileName == "")
             {
@@ -278,7 +278,7 @@ namespace AgIO
                         Environment.Exit(0);
                     }
                 }
-                this.Text = "AgIO  v" + GitVersionInformation.MajorMinorPatch + " Profile: "
+                this.Text = "AgIO  v" + Program.Version + " Profile: "
                     + RegistrySettings.profileName;
             }
 

--- a/SourceCode/AgIO/Source/Program.cs
+++ b/SourceCode/AgIO/Source/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Configuration;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -13,6 +14,8 @@ namespace AgIO
     internal static class Program
     {
         private static readonly Mutex Mutex = new Mutex(true, "{8F6F0AC4-B9A1-55fd-A8CF-72F04E6BDE8F}");
+
+        public static readonly string Version = Assembly.GetEntryAssembly().GetName().Version.ToString(3); // Major.Minor.Patch
 
         /// <summary>
         /// The main entry point for the application.

--- a/SourceCode/AgIO/Source/Properties/AssemblyInfo.cs
+++ b/SourceCode/AgIO/Source/Properties/AssemblyInfo.cs
@@ -22,6 +22,16 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c88a8244-47f5-4275-aa35-54cc884e9ede")]
 
-// Versioning is handled by the GitVersion.MsBuild NuGet package
-
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: NeutralResourcesLanguage("en-CA")]

--- a/SourceCode/AgLibrary/AgLibrary.csproj
+++ b/SourceCode/AgLibrary/AgLibrary.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <!-- Only write to build log in one project (AgOpenGPS), otherwise GitVersion will fail -->
-    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
-  </ItemGroup>
+
 </Project>

--- a/SourceCode/AgLibrary/Properties/AssemblyInfo.cs
+++ b/SourceCode/AgLibrary/Properties/AssemblyInfo.cs
@@ -22,4 +22,15 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("692b4970-37f1-4f02-8f7f-a514283fc399")]
 
-// Versioning is handled by the GitVersion.MsBuild NuGet package
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -4,12 +4,6 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <!-- Only write to build log in one project (AgOpenGPS), otherwise GitVersion will fail -->
-    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
-  </ItemGroup>
 
 </Project>

--- a/SourceCode/AgOpenGPS.Core/Properties/AssemblyInfo.cs
+++ b/SourceCode/AgOpenGPS.Core/Properties/AssemblyInfo.cs
@@ -22,4 +22,15 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("104C83B2-A4DD-4C4E-9D3B-754BA0C4F78E")]
 
-// Versioning is handled by the GitVersion.MsBuild NuGet package
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Control.Draggable" Version="1.0.5049.269" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.3.3" />
     <PackageReference Include="Resource.Embedder" Version="2.2.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/SourceCode/GPS/Forms/Form_About.cs
+++ b/SourceCode/GPS/Forms/Form_About.cs
@@ -24,7 +24,7 @@ namespace AgOpenGPS
 
         private void Form_About_Load(object sender, EventArgs e)
         {
-            lblVersion.Text = "Version " + GitVersionInformation.SemVer;
+            lblVersion.Text = "Version " + Program.SemVer;
 
             // Add a link to the LinkLabel.
             LinkLabel.Link link = new LinkLabel.Link { LinkData = "https://github.com/AgOpenGPS-Official/AgOpenGPS" };

--- a/SourceCode/GPS/Forms/Form_First.cs
+++ b/SourceCode/GPS/Forms/Form_First.cs
@@ -34,7 +34,7 @@ namespace AgOpenGPS
             labelTermsOne.Text = gStr.gsTermsOne;
             labelTerms2.Text = gStr.gsTermsTwo;
             labelTerms3.Text = gStr.gsTermsThree;
-            labelTermsAndVersion.Text = gStr.gsTermsConditions + GitVersionInformation.SemVer;
+            labelTermsAndVersion.Text = gStr.gsTermsConditions + Program.SemVer;
             labelDiscussionsAt.Text = gStr.gsDiscussions;
             labelCheckForUpdates.Text = gStr.gsCheckForUpdates;
 

--- a/SourceCode/GPS/Forms/Form_Help.cs
+++ b/SourceCode/GPS/Forms/Form_Help.cs
@@ -33,7 +33,7 @@ namespace AgOpenGPS
 
         private void Form_About_Load(object sender, EventArgs e)
         {
-            lblVersion.Text = "Version " + GitVersionInformation.SemVer;
+            lblVersion.Text = "Version " + Program.SemVer;
 
             // Add a link to the LinkLabel.
             LinkLabel.Link link = new LinkLabel.Link { LinkData = "https://github.com/farmerbriantee/AgOpenGPS/releases" };

--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -416,7 +416,7 @@ namespace AgOpenGPS
 
         public void LoadSettings()
         {
-            btnChangeMappingColor.Text = GitVersionInformation.MajorMinorPatch;
+            btnChangeMappingColor.Text = Program.Version;
 
             //metric settings
             isMetric = Settings.Default.setMenu_isMetric;
@@ -570,7 +570,7 @@ namespace AgOpenGPS
             else btnHeadlandOnOff.Image = Properties.Resources.HeadlandOff;
 
             //btnChangeMappingColor.BackColor = sectionColorDay;
-            btnChangeMappingColor.Text = GitVersionInformation.MajorMinorPatch;
+            btnChangeMappingColor.Text = Program.Version;
 
             if (Properties.Settings.Default.setDisplay_isStartFullScreen)
             {

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -529,8 +529,7 @@ namespace AgOpenGPS
                         }
                     }
 
-                    bool isPreRelease = !string.IsNullOrEmpty(GitVersionInformation.PreReleaseTag);
-                    if (isPreRelease) DrawBeta();
+                    if (Program.IsPreRelease) DrawBeta();
 
                     if (pn.age > pn.ageAlarm) DrawAge();
 
@@ -2760,7 +2759,7 @@ namespace AgOpenGPS
         private void DrawBeta()
         {
             GL.Color3(1f, 1f, 1f);
-            font.DrawText(-oglMain.Width / 2.1, oglMain.Height / 1.2, "Beta Testing v" + GitVersionInformation.SemVer, 0.8);
+            font.DrawText(-oglMain.Width / 2.1, oglMain.Height / 1.2, "Beta Testing v" + Program.SemVer, 0.8);
         }
 
         private void DrawAge()

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -529,7 +529,14 @@ namespace AgOpenGPS
                         }
                     }
 
-                    if (Program.IsPreRelease) DrawBeta();
+                    if (Program.IsDevelopVersion)
+                    {
+                        DrawVersion("DEVELOP VERSION");
+                    }
+                    else if (Program.IsPreRelease)
+                    {
+                        DrawVersion("Beta Testing v" + Program.SemVer);
+                    }
 
                     if (pn.age > pn.ageAlarm) DrawAge();
 
@@ -2756,10 +2763,10 @@ namespace AgOpenGPS
             font.DrawText(-oglMain.Width / 3, oglMain.Height / 3, "RTK Fix Lost", 2);
         }
 
-        private void DrawBeta()
+        private void DrawVersion(string version)
         {
             GL.Color3(1f, 1f, 1f);
-            font.DrawText(-oglMain.Width / 2.1, oglMain.Height / 1.2, "Beta Testing v" + Program.SemVer, 0.8);
+            font.DrawText(-oglMain.Width / 2.1, oglMain.Height / 1.2, version, 0.8);
         }
 
         private void DrawAge()

--- a/SourceCode/GPS/Program.cs
+++ b/SourceCode/GPS/Program.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -10,6 +12,10 @@ namespace AgOpenGPS
         /// The main entry point for the application.
         /// </summary>
         private static readonly Mutex Mutex = new Mutex(true, "{516-0AC5-B9A1-55fd-A8CE-72F04E6BDE8F}");
+
+        public static readonly string Version = Assembly.GetEntryAssembly().GetName().Version.ToString(3); // Major.Minor.Patch
+        public static readonly string SemVer = Application.ProductVersion.Split('+').First();
+        public static readonly bool IsPreRelease = Application.ProductVersion.Contains('-');
 
         [STAThread]
         private static void Main()

--- a/SourceCode/GPS/Program.cs
+++ b/SourceCode/GPS/Program.cs
@@ -16,6 +16,7 @@ namespace AgOpenGPS
         public static readonly string Version = Assembly.GetEntryAssembly().GetName().Version.ToString(3); // Major.Minor.Patch
         public static readonly string SemVer = Application.ProductVersion.Split('+').First();
         public static readonly bool IsPreRelease = Application.ProductVersion.Contains('-');
+        public static readonly bool IsDevelopVersion = Application.ProductVersion == "1.0.0.0";
 
         [STAThread]
         private static void Main()

--- a/SourceCode/GPS/Properties/AssemblyInfo.cs
+++ b/SourceCode/GPS/Properties/AssemblyInfo.cs
@@ -21,4 +21,15 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("43d3e75e-dc8b-4c3a-8931-9495e1467d01")]
 
-// Versioning is handled by the GitVersion.MsBuild NuGet package
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Removes the requirement for cloning the AgOpenGPS repository with Git according to the discussion in #597.

Changes:
- Do not use the static `GitVersionInformation` class to retrieve version information (necessary for the next step)
- Remove the `GitVersion.MSBuild` NuGet package
- Local build versions will have version `1.0.0.0` now and the watermark will display "DEVELOP VERSION"
- The actual version will be set in the GitHub workflow using GitVersion