### PR TITLE
Let CNMEA use baseclasses more

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/Wgs84.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/Wgs84.cs
@@ -5,6 +5,7 @@ namespace AgOpenGPS.Core.Models
     // Represents a coordinate in the World Geodetic System 1984
     public struct Wgs84
     {
+        const double EarthRadiusInMeters = 6371 * 1000.0;
         public Wgs84(double latitude, double longitude)
         {
             Latitude = latitude;
@@ -16,18 +17,15 @@ namespace AgOpenGPS.Core.Models
 
         public double DistanceInMeters(Wgs84 b)
         {
-            const double EarthRadius = 6371 * 1000.0;
-            double degreesToRad = Math.PI / 180.0;
-
-            double aLatRad = Latitude * degreesToRad;
-            double aLongRad = Longitude * degreesToRad;
-            double bLatRad = b.Latitude * degreesToRad;
-            double bLongRad = b.Longitude * degreesToRad;
+            double aLatRad = DegreesToRadians(Latitude);
+            double aLongRad = DegreesToRadians(Longitude);
+            double bLatRad = DegreesToRadians(b.Latitude);
+            double bLongRad = DegreesToRadians(b.Longitude);
             double sinHalfLongDelta = Math.Sin(0.5 * (bLongRad - aLongRad));
             double sinHalfLatDelta = Math.Sin(0.5 * (bLatRad - aLatRad));
 
             double d3 = sinHalfLatDelta * sinHalfLatDelta + Math.Cos(aLatRad) * Math.Cos(bLatRad) * sinHalfLongDelta * sinHalfLongDelta;
-            return EarthRadius * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));
+            return EarthRadiusInMeters * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));
         }
 
         public double DistanceInKiloMeters(Wgs84 b)
@@ -37,17 +35,27 @@ namespace AgOpenGPS.Core.Models
 
         public Wgs84 CalculateNewPostionFromBearingDistance(double bearing, double distanceInMeters)
         {
-            const double degreesToRadians = Math.PI / 180.0;
-            const double radiansToDegrees = 1.0 / degreesToRadians;
-            double latRadians = Latitude * degreesToRadians;
-            double lonRadians = Longitude * degreesToRadians;
+            double latRadians = DegreesToRadians(Latitude);
+            double lonRadians = DegreesToRadians(Longitude);
 
-            double R = distanceInMeters / (6371.0 * 1000);
+            double R = distanceInMeters / EarthRadiusInMeters;
 
             double lat2 = Math.Asin((Math.Sin(latRadians) * Math.Cos(R)) + (Math.Cos(latRadians) * Math.Sin(R) * Math.Cos(bearing)));
             double lon2 = lonRadians + Math.Atan2(Math.Sin(bearing) * Math.Sin(R) * Math.Cos(latRadians), Math.Cos(R) - (Math.Sin(latRadians) * Math.Sin(lat2)));
 
-            return new Wgs84(lat2 * radiansToDegrees, lon2 * radiansToDegrees);
+            return new Wgs84(RadiansToDegrees(lat2), RadiansToDegrees(lon2));
+        }
+
+        private double RadiansToDegrees(double radians)
+        {
+            const double radiansToDegrees = 180.0 / Math.PI;
+            return radians * radiansToDegrees;
+        }
+
+        private double DegreesToRadians(double degrees)
+        {
+            const double degreesToRadians = Math.PI / 180.0;
+            return degrees * degreesToRadians;
         }
 
     }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/Wgs84.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/Wgs84.cs
@@ -34,6 +34,22 @@ namespace AgOpenGPS.Core.Models
         {
             return 0.001 * DistanceInMeters(b);
         }
