### PR TITLE
Introduce color lib

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -1,0 +1,27 @@
+﻿using AgOpenGPS.Core.Models;
+namespace AgOpenGPS.Core.Drawing
+{
+    static public class Colors
+    {
+        // Physical colors
+        static public ColorRgb Black = new ColorRgb(0, 0, 0);
+        static public ColorRgb White = new ColorRgb(255, 255, 225);
+        static public ColorRgb Red = new ColorRgb(255, 0, 0);
+        static public ColorRgb Green = new ColorRgb(0, 255, 0);
+        static public ColorRgb Yellow = new ColorRgb(255, 255, 0);
+
+        // Functional colors
+        static public ColorRgb HitchColor = new ColorRgb(0.765f, 0.76f, 0.32f);
+        static public ColorRgba TramDotManualFlashOffColor = new ColorRgba(0.0f, 0.0f, 0.0f, 0.993f);
+        static public ColorRgba TramDotManualFlashOnColor = new ColorRgba(0.99f, 0.990f, 0.0f, 0.993f);
+        static public ColorRgba TramDotAutomaticControlBitOffColor = new ColorRgba(0.9f, 0.0f, 0.0f, 0.53f);
+        static public ColorRgba TramDotAutomaticControlBitOnColor = new ColorRgba(0.29f, 0.990f, 0.290f, 0.983f);
+        static public ColorRgb TramMarkerOnColor = new ColorRgb(0.0f, 0.900f, 0.39630f);
+        static public ColorRgb FlagRedColor = Red;
+        static public ColorRgb FlagGreenColor = Green;
+        static public ColorRgb FlagYellowColor = Yellow;
+
+        static public ColorRgb TrailingToolColor = new ColorRgb(0.7f, 0.4f, 0.2f);
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -12,16 +12,16 @@ namespace AgOpenGPS.Core.Drawing
 
         // Functional colors
         static public ColorRgb HitchColor = new ColorRgb(0.765f, 0.76f, 0.32f);
+        static public ColorRgb HitchTrailingColor = new ColorRgb(0.7f, 0.4f, 0.2f);
+
         static public ColorRgba TramDotManualFlashOffColor = new ColorRgba(0.0f, 0.0f, 0.0f, 0.993f);
         static public ColorRgba TramDotManualFlashOnColor = new ColorRgba(0.99f, 0.990f, 0.0f, 0.993f);
         static public ColorRgba TramDotAutomaticControlBitOffColor = new ColorRgba(0.9f, 0.0f, 0.0f, 0.53f);
         static public ColorRgba TramDotAutomaticControlBitOnColor = new ColorRgba(0.29f, 0.990f, 0.290f, 0.983f);
         static public ColorRgb TramMarkerOnColor = new ColorRgb(0.0f, 0.900f, 0.39630f);
+
         static public ColorRgb FlagRedColor = Red;
         static public ColorRgb FlagGreenColor = Green;
         static public ColorRgb FlagYellowColor = Yellow;
-
-        static public ColorRgb TrailingToolColor = new ColorRgb(0.7f, 0.4f, 0.2f);
-
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Drawing/GLW.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/GLW.cs
@@ -1,0 +1,26 @@
+﻿using AgOpenGPS.Core.Models;
+using OpenTK.Graphics.OpenGL;
+
+namespace AgOpenGPS.Core.Drawing
+{
+    // GLW is short for GL Wrapper.
+    // Please use this class in stead of direct calls to functions in the GL toolkit.
+    public static class GLW
+    {
+        public static void SetColor(ColorRgb color)
+        {
+            GL.Color3(color.Red, color.Green, color.Blue);
+        }
+
+        public static void SetColor(ColorRgba color)
+        {
+            GL.Color4(color.Red, color.Green, color.Blue, color.Alpha);
+        }
+
+        public static void SetLineStyle(LineStyle lineStyle)
+        {
+            GL.LineWidth(lineStyle.Width);
+            GLW.SetColor(lineStyle.Color);
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Drawing/LineStyle.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/LineStyle.cs
@@ -1,0 +1,16 @@
+﻿using AgOpenGPS.Core.Models;
+
+namespace AgOpenGPS.Core.Drawing
+{
+    public class LineStyle
+    {
+        public LineStyle(float width, ColorRgb colorRgb)
+        {
+            Width = width;
+            Color = colorRgb;
+        }
+
+        public float Width { get; set; }
+        public ColorRgb Color { get; set; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
@@ -1,4 +1,6 @@
-﻿namespace AgOpenGPS.Core.Models
+﻿using OpenTK.Graphics.OpenGL;
+
+namespace AgOpenGPS.Core.Models
 {
     public struct ColorRgb
     {
@@ -9,9 +11,22 @@
             Blue = blue;
         }
 
-        public byte Red { get; }
-        public byte Green { get; }
-        public byte Blue { get; }
+        public ColorRgb(float red, float green, float blue) :
+        this(
+            ColorRgb.FloatToByte(red),
+            ColorRgb.FloatToByte(green),
+            ColorRgb.FloatToByte(blue))
+        {
+        }
+
+        public byte Red { get; set; }
+        public byte Green { get; set; }
+        public byte Blue { get; set; }
+
+        public void SetColor()
+        {
+            GL.Color3(Red, Green, Blue);
+        }
 
         public static explicit operator System.Drawing.Color(ColorRgb color)
         {
@@ -22,5 +37,11 @@
         {
             return new ColorRgb(color.R, color.G, color.B);
         }
+
+        static private byte FloatToByte(float fraction)
+        {
+            return (byte)(255 * fraction);
+        }
     }
+
 }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
@@ -18,6 +18,9 @@ namespace AgOpenGPS.Core.Models
                 ColorRgb.FloatToByte(green),
                 ColorRgb.FloatToByte(blue))
         {
+            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException("red", "Argument out of range");
+            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException("green", "Argument out of range");
+            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException("blue", "Argument out of range");
         }
 
         public byte Red { get; set; }
@@ -36,8 +39,6 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
-            fraction = Math.Max(fraction, 0.0f);
-            fraction = Math.Min(fraction, 1.0f);
             return (byte)(255 * fraction);
         }
     }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
@@ -18,9 +18,9 @@ namespace AgOpenGPS.Core.Models
                 ColorRgb.FloatToByte(green),
                 ColorRgb.FloatToByte(blue))
         {
-            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException("red", "Argument out of range");
-            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException("green", "Argument out of range");
-            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException("blue", "Argument out of range");
+            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
+            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
+            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
         }
 
         public byte Red { get; set; }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Graphics.OpenGL;
+using System;
 
 namespace AgOpenGPS.Core.Models
 {
@@ -12,21 +13,16 @@ namespace AgOpenGPS.Core.Models
         }
 
         public ColorRgb(float red, float green, float blue) :
-        this(
-            ColorRgb.FloatToByte(red),
-            ColorRgb.FloatToByte(green),
-            ColorRgb.FloatToByte(blue))
+            this(
+                ColorRgb.FloatToByte(red),
+                ColorRgb.FloatToByte(green),
+                ColorRgb.FloatToByte(blue))
         {
         }
 
         public byte Red { get; set; }
         public byte Green { get; set; }
         public byte Blue { get; set; }
-
-        public void SetColor()
-        {
-            GL.Color3(Red, Green, Blue);
-        }
 
         public static explicit operator System.Drawing.Color(ColorRgb color)
         {
@@ -40,6 +36,8 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
+            fraction = Math.Max(fraction, 0.0f);
+            fraction = Math.Min(fraction, 1.0f);
             return (byte)(255 * fraction);
         }
     }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -20,6 +20,10 @@ namespace AgOpenGPS.Core.Models
                 ColorRgba.FloatToByte(blue),
                 ColorRgba.FloatToByte(alpha))
         {
+            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException("red", "Argument out of range");
+            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException("green", "Argument out of range");
+            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException("blue", "Argument out of range");
+            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException("alpha", "Argument out of range");
         }
 
         public byte Red { get; }
@@ -39,8 +43,6 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
-            fraction = Math.Max(fraction, 0.0f);
-            fraction = Math.Min(fraction, 1.0f);
             return (byte)(255 * fraction);
         }
 

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -20,10 +20,10 @@ namespace AgOpenGPS.Core.Models
                 ColorRgba.FloatToByte(blue),
                 ColorRgba.FloatToByte(alpha))
         {
-            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException("red", "Argument out of range");
-            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException("green", "Argument out of range");
-            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException("blue", "Argument out of range");
-            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException("alpha", "Argument out of range");
+            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
+            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
+            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
+            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
         }
 
         public byte Red { get; }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -1,6 +1,6 @@
 ﻿using OpenTK.Graphics.OpenGL;
 
