### PR TITLE
New views and main layout for new WpfApp

### DIFF
--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="AogWpf.App"
+﻿<Application x:Class="AgOpenGPS.WpfApp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 

--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml
@@ -1,9 +1,10 @@
-﻿<Application x:Class="AgOpenGPS.WpfApp.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:AgOpenGPS.WpfApp"
-             StartupUri="MainWindow.xaml">
+﻿<Application x:Class="AogWpf.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+
+    StartupUri="MainWindow.xaml">
+
     <Application.Resources>
-         
     </Application.Resources>
+
 </Application>

--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
 
-namespace AogWpf
+namespace AgOpenGPS.WpfApp
 {
     public partial class App : Application
     {

--- a/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/App.xaml.cs
@@ -1,14 +1,8 @@
-﻿using System.Configuration;
-using System.Data;
-using System.Windows;
+﻿using System.Windows;
 
-namespace AgOpenGPS.WpfApp
+namespace AogWpf
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
     public partial class App : Application
     {
     }
-
 }

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml
@@ -6,7 +6,7 @@
 
     xmlns:local="clr-namespace:AgOpenGPS.WpfApp.MainViews"
 
-    d:DesignHeight="80" d:DesignWidth="800">
+    d:DesignWidth="800">
 
     <Grid x:Name="bottomButtonStripGrid"
         HorizontalAlignment="Stretch">

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.MainViews.BottomButtonStrip"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    xmlns:local="clr-namespace:AgOpenGPS.WpfApp.MainViews"
+
+    d:DesignHeight="80" d:DesignWidth="800">
+
+    <Grid x:Name="bottomButtonStripGrid"
+        HorizontalAlignment="Stretch">
+        <StackPanel
+            Orientation="Horizontal"
+            HorizontalAlignment="Right">
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+        </StackPanel>
+    </Grid>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/BottomButtonStrip.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.MainViews
+{
+    public partial class BottomButtonStrip : UserControl
+    {
+        public BottomButtonStrip()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml
@@ -6,7 +6,7 @@
 
     xmlns:local="clr-namespace:AgOpenGPS.WpfApp.MainViews"
 
-    d:DesignHeight="50" d:DesignWidth="800">
+    d:DesignWidth="800">
 
     <Grid x:Name="headerBarGrid" HorizontalAlignment="Stretch" Height="50">
     </Grid>

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.MainViews.HeaderBar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    xmlns:local="clr-namespace:AgOpenGPS.WpfApp.MainViews"
+
+    d:DesignHeight="50" d:DesignWidth="800">
+
+    <Grid x:Name="headerBarGrid" HorizontalAlignment="Stretch" Height="50">
+    </Grid>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/HeaderBar.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.MainViews
+{
+    public partial class HeaderBar : UserControl
+    {
+        public HeaderBar()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.MainViews.LeftButtonStrip"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    d:DesignHeight="700" d:DesignWidth="100">
+
+    <Grid x:Name="leftButtonStripGrid" VerticalAlignment="Stretch">
+        <StackPanel VerticalAlignment="Bottom">
+            <Button Height="80" Width="100" />
+            <Button Height="80" Width="100" />
+            <Button Height="80" Width="100" />
+            <Button Height="80" Width="100" />
+        </StackPanel>
+    </Grid>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml
@@ -4,7 +4,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
 
-    d:DesignHeight="700" d:DesignWidth="100">
+    d:DesignHeight="700">
 
     <Grid x:Name="leftButtonStripGrid" VerticalAlignment="Stretch">
         <StackPanel VerticalAlignment="Bottom">

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/LeftButtonStrip.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.MainViews
+{
+    public partial class LeftButtonStrip : UserControl
+    {
+        public LeftButtonStrip()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.MainViews.RightButtonStrip"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    d:DesignHeight="450" d:DesignWidth="100">
+
+    <Grid x:Name="rightButtonStripGrid" VerticalAlignment="Stretch" Width="100">
+        <StackPanel VerticalAlignment="Bottom">
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+            <Button Height="80" Width="100"/>
+        </StackPanel>
+    </Grid>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml
@@ -4,7 +4,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
 
-    d:DesignHeight="450" d:DesignWidth="100">
+    d:DesignHeight="450">
 
     <Grid x:Name="rightButtonStripGrid" VerticalAlignment="Stretch" Width="100">
         <StackPanel VerticalAlignment="Bottom">

--- a/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainViews/RightButtonStrip.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.MainViews
+{
+    public partial class RightButtonStrip : UserControl
+    {
+        public RightButtonStrip()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml
@@ -1,13 +1,25 @@
 ﻿<Window x:Class="AgOpenGPS.WpfApp.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:AgOpenGPS.WpfApp"
-        xmlns:wpfviews="clr-namespace:AgOpenGPS.WpfViews;assembly=AgOpenGPS.WpfViews"
-        mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
-        <wpfviews:TestView />
-    </Grid>
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
+
+    xmlns:mv="clr-namespace:AgOpenGPS.WpfApp.MainViews"
+    xmlns:vv="clr-namespace:AgOpenGPS.WpfApp.ViewportViews"
+
+    Height="700" Width="1200">
+
+    <DockPanel LastChildFill="True">
+        <mv:HeaderBar DockPanel.Dock="Top"/>
+        <mv:LeftButtonStrip x:Name="leftButtonStrip"
+            DockPanel.Dock="Left" Width="100"/>
+        <mv:RightButtonStrip x:Name="rightButtonStrip"
+            DockPanel.Dock="Right"/>
+        <mv:BottomButtonStrip x:Name="bottomButtonStrip"
+            DockPanel.Dock="Bottom"/>
+        <Grid x:Name="viewportGrid">
+            <Grid x:Name="viewport" Background="Black"/>
+            <vv:ViewportOverlay/>
+        </Grid>
+    </DockPanel>
 </Window>

--- a/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/MainWindow.xaml.cs
@@ -1,19 +1,7 @@
-﻿using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace AgOpenGPS.WpfApp
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
     public partial class MainWindow : Window
     {
         public MainWindow()

--- a/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.ViewportViews.SimulatorBar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    d:DesignHeight="30" d:DesignWidth="800">
+
+    <StackPanel x:Name="simulatorStakPanel"
+        Orientation="Horizontal">
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
+    </StackPanel>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml
@@ -2,12 +2,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
-
-    d:DesignHeight="30" d:DesignWidth="800">
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d" >
 
     <StackPanel x:Name="simulatorStakPanel"
         Orientation="Horizontal">
+        <Button Width="40" Height="30" />
+        <Button Width="40" Height="30" />
         <Button Width="40" Height="30" />
         <Button Width="40" Height="30" />
         <Button Width="40" Height="30" />

--- a/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/ViewportViews/SimulatorBar.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.ViewportViews
+{
+    public partial class SimulatorBar : UserControl
+    {
+        public SimulatorBar()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.WpfApp/ViewportViews/ViewportOverlay.xaml
+++ b/SourceCode/AgOpenGPS.WpfApp/ViewportViews/ViewportOverlay.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="AgOpenGPS.WpfApp.ViewportViews.ViewportOverlay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+
+    xmlns:local="clr-namespace:AgOpenGPS.WpfApp.ViewportViews"
+
+    d:DesignHeight="450" d:DesignWidth="800">
+
+    <DockPanel x:Name="viewportOverlayDockPanel" LastChildFill="False">
+        <local:SimulatorBar x:Name="simulatorBar"
+            DockPanel.Dock="Bottom" Margin="0,0,0,40"
+            HorizontalAlignment="Center"/>
+    </DockPanel>
+
+</UserControl>

--- a/SourceCode/AgOpenGPS.WpfApp/ViewportViews/ViewportOverlay.xaml.cs
+++ b/SourceCode/AgOpenGPS.WpfApp/ViewportViews/ViewportOverlay.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace AgOpenGPS.WpfApp.ViewportViews
+{
+    public partial class ViewportOverlay : UserControl
+    {
+        public ViewportOverlay()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains the first views for the WPF Test app. The WPF test app will be a 'cheap' application that does not bother about translation, icons or perfect layout. The purpose of the app is to support and validate the refactoring towards the MVVM pattern. The user-interface will only give acess to the part of code/funtionality that has been refactored. As such it can also be used to show the progress of the refactoring process.

For people not familiar with WPF:
The layout of the MainWindow makes optimal use of the various  'layout containers' of WPF. Basically everything will layout itself without the need for additional code. For example the 'viewportGrid' is the last child of a DockPanel and will take all remaining space afte the buttonstrips have been placed and will update automtically when the visibility of one of the buttonstrip changes.
The 'viewportOverlay' inside the 'viewportGrid' also follows the automatic layout changes and no additional code is required to put the SimulatorBar in the correct position. 

Not in scope of this review:
- proper styling
- databinding
- all other panels and windows.
- all connections to other projects or other parts of the code.

