### PR TITLE
Ensure AgIO restart is done properly

### DIFF
--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -284,8 +284,7 @@ namespace AgIO
                 {
                     Log.EventWriter("Program Reset: Saving or Selecting Profile");
                     
-                    Application.Restart();
-                    Environment.Exit(0);
+                    Program.Restart();
                 }
             }
             this.Text = "AgIO  v" + Program.Version + "   Using Profile: " 

--- a/SourceCode/AgIO/Source/Forms/FormEthernet.cs
+++ b/SourceCode/AgIO/Source/Forms/FormEthernet.cs
@@ -65,8 +65,7 @@ namespace AgIO
             mf.YesMessageBox("AgIO will Restart to Enable UDP Networking Features");
             Log.EventWriter("Program Reset: Start Ethernet Selected");
 
-            Application.Restart();
-            Environment.Exit(0);
+            Program.Restart();
             Close();
         }
 

--- a/SourceCode/AgIO/Source/Forms/FormLoop.cs
+++ b/SourceCode/AgIO/Source/Forms/FormLoop.cs
@@ -274,8 +274,7 @@ namespace AgIO
                     {
                         Log.EventWriter("Program Reset: Saving or Selecting Profile");
 
-                        Application.Restart();
-                        Environment.Exit(0);
+                        Program.Restart();
                     }
                 }
                 this.Text = "AgIO  v" + Program.Version + " Profile: "

--- a/SourceCode/AgIO/Source/Forms/FormNtrip.cs
+++ b/SourceCode/AgIO/Source/Forms/FormNtrip.cs
@@ -117,8 +117,7 @@ namespace AgIO
             mf.YesMessageBox("Restart of AgIO is Required - Restarting");
             Log.EventWriter("Program Reset: Selecting NTRIP Feature");
 
-            Application.Restart();
-            Environment.Exit(0);
+            Program.Restart();
         }
 
         //get the ipv4 address only
@@ -265,8 +264,7 @@ namespace AgIO
             {
                 Log.EventWriter("Program Reset: Button Ok on Ntrip Form");
                 
-                Application.Restart();
-                Environment.Exit(0);
+                Program.Restart();
             }
         }
 

--- a/SourceCode/AgIO/Source/Forms/FormSerialPass.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSerialPass.cs
@@ -77,8 +77,7 @@ namespace AgIO
 
             Log.EventWriter("Program Reset: Button OK on Serial Pass Form");
 
-            Application.Restart();
-            Environment.Exit(0);
+            Program.Restart();
             Close();
         }
 

--- a/SourceCode/AgIO/Source/Forms/FormUDP.cs
+++ b/SourceCode/AgIO/Source/Forms/FormUDP.cs
@@ -342,8 +342,7 @@ namespace AgIO
             mf.YesMessageBox("AgIO will Restart to Disable UDP Networking Features");
             Log.EventWriter("Program Reset: Turning UDP OFF");
 
-            Application.Restart();
-            Environment.Exit(0);
+            Program.Restart();
 
             Close();
         }

--- a/SourceCode/AgIO/Source/Program.cs
+++ b/SourceCode/AgIO/Source/Program.cs
@@ -1,10 +1,6 @@
-﻿using AgIO.Properties;
-using AgLibrary.Logging;
-using Microsoft.Win32;
+﻿using AgLibrary.Logging;
 using System;
-using System.Configuration;
 using System.Globalization;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
@@ -13,7 +9,7 @@ namespace AgIO
 {
     internal static class Program
     {
-        private static readonly Mutex Mutex = new Mutex(true, "{8F6F0AC4-B9A1-55fd-A8CF-72F04E6BDE8F}");
+        private static Mutex _mutex;
 
         public static readonly string Version = Assembly.GetEntryAssembly().GetName().Version.ToString(3); // Major.Minor.Patch
 
@@ -23,31 +19,39 @@ namespace AgIO
         [STAThread]
         private static void Main()
         {
-            if (Mutex.WaitOne(TimeSpan.Zero, true))
+            using (_mutex = new Mutex(true, "{8F6F0AC4-B9A1-55fd-A8CF-72F04E6BDE8F}", out bool mutexCreated))
             {
-                //load the profile name and set profile directory
-                RegistrySettings.Load();
+                if (mutexCreated)
+                {
+                    //load the profile name and set profile directory
+                    RegistrySettings.Load();
 
-                Log.EventWriter("Program Started: " + DateTime.Now.ToString("f", CultureInfo.InvariantCulture));
-                Log.EventWriter("AgIO Version: " + Application.ProductVersion.ToString(CultureInfo.InvariantCulture));
+                    Log.EventWriter("Program Started: " + DateTime.Now.ToString("f", CultureInfo.InvariantCulture));
+                    Log.EventWriter("AgIO Version: " + Application.ProductVersion.ToString(CultureInfo.InvariantCulture));
 
-                Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(RegistrySettings.culture);
-                Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(RegistrySettings.culture);
-                Application.EnableVisualStyles();
-                Application.SetCompatibleTextRenderingDefault(false);
-                Application.Run(new FormLoop());
+                    Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(RegistrySettings.culture);
+                    Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(RegistrySettings.culture);
+                    Application.EnableVisualStyles();
+                    Application.SetCompatibleTextRenderingDefault(false);
+                    Application.Run(new FormLoop());
+                }
+            }
+        }
+
+        // If the application needs to be restarted, it should be done via this method.
+        // Manually disposing the Mutex before calling Application.Restart() ensures
+        // that the Mutex is not still owned by the current application instance while
+        // the new application instance is being started.
+        // See: https://stackoverflow.com/a/9456822
+        public static void Restart()
+        {
+            if (_mutex != null)
+            {
+                _mutex.ReleaseMutex();
+                _mutex.Dispose();
+                _mutex = null;
+                Application.Restart();
             }
         }
     }
 }
-
-//catch (System.Configuration.ConfigurationErrorsException ex)
-//{
-//    // Corrupted XML! Delete the file, the user can just reload when this fails to appear. No need to worry them
-//    MessageBoxButtons btns = MessageBoxButtons.OK;
-//    System.Windows.Forms.MessageBox.Show("Error detected in config file - fixing it now, please close this and restart app", "Problem!", btns);
-//    string filename = ((ex.InnerException as System.Configuration.ConfigurationErrorsException)?.Filename) as string;
-//    System.IO.File.Delete(filename);
-//    Settings.Default.Reload();
-//    Application.Exit();
-//}


### PR DESCRIPTION
When AgIO is restarting itself, there are a few things that can go wrong (as discovered by @lansalot):
- The new application instance is being started before the current application can release its `Mutex`.
  - In that case AgIO will just appear to not restart (even though it tried, but thought it is still running)
- The `Mutex` is not being properly disposed, because of the `Environment.Exit` call.
  - The new AgIO instance will then fail with an `AbandonedMutexException` (can be observed in the Event Viewer)