### PR TITLE
Bugfix: index out of bounds when clicking the green or yellow symbol for marking

### DIFF
--- a/SourceCode/GPS/Forms/Sections.Designer.cs
+++ b/SourceCode/GPS/Forms/Sections.Designer.cs
@@ -17,24 +17,31 @@ namespace AgOpenGPS
         //Off, Manual, and Auto, 3 states possible
         public btnStates manualBtnState = btnStates.Off;
         public btnStates autoBtnState = btnStates.Off;
-
+        
         private void markAsWorkedTrack()
         {
-            //is it an AB Line or a Curve?
-            if (trk.gArr[this.trk.idx].mode == TrackMode.AB)
+            
+            //only mark if there was a track selected?
+            if (this.trk.idx >= 0)
             {
-                //AB Line
-                if (!this.trk.gArr[this.trk.idx].workedTracks.Contains(this.ABLine.howManyPathsAway))
-                    this.trk.gArr[this.trk.idx].workedTracks.Add(this.ABLine.howManyPathsAway);
 
-            }
-            else if (trk.gArr[this.trk.idx].mode == TrackMode.Curve)
-            {
-                //Curve
-                if (!this.trk.gArr[this.trk.idx].workedTracks.Contains(this.curve.howManyPathsAway))
-                    this.trk.gArr[this.trk.idx].workedTracks.Add(this.curve.howManyPathsAway);
+                //is it an AB Line or a Curve?
+                if (trk.gArr[this.trk.idx].mode == TrackMode.AB)
+                {
+                    //AB Line
+                    if (!this.trk.gArr[this.trk.idx].workedTracks.Contains(this.ABLine.howManyPathsAway))
+                        this.trk.gArr[this.trk.idx].workedTracks.Add(this.ABLine.howManyPathsAway);
 
+                }
+                else if (trk.gArr[this.trk.idx].mode == TrackMode.Curve)
+                {
+                    //Curve
+                    if (!this.trk.gArr[this.trk.idx].workedTracks.Contains(this.curve.howManyPathsAway))
+                        this.trk.gArr[this.trk.idx].workedTracks.Add(this.curve.howManyPathsAway);
+
+                }
             }
+
         }
 
 


### PR DESCRIPTION
Bugfix: when opening a field and clicking one of the 2 mark-buttons (green or yellow) before you have selected a track an error occured in Sections.Designer.cs Method markAsWorkedTrack() - its about the new feature which allows skipping already worked tracks at youturn.