-namespace AgOpenGPS.Core.Models.Base
+namespace AgOpenGPS.Core.Models
 {
     public struct ColorRgba
     {

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Graphics.OpenGL;
+using System;
 
 namespace AgOpenGPS.Core.Models
 {
@@ -26,11 +27,6 @@ namespace AgOpenGPS.Core.Models
         public byte Blue { get; }
         public byte Alpha { get; }
 
-        public void SetColor()
-        {
-            GL.Color4(Red, Green, Blue, Alpha);
-        }
-
         public static explicit operator System.Drawing.Color(ColorRgba color)
         {
             return System.Drawing.Color.FromArgb(color.Red, color.Green, color.Blue, color.Alpha);
@@ -43,6 +39,8 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
+            fraction = Math.Max(fraction, 0.0f);
+            fraction = Math.Min(fraction, 1.0f);
             return (byte)(255 * fraction);
         }
 

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -1,0 +1,51 @@
+﻿using OpenTK.Graphics.OpenGL;
+
+namespace AgOpenGPS.Core.Models.Base
+{
+    public struct ColorRgba
+    {
+        public ColorRgba(byte red, byte green, byte blue, byte alpha)
+        {
+            Red = red;
+            Green = green;
+            Blue = blue;
+            Alpha = alpha;
+        }
+
+        public ColorRgba(float red, float green, float blue, float alpha) :
+            this(
+                ColorRgba.FloatToByte(red),
+                ColorRgba.FloatToByte(green),
+                ColorRgba.FloatToByte(blue),
+                ColorRgba.FloatToByte(alpha))
+        {
+        }
+
+        public byte Red { get; }
+        public byte Green { get; }
+        public byte Blue { get; }
+        public byte Alpha { get; }
+
+        public void SetColor()
+        {
+            GL.Color4(Red, Green, Blue, Alpha);
+        }
+
+        public static explicit operator System.Drawing.Color(ColorRgba color)
+        {
+            return System.Drawing.Color.FromArgb(color.Red, color.Green, color.Blue, color.Alpha);
+        }
+
+        public static explicit operator ColorRgba(System.Drawing.Color color)
+        {
+            return new ColorRgba(color.R, color.G, color.B, color.A);
+        }
+
+        static private byte FloatToByte(float fraction)
+        {
+            return (byte)(255 * fraction);
+        }
+
+    }
+
+}

--- a/SourceCode/GPS/Classes/CCamera.cs
+++ b/SourceCode/GPS/Classes/CCamera.cs
@@ -52,16 +52,6 @@ namespace AgOpenGPS
             //GL.Translate(0, camSetDistance * -0.04, 0);
             GL.Translate(panX, panY, 0); 
 
-            ////draw the guide
-            //GL.Begin(PrimitiveType.Triangles);
-            //GL.Color3(0.98f, 0.0f, 0.0f);
-            //GL.Vertex3(0.0f, -2.0f, 0.0f);
-            //GL.Color3(0.0f, 0.98f, 0.0f);
-            //GL.Vertex3(-2.0f, -3.0f, 0.0f);
-            //GL.Color3(0.98f, 0.98f, 0.0f);
-            //GL.Vertex3(2.0f, -3.0f, 0.0f);
-            //GL.End();						// Done Drawing Reticle
-
             //following game style or N fixed cam
             if (camFollowing)
             {

--- a/SourceCode/GPS/Classes/CGLM.cs
+++ b/SourceCode/GPS/Classes/CGLM.cs
@@ -142,16 +142,6 @@ namespace AgOpenGPS
                     GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
                 }
                 GL.End();
-
-                //GL.PointSize(4.0f);
-                //GL.Begin(PrimitiveType.Points);
-                //GL.Color3(1.0f, 1.0f, 0.50f);
-                //for (int i = 0; i < polygon.Count; i++)
-                //{
-                //    GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
-                //}
-                //GL.End();
-                //GL.PointSize(1.0f);
             }
         }
 
@@ -165,16 +155,6 @@ namespace AgOpenGPS
                     GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
                 }
                 GL.End();
