### PR TITLE
Refactored Dubins classes

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/GeoCircle.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/GeoCircle.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace AgOpenGPS.Core.Models
+{
+    public enum TurnType { Straight, Left, Right }
+
+    public struct GeoCircle
+    {
+
+        public GeoCircle(GeoCoord center, double radius)
+        {
+            Center = center;
+            Radius = radius;
+        }
+
+        public GeoCoord Center { get; }
+        public double Radius { get; }
+
+        public GeoCoord PointOnCircle(GeoDir dir)
+        {
+            return Center + Radius * dir;
+        }
+
+        public double GetArcLength(
+            GeoCoord startPos,
+            GeoCoord goalPos,
+            TurnType turnType)
+        {
+            Debug.Assert(turnType != TurnType.Straight);
+            GeoDir startDir = new GeoDir(startPos - Center);
+            GeoDir goalDir = new GeoDir(goalPos - Center);
+
+            double theta = goalDir.Angle - startDir.Angle;
+
+            if (TurnType.Right == turnType)
+            {
+                if (theta < 0.0) theta += 2.0 * Math.PI;
+            }
+            else if (TurnType.Left == turnType)
+            {
+                if (theta > 0.0) theta -= 2.0 * Math.PI;
+            }
+            return Math.Abs(theta * Radius);
+        }
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
@@ -119,7 +119,9 @@ namespace AgOpenGPS.Core.Models
 
         static public bool PathIsPossible(GeoCircle startCircle, GeoCircle goalCircle)
         {
-            bool isPossible = startCircle.Center.Easting != goalCircle.Center.Easting && startCircle.Center.Northing != goalCircle.Center.Northing;
+            bool isPossible =
+                startCircle.Center.Easting != goalCircle.Center.Easting ||
+                startCircle.Center.Northing != goalCircle.Center.Northing;
             return isPossible;
         }
 
@@ -155,7 +157,7 @@ namespace AgOpenGPS.Core.Models
         static public bool PathIsPossible(GeoCircle startCircle, GeoCircle goalCircle)
         {
             //RSL and LSR is only working of the circles don't intersect
-            return startCircle.Center.DistanceSquared(goalCircle.Center) > 2.0 * startCircle.Radius * 2.0 * goalCircle.Radius;
+            return startCircle.Center.Distance(goalCircle.Center) > startCircle.Radius + goalCircle.Radius;
         }
 
         protected override void ComputeTangents(

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
@@ -1,0 +1,265 @@
+﻿using AgOpenGPS.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace AgOpenGPS.Core.Models
+{
+    public abstract class DubinsPath
+    {
+        protected DubinsPathConstraints _constraints;
+
+        protected GeoCircle _startCircle;
+        protected GeoCircle _middleCircle;
+        protected GeoCircle _goalCircle;
+
+        protected GeoCoord _startTangent;
+        protected GeoCoord _goalTangent;
+        private bool _isComputed = false;
+
+        protected double _length1, _length2, _length3;
+        protected double _totalLength;
+
+        protected abstract void ComputeTangents(
+            GeoCircle startCircle,
+            TurnType startTurnType,
+            GeoCircle goalCircle,
+            out GeoCoord startTangent,
+            out GeoCoord goalTangent);
+
+        // Technical note
+        // DubinsPath does not call Compute() in the constructor, because it relies on the virtual function 
+        // ComputeTangents. It delays computation to the moment that somebody asks for the Length
+        public DubinsPath(
+            DubinsPathConstraints constraints,
+            TurnType startTurnType,
+            TurnType middleTurnType,
+            TurnType goalTurnType)
+        {
+            _constraints = constraints;
+            StartTurnType = startTurnType;
+            MiddleTurnType = middleTurnType;
+            GoalTurnType = goalTurnType;
+            _isComputed = false;
+        }
+
+        public TurnType StartTurnType { get; }
+        public TurnType MiddleTurnType { get; }
+        public TurnType GoalTurnType { get; }
+
+        public double TotalLength
+        {
+            get
+            {
+                Compute();
+                return _totalLength;
+            }
+        }
+
+        public double Length1
+        {
+            get
+            {
+                Compute();
+                return _length1;
+            }
+        }
+
+        public double Length2
+        {
+            get
+            {
+                Compute();
+                return _length2;
+            }
+        }
+
+        public double Length3
+        {
+            get
+            {
+                Compute();
+                return _length3;
+            }
+        }
+
+        private void Compute()
+        {
+            if (_isComputed) return;
+            _isComputed = true;
+            _startCircle = ComputeCircle(_constraints.StartConstraint, _constraints.RadiusConstraint, StartTurnType);
+            _goalCircle = ComputeCircle(_constraints.GoalConstraint, _constraints.RadiusConstraint, GoalTurnType);
+            ComputeTangents(_startCircle, StartTurnType, _goalCircle, out _startTangent, out _goalTangent);
+            _length1 = _startCircle.GetArcLength(_constraints.StartConstraint.Coord, _startTangent, StartTurnType);
+            _length2 = MiddleTurnType == TurnType.Straight ?
+                (_goalTangent - _startTangent).Length :
+                _middleCircle.GetArcLength(_startTangent, _goalTangent, MiddleTurnType);
+            _length3 = _goalCircle.GetArcLength(_goalTangent, _constraints.GoalConstraint.Coord, GoalTurnType);
+            _totalLength = _length1 + _length2 + _length3;
+        }
+
+        public static GeoCircle ComputeCircle(GeoCoordDir cdOnCircle, double radius, TurnType turnType)
+        {
+            Debug.Assert(turnType != TurnType.Straight);
+            GeoDir dir = turnType == TurnType.Right ? cdOnCircle.Direction.PerpendicularRight : cdOnCircle.Direction.PerpendicularLeft;
+            return new GeoCircle(cdOnCircle.Coord + radius * dir, radius);
+        }
+    }
+
+    // Base class of LslDubinsPath and RsrDubinsPath
+    public abstract class OuterDubinsPath : DubinsPath
+    {
+        public OuterDubinsPath(
+            DubinsPathConstraints constraints,
+            TurnType startTurnType, TurnType goalTurnType) : base(constraints, startTurnType, TurnType.Straight, goalTurnType)
+        {
+            Debug.Assert(startTurnType != TurnType.Straight);
+            Debug.Assert(goalTurnType != TurnType.Straight);
+        }
+
+        static public bool PathIsPossible(GeoCircle startCircle, GeoCircle goalCircle)
+        {
+            bool isPossible = startCircle.Center.Easting != goalCircle.Center.Easting && startCircle.Center.Northing != goalCircle.Center.Northing;
+            return isPossible;
+        }
+
+        protected override void ComputeTangents(
+            GeoCircle startCircle,
+            TurnType startTurnType,
+            GeoCircle goalCircle,
+            out GeoCoord startTangent,
+            out GeoCoord goalTangent)
+        {
+            Debug.Assert(TurnType.Straight != startTurnType);
+            GeoDelta delta = (goalCircle.Center - startCircle.Center);
+            GeoDir direction = new GeoDir(delta);
+            GeoDir tangentDir = (TurnType.Right == startTurnType) ? direction.PerpendicularLeft : direction.PerpendicularRight;
+
+            startTangent = startCircle.PointOnCircle(tangentDir);
+            goalTangent = goalCircle.PointOnCircle(tangentDir);
+        }
+    }
+
+    // Base class of RslDubinsPath and LsrDubinsPath
+    public abstract class InnerDubinsPath : DubinsPath
+    {
+        public InnerDubinsPath(
+            DubinsPathConstraints constraints,
+            TurnType startTurnType,
+            TurnType goalTurnType) : base(constraints, startTurnType, TurnType.Straight, goalTurnType)
+        {
+            Debug.Assert(startTurnType != TurnType.Straight);
+            Debug.Assert(goalTurnType != TurnType.Straight);
+        }
+
+        static public bool PathIsPossible(GeoCircle startCircle, GeoCircle goalCircle)
+        {
+            //RSL and LSR is only working of the circles don't intersect
+            return startCircle.Center.DistanceSquared(goalCircle.Center) > 2.0 * startCircle.Radius * 2.0 * goalCircle.Radius;
+        }
+
+        protected override void ComputeTangents(
+            GeoCircle startCircle,
+            TurnType startTurnType,
+            GeoCircle goalCircle,
+            out GeoCoord startTangent,
+            out GeoCoord goalTangent)
+        {
+            Debug.Assert(TurnType.Straight != startTurnType);
+            GeoDelta delta = goalCircle.Center - startCircle.Center;
+            GeoDir direction = new GeoDir(delta);
+
+            //If the circles have the same radius we can use cosine and not the law of cosines
+            //to calculate the angle to the first tangent coordinate
+            double theta = Math.Acos((2 * startCircle.Radius) / delta.Length);
+
+            GeoDir startTangentDir = (TurnType.Right == startTurnType) ? direction - theta : direction + theta;
+            startTangent = startCircle.PointOnCircle(startTangentDir);
+            goalTangent = goalCircle.PointOnCircle(startTangentDir.Inverted);
+        }
+    }
+
+    // Base class of RlrDubinsPath and LrlDubinsPath
+    public abstract class CurvedDubinsPath : DubinsPath
+    {
+        public CurvedDubinsPath(
+            DubinsPathConstraints constraints,
+            TurnType startTurnType,
+            TurnType middleTurnType,
+            TurnType goalTurnType) : base(constraints, startTurnType, middleTurnType, goalTurnType)
+        {
+            Debug.Assert(middleTurnType != TurnType.Straight);
+        }
+
+        static public bool PathIsPossible(GeoCircle startCircle, GeoCircle goalCircle)
+        {
+            // With the LRL and RLR paths, the distance between the circles has to be less than 4 * r
+            return
+                startCircle.Center.DistanceSquared(goalCircle.Center) < 4.0 * startCircle.Radius * 4.0 * goalCircle.Radius;
+        }
+
+        protected override void ComputeTangents(
+            GeoCircle startCircle,
+            TurnType startTurnType,
+            GeoCircle goalCircle,
+            out GeoCoord startTangent,
+            out GeoCoord goalTangent)
+        {
+            Debug.Assert(TurnType.Straight != startTurnType);
+            GeoDelta delta = goalCircle.Center - startCircle.Center;
+            GeoDir direction = new GeoDir(delta);
+            double D = delta.Length;
+
+            //The angle between the goal and the new 3rd circle we create with the law of cosines
+            double theta = Math.Acos(D / (4f * _constraints.RadiusConstraint));
+
+            GeoDir startTangentDir = (TurnType.Left == startTurnType) ? direction + theta : direction - theta;
+            _middleCircle = new GeoCircle(startCircle.Center + 2 * startCircle.Radius * startTangentDir, startCircle.Radius);
+
+            startTangent = _middleCircle.PointOnCircle(new GeoDir(startCircle.Center - _middleCircle.Center));
+            goalTangent = _middleCircle.PointOnCircle(new GeoDir(goalCircle.Center - _middleCircle.Center));
+        }
+    }
+
+    public class LslDubinsPath : OuterDubinsPath
+    {
+        public LslDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Left, TurnType.Left)
+        {
+        }
+    }
+
+    public class RsrDubinsPath : OuterDubinsPath
+    {
+        public RsrDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Right, TurnType.Right)
+        {
+        }
+    }
+
+    public class RslDubinsPath : InnerDubinsPath
+    {
+        public RslDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Right, TurnType.Left)
+        {
+        }
+    }
+
+    public class LsrDubinsPath : InnerDubinsPath
+    {
+        public LsrDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Left, TurnType.Right)
+        {
+        }
+    }
+
+    public class RlrDubinsPath : CurvedDubinsPath
+    {
+        public RlrDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Right, TurnType.Left, TurnType.Right)
+        {
+        }
+    }
+
+    public class LrlDubinsPath : CurvedDubinsPath
+    {
+        public LrlDubinsPath(DubinsPathConstraints constraints) : base(constraints, TurnType.Left, TurnType.Right, TurnType.Left)
+        {
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPath.cs
@@ -197,7 +197,7 @@ namespace AgOpenGPS.Core.Models
         {
             // With the LRL and RLR paths, the distance between the circles has to be less than 4 * r
             return
-                startCircle.Center.DistanceSquared(goalCircle.Center) < 4.0 * startCircle.Radius * 4.0 * goalCircle.Radius;
+                startCircle.Center.Distance(goalCircle.Center) < 2.0 * (startCircle.Radius + goalCircle.Radius);
         }
 
         protected override void ComputeTangents(

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathConstraints.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathConstraints.cs
@@ -1,0 +1,19 @@
+﻿using AgOpenGPS.Core.Models;
+
+namespace AgOpenGPS.Core.Models
+{
+    public class DubinsPathConstraints
+    {
+
+        public DubinsPathConstraints(GeoCoordDir startConstraint, GeoCoordDir goalConstraint, double radiusConstraint)
+        {
+            StartConstraint = startConstraint;
+            GoalConstraint = goalConstraint;
+            RadiusConstraint = radiusConstraint;
+        }
+
+        public GeoCoordDir StartConstraint { get; }
+        public GeoCoordDir GoalConstraint { get; }
+        public double RadiusConstraint { get; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathSelector.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathSelector.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AgOpenGPS.Core.Models
+{
+    public class DubinsPathSelector
+    {
+        private readonly DubinsPathConstraints _constraints;
+        public List<DubinsPath> paths = new List<DubinsPath>();
+
+        public DubinsPathSelector(DubinsPathConstraints constraints)
+        {
+            _constraints = constraints;
+            GeoCircle startRightCircle = DubinsPath.ComputeCircle(constraints.StartConstraint, constraints.RadiusConstraint, TurnType.Right);
+            GeoCircle startLeftCircle = DubinsPath.ComputeCircle(constraints.StartConstraint, constraints.RadiusConstraint, TurnType.Left);
+            GeoCircle goalRightCircle = DubinsPath.ComputeCircle(constraints.GoalConstraint, constraints.RadiusConstraint, TurnType.Right);
+            GeoCircle goalLeftCircle = DubinsPath.ComputeCircle(constraints.GoalConstraint, constraints.RadiusConstraint, TurnType.Left);
+
+            // 2 x OuterDubinsPath
+            if (RsrDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
+            {
+                paths.Add(new RsrDubinsPath(_constraints));
+            }
+            if (LslDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
+            {
+                paths.Add(new LslDubinsPath(_constraints));
+            }
+            // 2 x CurvedDubinsPath
+            if (LrlDubinsPath.PathIsPossible(startLeftCircle, goalLeftCircle))
+            {
+                paths.Add(new LrlDubinsPath(_constraints));
+            }
+            if (RlrDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
+            {
+                paths.Add(new RlrDubinsPath(_constraints));
+            }
+            // 2 x InnerDubinsPath
+            if (RslDubinsPath.PathIsPossible(startRightCircle, goalLeftCircle))
+            {
+                paths.Add(new RslDubinsPath(_constraints));
+            }
+            if (LsrDubinsPath.PathIsPossible(startLeftCircle, goalRightCircle))
+            {
+                paths.Add(new LsrDubinsPath(_constraints));
+            }
+            paths.Sort((x, y) => x.TotalLength.CompareTo(y.TotalLength));
+        }
+    }
+
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathSelector.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Guidance/DubinsPathSelector.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace AgOpenGPS.Core.Models
 {
     public class DubinsPathSelector
     {
         private readonly DubinsPathConstraints _constraints;
-        public List<DubinsPath> paths = new List<DubinsPath>();
+        private List<DubinsPath> _paths = new List<DubinsPath>();
 
         public DubinsPathSelector(DubinsPathConstraints constraints)
         {
@@ -19,32 +20,35 @@ namespace AgOpenGPS.Core.Models
             // 2 x OuterDubinsPath
             if (RsrDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
             {
-                paths.Add(new RsrDubinsPath(_constraints));
+                _paths.Add(new RsrDubinsPath(_constraints));
             }
-            if (LslDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
+            if (LslDubinsPath.PathIsPossible(startLeftCircle, goalLeftCircle))
             {
-                paths.Add(new LslDubinsPath(_constraints));
+                _paths.Add(new LslDubinsPath(_constraints));
             }
             // 2 x CurvedDubinsPath
             if (LrlDubinsPath.PathIsPossible(startLeftCircle, goalLeftCircle))
             {
-                paths.Add(new LrlDubinsPath(_constraints));
+                _paths.Add(new LrlDubinsPath(_constraints));
             }
             if (RlrDubinsPath.PathIsPossible(startRightCircle, goalRightCircle))
             {
-                paths.Add(new RlrDubinsPath(_constraints));
+                _paths.Add(new RlrDubinsPath(_constraints));
             }
             // 2 x InnerDubinsPath
             if (RslDubinsPath.PathIsPossible(startRightCircle, goalLeftCircle))
             {
-                paths.Add(new RslDubinsPath(_constraints));
+                _paths.Add(new RslDubinsPath(_constraints));
             }
             if (LsrDubinsPath.PathIsPossible(startLeftCircle, goalRightCircle))
             {
-                paths.Add(new LsrDubinsPath(_constraints));
+                _paths.Add(new LsrDubinsPath(_constraints));
             }
-            paths.Sort((x, y) => x.TotalLength.CompareTo(y.TotalLength));
+            _paths.Sort((x, y) => x.TotalLength.CompareTo(y.TotalLength));
         }
+
+        public ReadOnlyCollection<DubinsPath> Paths => _paths.AsReadOnly();
+
     }
 
 }


### PR DESCRIPTION
The refactored code for generation and selection of a DubinsPath is shorter en less complex than the original, for a number of reasons:
- the code for generating and selection is clearly separated
- the code for generating delegates repating parts of the job to the new base class GeoCircle.
- Each type of DubinsPath (RSR, LSL, RSL, LSR, RLR, LRL) has its own class that knows best how to do the computation.
- In the original code angle==0.0 meant 'to the East', which is very confusing because (almost) all other code angle==0.0 means 'to the North'

The results for all six types of DubinsPath equals the results of the original code, except for RLR and LRL.
It turns out that the original code is wrong in these cases. The original LRL, RLR are too long and therefor not selected as best option. This could explain how these bugs stayed unnoticed.