### PR TITLE
Build applicationcore

### DIFF
--- a/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
+++ b/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
@@ -1,0 +1,18 @@
+﻿using AgOpenGPS.Core.Models;
+
+namespace AgOpenGPS.Core
+{
+    public class ApplicationCore
+    {
+
+        public ApplicationCore(string baseDirectory)
+        {
+            AppModel = new ApplicationModel(baseDirectory);
+        }
+
+        public ApplicationModel AppModel { get; }
+
+        public Field CurrentField => AppModel.Fields.CurrentField;
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
+++ b/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
@@ -1,11 +1,12 @@
 ﻿using AgOpenGPS.Core.Models;
+using System.IO;
 
 namespace AgOpenGPS.Core
 {
     public class ApplicationCore
     {
 
-        public ApplicationCore(string baseDirectory)
+        public ApplicationCore(DirectoryInfo baseDirectory)
         {
             AppModel = new ApplicationModel(baseDirectory);
         }

--- a/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IApplicationPresenter.cs
+++ b/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IApplicationPresenter.cs
@@ -1,0 +1,10 @@
+﻿namespace AgOpenGPS.Core.Interfaces
+{
+    public interface IApplicationPresenter
+    {
+        IErrorPresenter ErrorPresenter { get; }
+
+        IFieldStreamerPresenter FieldStreamerPresenter { get; }
+    }
+}
+

--- a/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IErrorPresenter.cs
+++ b/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IErrorPresenter.cs
@@ -1,9 +1,11 @@
-﻿namespace AgOpenGPS.Core.Interfaces
+﻿using System;
+
+namespace AgOpenGPS.Core.Interfaces
 {
     public interface IErrorPresenter
     {
         void PresentTimedMessage(
-            int timeInMilliSec,
+            TimeSpan timeSpan,
             string titleString,
             string messageString);
     }

--- a/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IErrorPresenter.cs
+++ b/SourceCode/AgOpenGPS.Core/Interfaces/Presenters/IErrorPresenter.cs
@@ -1,0 +1,10 @@
+﻿namespace AgOpenGPS.Core.Interfaces
+{
+    public interface IErrorPresenter
+    {
+        void PresentTimedMessage(
+            int timeInMilliSec,
+            string titleString,
+            string messageString);
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
@@ -1,0 +1,31 @@
+﻿using AgOpenGPS.Core.Interfaces;
+using AgOpenGPS.Core.Models;
+using AgOpenGPS.Core.Streamers;
+
+namespace AgOpenGPS.Core
+{
+    public class ApplicationModel
+    {
+
+        private IApplicationPresenter _applicationPresenter;
+
+        public ApplicationModel(string baseDirectory)
+        {
+            BaseDirectories = new BaseDirectories(baseDirectory);
+            Fields = new Fields(BaseDirectories.FieldsDir);
+        }
+
+        public void SetPresenter(IApplicationPresenter applicationPresenter)
+        {
+            _applicationPresenter = applicationPresenter;
+            FieldStreamer.SetPresenter(_applicationPresenter.FieldStreamerPresenter);
+        }
+
+        public BaseDirectories BaseDirectories { get; }
+
+        public Fields Fields { get; }
+
+        public FieldStreamer FieldStreamer => Fields.FieldStreamer;
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
@@ -1,6 +1,7 @@
 ﻿using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Streamers;
+using System.IO;
 
 namespace AgOpenGPS.Core
 {
@@ -9,10 +10,10 @@ namespace AgOpenGPS.Core
 
         private IApplicationPresenter _applicationPresenter;
 
-        public ApplicationModel(string baseDirectory)
+        public ApplicationModel(DirectoryInfo baseDirectory)
         {
             BaseDirectories = new BaseDirectories(baseDirectory);
-            Fields = new Fields(BaseDirectories.FieldsDir);
+            Fields = new Fields(BaseDirectories.FieldsDirectory);
         }
 
         public void SetPresenter(IApplicationPresenter applicationPresenter)

--- a/SourceCode/AgOpenGPS.Core/Models/BaseDirectories.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/BaseDirectories.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+
+namespace AgOpenGPS.Core.Models
+{
+    public class BaseDirectories
+    {
+        public BaseDirectories(string baseDirectory)
+        {
+            //get the fields directory, if not exist, create
+            FieldsDir = baseDirectory + "Fields\\";
+            string dir = Path.GetDirectoryName(FieldsDir);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
+
+            //get the Vehices directory, if not exist, create
+            VehiclesDir = baseDirectory + "Vehicles\\";
+            dir = Path.GetDirectoryName(VehiclesDir);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
+        }
+
+        public string FieldsDir { get; }
+        public string VehiclesDir { get; }
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/BaseDirectories.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/BaseDirectories.cs
@@ -4,21 +4,14 @@ namespace AgOpenGPS.Core.Models
 {
     public class BaseDirectories
     {
-        public BaseDirectories(string baseDirectory)
+        public BaseDirectories(DirectoryInfo baseDirectory)
         {
-            //get the fields directory, if not exist, create
-            FieldsDir = baseDirectory + "Fields\\";
-            string dir = Path.GetDirectoryName(FieldsDir);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
-
-            //get the Vehices directory, if not exist, create
-            VehiclesDir = baseDirectory + "Vehicles\\";
-            dir = Path.GetDirectoryName(VehiclesDir);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
+            FieldsDirectory = baseDirectory.CreateSubdirectory("Fields");
+            VehiclesDirectory = baseDirectory.CreateSubdirectory("Vehicles");
         }
 
-        public string FieldsDir { get; }
-        public string VehiclesDir { get; }
+        public DirectoryInfo FieldsDirectory { get; }
+        public DirectoryInfo VehiclesDirectory { get; }
 
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
@@ -12,8 +12,8 @@ namespace AgOpenGPS.Core.Models
         }
 
         public string Name { get; }
-        public Wgs84? Wgs84Start { get; set; } // No value indicates error indicates error in Field.txt file
-        public double? Area { get; set; } // In Meters. No value indicates error in reading Boundary file
+        public Wgs84? Wgs84Start { get; set; } // No value indicates error in Field.txt file
+        public double? Area { get; set; } // In Square meters. No value indicates error in reading Boundary file
 
     }
 

--- a/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics.Tracing;
+
+namespace AgOpenGPS.Core.Models
+{
+    // Small summary of a field.
+    // Used to build a FieldDescriptionViewModel to display a row in a table of fields
+    public class FieldDescription
+    {
+        public FieldDescription(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+        public Wgs84? Wgs84Start { get; set; } // No value indicates error indicates error in Field.txt file
+        public double? Area { get; set; } // In Meters. No value indicates error in reading Boundary file
+
+    }
+
+}
+

--- a/SourceCode/AgOpenGPS.Core/Models/Field/Fields.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/Fields.cs
@@ -1,0 +1,80 @@
+﻿using AgOpenGPS.Core.Streamers;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace AgOpenGPS.Core.Models
+{
+    public class Fields
+    {
+        private readonly string _fieldsDirectory;
+        private Field _currentField;
+        private FieldStreamer _fieldStreamer;
+
+        public Fields(string fieldsDirectory)
+        {
+            _fieldsDirectory = fieldsDirectory;
+        }
+
+        public Field CurrentField
+        {
+            get { return _currentField; }
+            private set
+            {
+                _currentField = value;
+                FieldStreamer = new FieldStreamer(CurrentField);
+            }
+        }
+
+        public FieldStreamer FieldStreamer
+        {
+            get { return _fieldStreamer; }
+            private set {
+                _fieldStreamer = value;
+            }
+        }
+
+        public ReadOnlyCollection<FieldDescription> GetFieldDescriptions()
+        {
+            string[] dirs = Directory.GetDirectories(_fieldsDirectory);
+
+            if (dirs == null || dirs.Length < 1)
+            {
+                return null;
+            }
+            List<FieldDescription> list = new List<FieldDescription>();
+            BoundaryStreamer boundaryStreamer = new BoundaryStreamer();
+            OverviewStreamer overviewStreamer = new OverviewStreamer();
+
+            foreach (string dir in dirs)
+            {
+                string fieldName = Path.GetFileName(dir);
+                string filename = dir + "\\Field.txt";
+
+                if (File.Exists(filename))
+                {
+                    var fieldDescription = new FieldDescription(fieldName);
+                    var boundary = boundaryStreamer.Read(dir);
+                    fieldDescription.Area = boundary.Area;
+
+                    var overview = overviewStreamer.Read(dir);
+                    fieldDescription.Wgs84Start = overview.Start;
+                    list.Add(fieldDescription);
+                }
+            }
+            return list.AsReadOnly();
+        }
+
+        public void DeleteField(string fieldName)
+        {
+            string dir = _fieldsDirectory + "\\" + fieldName;
+            System.IO.Directory.Delete(dir);
+        }
+
+        public void SelectField(string fieldName)
+        {
+            CurrentField = new Field(fieldName);
+        }
+
+    }
+}


### PR DESCRIPTION
AgOpenGPS.Core:
This is the toplevel class in ApplicationCore. In the final situation it will contain everything except the Views. On of the next PR's will also add the ApplicationViewModel

ApplicationModel:
This is the toplevel class for all models. For now we only have Field models. But in the final situation we will have Vehicle and Guidance models too, and probabbly more.

Fields:
This is the top level for all field model related code. 

IApplicationPresenter:
Sometimes code in AgOpenGPS.Core needs to call Winforms or WPF specific code. AgOpenGPS.Core can not have a dependency to AgOpenGPS, (or AgOpenGPS.WpfApp), so we need this interface to make those calls. The current IApplicationPresenter only has the interfaces that the FieldStreamer needs in its constructor.