-
-                //GL.PointSize(8.0f);
-                //GL.Begin(PrimitiveType.Points);
-                //GL.Color3(1.0f, 1.0f, 0.50f);
-                //for (int i = 0; i < polygon.Count; i++)
-                //{
-                //    GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
-                //}
-                //GL.End();
-                //GL.PointSize(1.0f);
             }
         }
 

--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -124,29 +124,40 @@ namespace AgOpenGPS
             isDisplayTramControl = Properties.Settings.Default.setTool_isDisplayTramControl;
         }
 
-        private void DrawHitchLayer(bool isBackgroundLayer, double trailingTank)
+        private void DrawHitch(double trailingTank)
         {
-            GL.LineWidth(isBackgroundLayer ? 6 : 1);
-            (isBackgroundLayer ? Colors.Black : Colors.HitchColor).SetColor();
+            LineStyle backgroundLineStyle = new LineStyle(6.0f, Colors.Black);
+            LineStyle foregroundLineStyle = new LineStyle(1.0f, Colors.HitchColor);
+            LineStyle[] lineStyles = { backgroundLineStyle, foregroundLineStyle };
 
-            //draw the rigid hitch
-            GL.Begin(PrimitiveType.LineLoop);
-            GL.Vertex3(-0.57, trailingTank, 0);
-            GL.Vertex3(0, 0, 0);
-            GL.Vertex3(0.57, trailingTank, 0);
-            GL.End();
+            foreach (LineStyle lineStyle in lineStyles)
+            {
+                GLW.SetLineStyle(lineStyle);
+
+                GL.Begin(PrimitiveType.LineLoop);
+                GL.Vertex3(-0.57, trailingTank, 0);
+                GL.Vertex3(0, 0, 0);
+                GL.Vertex3(0.57, trailingTank, 0);
+                GL.End();
+            }
         }
 
