### PR TITLE
Bugfix: let cnmea use base classes more

### DIFF
--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -779,8 +779,8 @@ namespace AgOpenGPS
                     //start positions
                     if (!reader.EndOfStream)
                     {
+                        reader.ReadLine(); // Skip line 'StartFix'
                         pn.StartLatLon = reader.ReadWgs84();
-
                         pn.SetLocalMetersPerDegree(true);
                     }
                 }


### PR DESCRIPTION
Unfortunately, my changes from 2025-03-01 'Let CNMEA use base classes more' contain a bug that result in 'Field is corrupt'
message box. This PR fixes the bug.