### PR TITLE
Use System.Resources.Extensions 9.0.0

### DIFF
--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="3.3.3" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
+    <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
My pull request on 2025-02-25 (refactor Brand related bitmaps) contained a change to the project file AgopenGPS.Core.csproj
to fix the build on GitHub. Unfortunately, this change has  side effects and it fails the build on my own computer and others.
On my computer the text of the error messagebox is:

System.IO.FileLoadException
  HResult=0x80131040
  Message=Could not load file or assembly 'System.Resources.Extensions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
  Source=<Cannot evaluate the exception source>
  StackTrace:
<Cannot evaluate the exception stack trace>

Inner Exception 1:
FileLoadException: Could not load file or assembly 'System.Resources.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)



The change in this pull request runs fine on my computer and apperently it also runs fine on GitHub.
I don't know if this is the best solution....

I also updated my VisualStudio to the latest version 17.13.2, but that does not solve the problem