-        private void DrawTrailingHitchLayer(bool isBackgroundLayer, double trailingTool)
+        private void DrawTrailingHitch(double trailingTool)
         {
-            GL.LineWidth(isBackgroundLayer ? 6 : 1);
-            (isBackgroundLayer ? Colors.Black : Colors.TrailingToolColor).SetColor();
+            LineStyle backgroundLineStyle = new LineStyle(6.0f, Colors.Black);
+            LineStyle foregroundLineStyle = new LineStyle(1.0f, Colors.HitchTrailingColor);
+            LineStyle[] lineStyles = { backgroundLineStyle, foregroundLineStyle };
 
-            GL.Begin(PrimitiveType.LineLoop);
-            GL.Vertex3(-0.65 + mf.tool.offset, trailingTool, 0);
-            GL.Vertex3(0, 0, 0);
-            GL.Vertex3(0.65 + mf.tool.offset, trailingTool, 0);
-            GL.End();
+            foreach (LineStyle lineStyle in lineStyles)
+            {
+                GLW.SetLineStyle(lineStyle);
+
+                GL.Begin(PrimitiveType.LineLoop);
+                GL.Vertex3(-0.65 + mf.tool.offset, trailingTool, 0);
+                GL.Vertex3(0, 0, 0);
+                GL.Vertex3(0.65 + mf.tool.offset, trailingTool, 0);
+                GL.End();
+            }
         }
 
         public void DrawTool()
