### PR TITLE
Add test project for `AgOpenGPS.Core` and a WPF example application

### DIFF
--- a/SourceCode/AgOpenGPS.Core.Tests/AgOpenGPS.Core.Tests.csproj
+++ b/SourceCode/AgOpenGPS.Core.Tests/AgOpenGPS.Core.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.Core\AgOpenGPS.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoCoordTests.cs
+++ b/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoCoordTests.cs
@@ -1,0 +1,36 @@
+﻿using AgOpenGPS.Core.Models;
+using NUnit.Framework;
+
+namespace AgOpenGPS.Core.Tests.Models
+{
+    public class GeoCoordTests
+    {
+        [Test]
+        public void DistanceSquared_ShouldBeCorrect()
+        {
+            // Arrange
+            GeoCoord coord1 = new GeoCoord(0.0, 3.0);
+            GeoCoord coord2 = new GeoCoord(4.0, 0.0);
+
+            // Act
+            double result = coord1.DistanceSquared(coord2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(25.0));
+        }
+
+        [Test]
+        public void Distance_ShouldBeCorrect()
+        {
+            // Arrange
+            GeoCoord coord1 = new GeoCoord(0.0, 3.0);
+            GeoCoord coord2 = new GeoCoord(4.0, 0.0);
+
+            // Act
+            double result = coord1.Distance(coord2);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(5.0));
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/AgOpenGPS.WpfApp.csproj
+++ b/SourceCode/AgOpenGPS.WpfApp/AgOpenGPS.WpfApp.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.WpfViews\AgOpenGPS.WpfViews.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="AgOpenGPS.WpfApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AgOpenGPS.WpfApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace AgOpenGPS.WpfApp
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+
+}

--- a/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml
@@ -1,0 +1,13 @@
+﻿<Window x:Class="AgOpenGPS.WpfApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AgOpenGPS.WpfApp"
+        xmlns:wpfviews="clr-namespace:AgOpenGPS.WpfViews;assembly=AgOpenGPS.WpfViews"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <wpfviews:TestView />
+    </Grid>
+</Window>

--- a/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AgOpenGPS.WpfApp
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/Properties/AssemblyInfo.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AgOpenGPS.WpfApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AgOpenGPS.WpfApp")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("14B0F605-13CF-4CC0-AD2C-6699B8D87CDC")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/SourceCode/AgOpenGPS.WpfViews/AgOpenGPS.WpfViews.csproj
+++ b/SourceCode/AgOpenGPS.WpfViews/AgOpenGPS.WpfViews.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgOpenGPS.Core\AgOpenGPS.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SourceCode/AgOpenGPS.WpfViews/TestView.xaml
+++ b/SourceCode/AgOpenGPS.WpfViews/TestView.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfViews.TestView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:AgOpenGPS.WpfViews"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TextBlock VerticalAlignment="Center"
+                   HorizontalAlignment="Center"
+                   FontSize="24"
+                   FontWeight="Bold"
+                   Text="I am a test" />
+    </Grid>
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfViews/TestView.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfViews/TestView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AgOpenGPS.WpfViews
+{
+    /// <summary>
+    /// Interaction logic for TestView.xaml
+    /// </summary>
+    public partial class TestView : UserControl
+    {
+        public TestView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgLibrary.Tests", "AgLibrar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Core", "AgOpenGPS.Core\AgOpenGPS.Core.csproj", "{F2486554-D063-4CB0-8220-52883AFEF238}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Core.Tests", "AgOpenGPS.Core.Tests\AgOpenGPS.Core.Tests.csproj", "{C11215F6-2903-4CE6-BEA2-B70F831770D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,16 +64,20 @@ Global
 		{F2486554-D063-4CB0-8220-52883AFEF238}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2486554-D063-4CB0-8220-52883AFEF238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2486554-D063-4CB0-8220-52883AFEF238}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_ResXSortingComparison = Ordinal
-		SolutionGuid = {31C86FEF-A77A-49A7-9088-8E0D8AD2ACA5}
-		RESX_ShowErrorsInErrorList = False
-		RESX_SortFileContentOnSave = True
-		RESX_NeutralResourcesLanguage = en-US
 		RESX_ConfirmAddLanguageFile = True
+		RESX_NeutralResourcesLanguage = en-US
+		RESX_SortFileContentOnSave = True
+		RESX_ShowErrorsInErrorList = False
+		SolutionGuid = {31C86FEF-A77A-49A7-9088-8E0D8AD2ACA5}
+		RESX_ResXSortingComparison = Ordinal
 	EndGlobalSection
 EndGlobal

--- a/SourceCode/AgOpenGPS.sln
+++ b/SourceCode/AgOpenGPS.sln
@@ -26,6 +26,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Core", "AgOpenGPS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.Core.Tests", "AgOpenGPS.Core.Tests\AgOpenGPS.Core.Tests.csproj", "{C11215F6-2903-4CE6-BEA2-B70F831770D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.WpfApp", "AgOpenGPS.WpfApp\AgOpenGPS.WpfApp.csproj", "{CCBC7CE7-6A6A-47F7-9781-36A864FDCBD5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgOpenGPS.WpfViews", "AgOpenGPS.WpfViews\AgOpenGPS.WpfViews.csproj", "{03B426E1-59BD-4E72-9528-DE37429E21C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +72,14 @@ Global
 		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C11215F6-2903-4CE6-BEA2-B70F831770D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCBC7CE7-6A6A-47F7-9781-36A864FDCBD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCBC7CE7-6A6A-47F7-9781-36A864FDCBD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCBC7CE7-6A6A-47F7-9781-36A864FDCBD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCBC7CE7-6A6A-47F7-9781-36A864FDCBD5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B426E1-59BD-4E72-9528-DE37429E21C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B426E1-59BD-4E72-9528-DE37429E21C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B426E1-59BD-4E72-9528-DE37429E21C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B426E1-59BD-4E72-9528-DE37429E21C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The test project uses the following suggested conventions:
- Test class follows the same folder structure as the tested class
- "Arrange", "Act", "Assert" sections (denoted by comments)
- Test method name: `<Tested Method>_Should<Description>`

The added WPF projects have the following intention:
- `AgOpenGPS.WpfApp`: used as a test application for WPF standalone
- `AgOpenGPS.WpfViews`: will contain the individual views that are converted from the WinForms application and is referenced by the test app and later by AgOpenGPS itself