+
+        public Wgs84 CalculateNewPostionFromBearingDistance(double bearing, double distanceInMeters)
+        {
+            const double degreesToRadians = Math.PI / 180.0;
+            const double radiansToDegrees = 1.0 / degreesToRadians;
+            double latRadians = Latitude * degreesToRadians;
+            double lonRadians = Longitude * degreesToRadians;
+
+            double R = distanceInMeters / (6371.0 * 1000);
+
+            double lat2 = Math.Asin((Math.Sin(latRadians) * Math.Cos(R)) + (Math.Cos(latRadians) * Math.Sin(R) * Math.Cos(bearing)));
+            double lon2 = lonRadians + Math.Atan2(Math.Sin(bearing) * Math.Sin(R) * Math.Cos(latRadians), Math.Cos(R) - (Math.Sin(latRadians) * Math.Sin(lat2)));
+
+            return new Wgs84(lat2 * radiansToDegrees, lon2 * radiansToDegrees);
+        }
+
     }
 
 }

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -8,13 +8,15 @@ namespace AgOpenGPS
     public class CNMEA
     {
         const double degreesToRadians = 2.0 * Math.PI / 360.0;
-        //WGS84 Lat Long
-        public double latitude, longitude;
 
-        public double prevLatitude, prevLongitude;
+        public Wgs84 CurrentLatLon { get; set; }
+        public double latitude => CurrentLatLon.Latitude;
+        public double longitude => CurrentLatLon.Longitude;
 
         //local plane geometry
-        public double latStart, lonStart;
+        public Wgs84 StartLatLon { get; set; }
+        public double latStart => StartLatLon.Latitude;
+        public double lonStart => StartLatLon.Longitude;
 
         public double mPerDegreeLat, mPerDegreeLon;
 
@@ -40,8 +42,7 @@ namespace AgOpenGPS
         {
             //constructor, grab the main form reference
             mf = f;
-            latStart = 0;
-            lonStart = 0;
+            StartLatLon = new Wgs84(0, 0);
             ageAlarm = Properties.Settings.Default.setGPS_ageAlarm;
         }
 
@@ -56,8 +57,11 @@ namespace AgOpenGPS
         {
             if (setSim && mf.timerSim.Enabled)
             {
-                latitude = mf.sim.latitude = Properties.Settings.Default.setGPS_SimLatitude = latStart;
-                longitude = mf.sim.longitude = Properties.Settings.Default.setGPS_SimLongitude = lonStart;
+                CurrentLatLon = StartLatLon;
+                mf.sim.CurrentLatLon = StartLatLon;
+
+                Properties.Settings.Default.setGPS_SimLatitude = latStart;
+                Properties.Settings.Default.setGPS_SimLongitude = lonStart;
                 Properties.Settings.Default.Save();
             }
 

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using AgLibrary.Logging;
+using AgOpenGPS.Core.Models;
 using AgOpenGPS.Culture;
 using AgOpenGPS.Forms;
 using AgOpenGPS.Forms.Pickers;
@@ -2244,8 +2245,9 @@ namespace AgOpenGPS
         }
         private void btnResetSim_Click(object sender, EventArgs e)
         {
-            sim.latitude = Properties.Settings.Default.setGPS_SimLatitude;
-            sim.longitude = Properties.Settings.Default.setGPS_SimLongitude;
+            sim.CurrentLatLon = new Wgs84(
+                Properties.Settings.Default.setGPS_SimLatitude,
+                Properties.Settings.Default.setGPS_SimLongitude);
         }
         private void btnSimSetSpeedToZero_Click(object sender, EventArgs e)
         {

--- a/SourceCode/GPS/Forms/Field/FormFieldDir.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldDir.cs
@@ -101,8 +101,7 @@ namespace AgOpenGPS
                 }
                 else
                 {
-                    mf.pn.latStart = mf.pn.latitude;
-                    mf.pn.lonStart = mf.pn.longitude;
+                    mf.pn.StartLatLon = mf.pn.CurrentLatLon;
 
                     mf.pn.SetLocalMetersPerDegree(false);
 

--- a/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
@@ -295,8 +295,7 @@ namespace AgOpenGPS
                 }
                 else
                 {
-                    mf.pn.latStart = latK;
-                    mf.pn.lonStart = lonK;
+                    mf.pn.StartLatLon = new Wgs84(latK, lonK);
 
                     mf.pn.SetLocalMetersPerDegree(true);
 

--- a/SourceCode/GPS/Forms/Field/FormFieldKML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldKML.cs
@@ -333,8 +333,7 @@ namespace AgOpenGPS
                 }
                 else
                 {
-                    mf.pn.latStart = latK;
-                    mf.pn.lonStart = lonK;
+                    mf.pn.StartLatLon = new Wgs84(latK, lonK);
 
                     mf.pn.SetLocalMetersPerDegree(true);
 

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -1651,8 +1651,7 @@ namespace AgOpenGPS
             {
                 if (!isJobStarted)
                 {
-                    pn.latStart = pn.latitude;
-                    pn.lonStart = pn.longitude;
+                    pn.StartLatLon = pn.CurrentLatLon;
                     pn.SetLocalMetersPerDegree(false);
                 }
 

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -13,6 +13,7 @@ using AgOpenGPS.Culture;
 using AgLibrary.Logging;
 using AgOpenGPS.Protocols.ISOBUS;
 using AgOpenGPS.Core.Models;
+using AgOpenGPS.Core.Streamers;
 
 namespace AgOpenGPS
 {
@@ -743,7 +744,7 @@ namespace AgOpenGPS
 
             //start to read the file
             string line;
-            using (StreamReader reader = new StreamReader(fileAndDirectory))
+            using (GeoStreamReader reader = new GeoStreamReader(fileAndDirectory))
             {
                 try
                 {
@@ -778,12 +779,7 @@ namespace AgOpenGPS
                     //start positions
                     if (!reader.EndOfStream)
                     {
-                        line = reader.ReadLine();
-                        line = reader.ReadLine();
-                        offs = line.Split(',');
-
-                        pn.latStart = double.Parse(offs[0], CultureInfo.InvariantCulture);
-                        pn.lonStart = double.Parse(offs[1], CultureInfo.InvariantCulture);
+                        pn.StartLatLon = reader.ReadWgs84();
 
                         pn.SetLocalMetersPerDegree(true);
                     }

--- a/SourceCode/GPS/Forms/Settings/FormSimCoords.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSimCoords.cs
@@ -1,4 +1,5 @@
 ﻿using AgOpenGPS.Controls;
+using AgOpenGPS.Core.Models;
 using AgOpenGPS.Culture;
 using System;
 using System.Windows.Forms;
@@ -41,9 +42,7 @@ namespace AgOpenGPS
                 mf.TimedMessageBox(2000, "Simulator is off", "Go Back To Work, No Time For Games");
                 Close();
             }
-
-            mf.pn.latStart = (double)nudLatitude.Value;
-            mf.pn.lonStart = (double)nudLongitude.Value;
+            mf.pn.StartLatLon = new Wgs84((double)nudLatitude.Value, (double)nudLongitude.Value);
 
             mf.pn.SetLocalMetersPerDegree(true);
 

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -68,13 +68,11 @@ namespace AgOpenGPS
 
                             if (Lon != double.MaxValue && Lat != double.MaxValue)
                             {
-                                if (timerSim.Enabled)
-                                    DisableSim();
+                                if (timerSim.Enabled) DisableSim();
 
-                                pn.longitude = Lon;
-                                pn.latitude = Lat;
+                                pn.CurrentLatLon = new Wgs84(Lat, Lon);
 
-                                GeoCoord fixCoord = pn.ConvertWgs84ToGeoCoord(new Wgs84(Lat, Lon));
+                                GeoCoord fixCoord = pn.ConvertWgs84ToGeoCoord(pn.CurrentLatLon);
                                 pn.fix.northing = fixCoord.Northing;
                                 pn.fix.easting = fixCoord.Easting;
 


### PR DESCRIPTION
I'am working towards the first ViewModels for opening Fields. The tables that show the fields contain a column with the distance.
To compute these distances, I need the current location'. The current location is stored in the two separate variables 'latitiude' and 'longitude'
This PR only converts the two separate values for latitude and logitude, to a more maintainable and meaningfull variable named CurrentLocation
The next step will be that I move 'CurrentLocation' to the Core project, to make it accessible for future non-winform applications.