@@ -174,8 +185,7 @@ namespace AgOpenGPS
                 //rotate to tank heading
                 GL.Rotate(glm.toDegrees(-mf.tankPos.heading), 0.0, 0.0, 1.0);
 
-                DrawHitchLayer(true, trailingTank);
-                DrawHitchLayer(false, trailingTank);
+                DrawHitch(trailingTank);
 
                 GL.Color4(1, 1, 1, 0.75);
                 XyCoord toolAxleCenter = new XyCoord(0.0, trailingTank);
@@ -191,8 +201,7 @@ namespace AgOpenGPS
             //draw the hitch if trailing
             if (isToolTrailing)
             {
-                DrawTrailingHitchLayer(true, trailingTool);
-                DrawTrailingHitchLayer(false, trailingTool);
+                DrawTrailingHitch(trailingTool);
 
                 if (Math.Abs(trailingToolToPivotLength) > 1 && mf.camera.camSetDistance > -100)
                 {
@@ -327,11 +336,9 @@ namespace AgOpenGPS
                     double leftX = mf.tram.isOuter ? farLeftPosition + mf.tram.halfWheelTrack : -mf.tram.halfWheelTrack;
                     // section markers
                     GL.Begin(PrimitiveType.Points);
-                    // right side
-                    rightMarkerColor.SetColor();
+                    GLW.SetColor(rightMarkerColor);
                     GL.Vertex3(rightX, trailingTool, 0);
-                    // left size
-                    leftMarkerColor.SetColor();
+                    GLW.SetColor(leftMarkerColor);
                     GL.Vertex3(leftX, trailingTool, 0);
                     GL.End();
                 }

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -1857,11 +1857,11 @@ namespace AgOpenGPS
             XyDelta dotDelta = new XyDelta(24, 24);
 
             ColorRgba leftDotColor = TramDotColor(tram.isLeftManualOn, isFlashOnOff, (tram.controlByte & 2) != 0);
-            leftDotColor.SetColor();
+            GLW.SetColor(leftDotColor);
             ScreenTextures.TramDot.DrawCentered(leftDotCenter, dotDelta);
 
             ColorRgba rightDotColor = TramDotColor(tram.isRightManualOn, isFlashOnOff, (tram.controlByte & 1) != 0);
-            rightDotColor.SetColor();
+            GLW.SetColor(rightDotColor);
             ScreenTextures.TramDot.DrawCentered(rightDotCenter, dotDelta);
         }
 
@@ -1933,6 +1933,7 @@ namespace AgOpenGPS
                         flagColor = "~";
                     }
                     flagColorRgb.Blue = (byte)flag.ID;
+                    GLW.SetColor(flagColorRgb);
                     GL.Vertex3(flag.easting, flag.northing, 0);
                     GL.End();
 

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -1841,6 +1841,13 @@ namespace AgOpenGPS
             GL.PopMatrix();
         }
 
+        private ColorRgba TramDotColor(bool isManual, bool isFlashOn, bool controlBitOn)
+        {
+            return isManual
+                ? (isFlashOn ? Colors.TramDotManualFlashOnColor : Colors.TramDotManualFlashOffColor)
+                : (controlBitOn ? Colors.TramDotAutomaticControlBitOnColor : Colors.TramDotAutomaticControlBitOffColor);
+        }
+
         private void DrawTramMarkers()
         {
             //int sizer = 60;
@@ -1849,25 +1856,12 @@ namespace AgOpenGPS
             XyCoord rightDotCenter = new XyCoord(+50, bottomSide);
             XyDelta dotDelta = new XyDelta(24, 24);
 
-            if ((tram.controlByte & 2) == 2) GL.Color4(0.29f, 0.990f, 0.290f, 0.983f);
-            else GL.Color4(0.9f, 0.0f, 0.0f, 0.53f);
-
-            if (tram.isLeftManualOn)
-            {
-                if (isFlashOnOff) GL.Color4(0.0f, 0.0f, 0.0f, 0.993f);
-                else GL.Color4(0.99f, 0.990f, 0.0f, 0.993f);
-            }
+            ColorRgba leftDotColor = TramDotColor(tram.isLeftManualOn, isFlashOnOff, (tram.controlByte & 2) != 0);
+            leftDotColor.SetColor();
             ScreenTextures.TramDot.DrawCentered(leftDotCenter, dotDelta);
 
-            if ((tram.controlByte & 1) == 1) GL.Color4(0.29f, 0.990f, 0.290f, 0.983f);
-            else GL.Color4(0.9f, 0.0f, 0.0f, 0.53f);
-
-            if (tram.isRightManualOn)
-            {
-                if (isFlashOnOff) GL.Color4(0.0f, 0.0f, 0.0f, 0.993f);
-                else GL.Color4(0.99f, 0.990f, 0.0f, 0.993f);
-            }
-
+            ColorRgba rightDotColor = TramDotColor(tram.isRightManualOn, isFlashOnOff, (tram.controlByte & 1) != 0);
+            rightDotColor.SetColor();
             ScreenTextures.TramDot.DrawCentered(rightDotCenter, dotDelta);
         }
 
@@ -1922,33 +1916,27 @@ namespace AgOpenGPS
         {
             try
             {
-                int flagCnt = flagPts.Count;
-                for (int f = 0; f < flagCnt; f++)
+                foreach (CFlag flag in flagPts)
                 {
                     GL.PointSize(8.0f);
                     GL.Begin(PrimitiveType.Points);
+                    ColorRgb flagColorRgb = Colors.FlagRedColor;
                     string flagColor = "&";
-                    if (flagPts[f].color == 0)
+                    if (flag.color == 1)
                     {
-                        GL.Color3((byte)255, (byte)0, (byte)flagPts[f].ID);
-                    }
-                    if (flagPts[f].color == 1)
-                    {
-                        GL.Color3((byte)0, (byte)255, (byte)flagPts[f].ID);
+                        flagColorRgb = Colors.FlagGreenColor;
                         flagColor = "|";
                     }
-                    if (flagPts[f].color == 2)
+                    if (flag.color == 2)
                     {
-                        GL.Color3((byte)255, (byte)255, (byte)flagPts[f].ID);
+                        flagColorRgb = Colors.FlagYellowColor;
                         flagColor = "~";
                     }
-
-                    GL.Vertex3(flagPts[f].easting, flagPts[f].northing, 0);
+                    flagColorRgb.Blue = (byte)flag.ID;
+                    GL.Vertex3(flag.easting, flag.northing, 0);
                     GL.End();
 
-                    font.DrawText3D(flagPts[f].easting, flagPts[f].northing, flagColor + flagPts[f].notes);
-                    //else
-                    //    font.DrawText3D(flagPts[f].easting, flagPts[f].northing, "&");
+                    font.DrawText3D(flag.easting, flag.northing, flagColor + flag.notes);
                 }
 
                 if (flagNumberPicked != 0)
@@ -1964,13 +1952,6 @@ namespace AgOpenGPS
                     GL.Vertex3(flagPts[flagNumberPicked - 1].easting + offSet, flagPts[flagNumberPicked - 1].northing, 0);
                     GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing + offSet, 0);
                     GL.End();
-
-                    //draw the flag with a black dot inside
-                    //GL.PointSize(4.0f);
-                    //GL.Color3(0, 0, 0);
-                    //GL.Begin(PrimitiveType.Points);
-                    //GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing, 0);
-                    //GL.End();
                 }
             }
             catch { }


### PR DESCRIPTION
I started a color library for the following reasons.
- color names are more easy to read and remember than hardcoded colors
- color names are more easy to search for, especially when they contain both the functional name, (so yo can search for TramLine/TramLineDot etc) and a physical name (so you can search for Black/Blue etc.)
- currently the code contains about 1600 direct dependencies to opengl toolkit. (Search for 'GL.') For portability it is better to start moving all the colors to the colorlib.