### PR TITLE
Refactor: add GLW.DrawPrimitive to reduce number of dependencies to OpenGL toolkit

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -25,7 +25,7 @@ namespace AgOpenGPS.Core.Drawing
 
         static public ColorRgb HitchColor = new ColorRgb(0.765f, 0.76f, 0.32f);
         static public ColorRgb HitchTrailingColor = new ColorRgb(0.7f, 0.4f, 0.2f);
-        static public ColorRgb HitchRigidColor = new ColorRgb(1.237f, 0.037f, 0.0397f);
+        static public ColorRgb HitchRigidColor = new ColorRgb(0.237f, 0.037f, 0.0397f);
 
         static public ColorRgb SvenArrowColor = new ColorRgb(0.95f, 0.95f, 0.10f);
 

--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -1,4 +1,5 @@
 ﻿using AgOpenGPS.Core.Models;
+
 namespace AgOpenGPS.Core.Drawing
 {
     static public class Colors
@@ -9,10 +10,22 @@ namespace AgOpenGPS.Core.Drawing
         static public ColorRgb Red = new ColorRgb(255, 0, 0);
         static public ColorRgb Green = new ColorRgb(0, 255, 0);
         static public ColorRgb Yellow = new ColorRgb(255, 255, 0);
+        static public ColorRgb Gray012 = new ColorRgb(0.12f, 0.12f, 0.12f);
+        static public ColorRgb Gray025 = new ColorRgb(0.25f, 0.25f, 0.25f);
 
         // Functional colors
+        static public ColorRgb AntennaColor = new ColorRgb(0.20f, 0.98f, 0.98f);
+        static public ColorRgb FlagRedColor = Red;
+        static public ColorRgb FlagGreenColor = Green;
+        static public ColorRgb FlagYellowColor = Yellow;
+        static public ColorRgb FlagSelectedBoxColor = new ColorRgb(0.980f, 0.0f, 0.980f);
+
+        static public ColorRgb GoalPointColor = new ColorRgb(0.98f, 0.98f, 0.098f);
         static public ColorRgb HitchColor = new ColorRgb(0.765f, 0.76f, 0.32f);
         static public ColorRgb HitchTrailingColor = new ColorRgb(0.7f, 0.4f, 0.2f);
+        static public ColorRgb HitchRigidColor = new ColorRgb(1.237f, 0.037f, 0.0397f);
+
+        static public ColorRgb SvenArrowColor = new ColorRgb(0.95f, 0.95f, 0.10f);
 
         static public ColorRgba TramDotManualFlashOffColor = new ColorRgba(0.0f, 0.0f, 0.0f, 0.993f);
         static public ColorRgba TramDotManualFlashOnColor = new ColorRgba(0.99f, 0.990f, 0.0f, 0.993f);
@@ -20,8 +33,8 @@ namespace AgOpenGPS.Core.Drawing
         static public ColorRgba TramDotAutomaticControlBitOnColor = new ColorRgba(0.29f, 0.990f, 0.290f, 0.983f);
         static public ColorRgb TramMarkerOnColor = new ColorRgb(0.0f, 0.900f, 0.39630f);
 
-        static public ColorRgb FlagRedColor = Red;
-        static public ColorRgb FlagGreenColor = Green;
-        static public ColorRgb FlagYellowColor = Yellow;
+        static public ColorRgb WorldGridDayColor = Gray012;
+        static public ColorRgb WorldGridNightColor = Gray025;
+        static public ColorRgb WorldGridColor(bool isDay) { return isDay ? WorldGridDayColor : WorldGridNightColor; }
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -37,6 +37,5 @@ namespace AgOpenGPS.Core.Drawing
 
         static public ColorRgb WorldGridDayColor = Gray012;
         static public ColorRgb WorldGridNightColor = Gray025;
-        static public ColorRgb WorldGridColor(bool isDay) { return isDay ? WorldGridDayColor : WorldGridNightColor; }
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Colors.cs
@@ -21,6 +21,8 @@ namespace AgOpenGPS.Core.Drawing
         static public ColorRgb FlagSelectedBoxColor = new ColorRgb(0.980f, 0.0f, 0.980f);
 
         static public ColorRgb GoalPointColor = new ColorRgb(0.98f, 0.98f, 0.098f);
+        static public ColorRgb HarvesterWheelColor = new ColorRgb(20, 20, 20);
+
         static public ColorRgb HitchColor = new ColorRgb(0.765f, 0.76f, 0.32f);
         static public ColorRgb HitchTrailingColor = new ColorRgb(0.7f, 0.4f, 0.2f);
         static public ColorRgb HitchRigidColor = new ColorRgb(1.237f, 0.037f, 0.0397f);

--- a/SourceCode/AgOpenGPS.Core/Drawing/GLW.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/GLW.cs
@@ -1,5 +1,6 @@
 ﻿using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
+using System.Collections.Generic;
 
 namespace AgOpenGPS.Core.Drawing
 {
@@ -20,7 +21,53 @@ namespace AgOpenGPS.Core.Drawing
         public static void SetLineStyle(LineStyle lineStyle)
         {
             GL.LineWidth(lineStyle.Width);
-            GLW.SetColor(lineStyle.Color);
+            SetColor(lineStyle.Color);
         }
+
+        public static void SetPointStyle(PointStyle pointStyle)
+        {
+            GL.PointSize(pointStyle.Size);
+            SetColor(pointStyle.Color);
+        }
+
+        public static void DrawPoint(double x, double y, double z)
+        {
+            GL.Begin(PrimitiveType.Points);
+            GL.Vertex3(x, y, z);
+            GL.End();
+        }
+
+        public static void DrawPrimitive(PrimitiveType primitiveType, XyCoord[] vertices)
+        {
+            Vertex2Array vertex2Array = new Vertex2Array(vertices);
+            GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+            vertex2Array.DeleteBuffer();
+        }
+
+        public static void DrawPointLayered(
+            PointStyle[] pointStyles,
+            double x, double y, double z)
+        {
+            foreach (PointStyle pointStyle in pointStyles)
+            {
+                SetPointStyle(pointStyle);
+                DrawPoint(x, y, z);
+            }
+        }
+
+        public static void DrawPrimitiveLayered(
+            PrimitiveType primitiveType,
+            LineStyle[] lineStyles,
+            XyCoord[] vertices)
+        {
+            Vertex2Array vertex2Array = new Vertex2Array(vertices);
+            foreach (LineStyle lineStyle in lineStyles)
+            {
+                SetLineStyle(lineStyle);
+                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+            }
+            vertex2Array.DeleteBuffer();
+        }
+
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Drawing/PointStyle.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/PointStyle.cs
@@ -1,0 +1,16 @@
+﻿using AgOpenGPS.Core.Models;
+
+namespace AgOpenGPS.Core.Drawing
+{
+    public class PointStyle
+    {
+        public PointStyle(float size, ColorRgb colorRgb)
+        {
+            Size = size;
+            Color = colorRgb;
+        }
+
+        public float Size { get; set; }
+        public ColorRgb Color { get; set; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Drawing/Vertex2Array.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/Vertex2Array.cs
@@ -1,0 +1,16 @@
+﻿using AgOpenGPS.Core.Models;
+using OpenTK.Graphics.OpenGL;
+using System;
+
+namespace AgOpenGPS.Core.Drawing
+{
+    public class Vertex2Array : VertexArrayBase
+    {
+        public Vertex2Array(XyCoord[] vertices) : base(2)
+        {
+            Length = vertices.Length;
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * 2 * sizeof(double), vertices, BufferUsageHint.StaticDraw);
+        }
+    }
+
+}

--- a/SourceCode/AgOpenGPS.Core/Drawing/VertexArrayBase.cs
+++ b/SourceCode/AgOpenGPS.Core/Drawing/VertexArrayBase.cs
@@ -1,0 +1,32 @@
+﻿using AgOpenGPS.Core.Models;
+using OpenTK.Graphics.OpenGL;
+using System;
+
+namespace AgOpenGPS.Core.Drawing
+{
+    public abstract class VertexArrayBase
+    {
+        private readonly int _bufId;
+
+        public VertexArrayBase(int nDimensions)
+        {
+            _bufId = GL.GenBuffer();
+            Bind();
+            GL.EnableVertexAttribArray(0);
+            GL.VertexAttribPointer(0, nDimensions, VertexAttribPointerType.Double, false, 0, 0);
+        }
+
+        public int Length { get; protected set; }
+
+        public void Bind()
+        {
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _bufId);
+        }
+
+        public void DeleteBuffer()
+        {
+            GL.DeleteBuffer(_bufId);
+        }
+    }
+
+}

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgb.cs
@@ -1,5 +1,4 @@
-﻿using OpenTK.Graphics.OpenGL;
-using System;
+﻿using System;
 
 namespace AgOpenGPS.Core.Models
 {
@@ -12,15 +11,14 @@ namespace AgOpenGPS.Core.Models
             Blue = blue;
         }
 
-        public ColorRgb(float red, float green, float blue) :
-            this(
-                ColorRgb.FloatToByte(red),
-                ColorRgb.FloatToByte(green),
-                ColorRgb.FloatToByte(blue))
+        public ColorRgb(float red, float green, float blue)
         {
-            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
-            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
-            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
+            if (red < 0.0f || 1.0f < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
+            if (green < 0.0f || 1.0f < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
+            if (blue < 0.0f || 1.0f < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
+            Red = ColorRgb.FloatToByte(red);
+            Green = ColorRgb.FloatToByte(green);
+            Blue = ColorRgb.FloatToByte(blue);
         }
 
         public byte Red { get; set; }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -1,5 +1,4 @@
-﻿using OpenTK.Graphics.OpenGL;
-using System;
+﻿using System;
 
 namespace AgOpenGPS.Core.Models
 {
@@ -13,22 +12,25 @@ namespace AgOpenGPS.Core.Models
             Alpha = alpha;
         }
 
-        public ColorRgba(ColorRgb colorRgb, float alpha) :
-            this(
-                colorRgb.Red,
-                colorRgb.Green,
-                colorRgb.Blue,
-                ColorRgba.FloatToByte(alpha))
+        public ColorRgba(ColorRgb colorRgb, float alpha)
         {
+            if (alpha < 0.0f || 1.0f < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
+            Red = colorRgb.Red;
+            Green = colorRgb.Green;
+            Blue = colorRgb.Blue;
+            Alpha = ColorRgba.FloatToByte(alpha);
         }
 
-        public ColorRgba(float red, float green, float blue, float alpha) :
-            this(
-                ColorRgba.FloatToByte(red),
-                ColorRgba.FloatToByte(green),
-                ColorRgba.FloatToByte(blue),
-                ColorRgba.FloatToByte(alpha))
+        public ColorRgba(float red, float green, float blue, float alpha)
         {
+            if (red < 0.0f || 1.0f < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
+            if (green < 0.0f || 1.0f < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
+            if (blue < 0.0f || 1.0f < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
+            if (alpha < 0.0f || 1.0f < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
+            Red = ColorRgba.FloatToByte(red);
+            Green = ColorRgba.FloatToByte(green);
+            Blue = ColorRgba.FloatToByte(blue);
+            Alpha = ColorRgba.FloatToByte(alpha);
         }
 
         public byte Red { get; }
@@ -48,8 +50,6 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
-            if (fraction < 0.0f || 1.0f < fraction) throw new ArgumentOutOfRangeException(nameof(fraction), "Argument out of range");
-
             return (byte)(255 * fraction);
         }
 

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -13,6 +13,16 @@ namespace AgOpenGPS.Core.Models
             Alpha = alpha;
         }
 
+        public ColorRgba(ColorRgb colorRgb, float alpha) :
+            this(
+                colorRgb.Red,
+                colorRgb.Green,
+                colorRgb.Blue,
+                ColorRgba.FloatToByte(alpha))
+        {
+            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
+        }
+
         public ColorRgba(float red, float green, float blue, float alpha) :
             this(
                 ColorRgba.FloatToByte(red),

--- a/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/ColorRgba.cs
@@ -20,7 +20,6 @@ namespace AgOpenGPS.Core.Models
                 colorRgb.Blue,
                 ColorRgba.FloatToByte(alpha))
         {
-            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
         }
 
         public ColorRgba(float red, float green, float blue, float alpha) :
@@ -30,10 +29,6 @@ namespace AgOpenGPS.Core.Models
                 ColorRgba.FloatToByte(blue),
                 ColorRgba.FloatToByte(alpha))
         {
-            if (red < 0.0f || 255.0 < red) throw new ArgumentOutOfRangeException(nameof(red), "Argument out of range");
-            if (green < 0.0f || 255.0 < green) throw new ArgumentOutOfRangeException(nameof(green), "Argument out of range");
-            if (blue < 0.0f || 255.0 < blue) throw new ArgumentOutOfRangeException(nameof(blue), "Argument out of range");
-            if (alpha < 0.0f || 255.0 < alpha) throw new ArgumentOutOfRangeException(nameof(alpha), "Argument out of range");
         }
 
         public byte Red { get; }
@@ -53,6 +48,8 @@ namespace AgOpenGPS.Core.Models
 
         static private byte FloatToByte(float fraction)
         {
+            if (fraction < 0.0f || 1.0f < fraction) throw new ArgumentOutOfRangeException(nameof(fraction), "Argument out of range");
+
             return (byte)(255 * fraction);
         }
 

--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -126,38 +126,28 @@ namespace AgOpenGPS
 
         private void DrawHitch(double trailingTank)
         {
+            XyCoord[] vertices = {
+                new XyCoord(-0.57, trailingTank),
+                new XyCoord(0.0, 0.0),
+                new XyCoord(0.57, trailingTank)
+            };
             LineStyle backgroundLineStyle = new LineStyle(6.0f, Colors.Black);
             LineStyle foregroundLineStyle = new LineStyle(1.0f, Colors.HitchColor);
             LineStyle[] lineStyles = { backgroundLineStyle, foregroundLineStyle };
-
-            foreach (LineStyle lineStyle in lineStyles)
-            {
-                GLW.SetLineStyle(lineStyle);
-
-                GL.Begin(PrimitiveType.LineLoop);
-                GL.Vertex3(-0.57, trailingTank, 0);
-                GL.Vertex3(0, 0, 0);
-                GL.Vertex3(0.57, trailingTank, 0);
-                GL.End();
-            }
+            GLW.DrawPrimitiveLayered(PrimitiveType.LineLoop, lineStyles, vertices);
         }
 
         private void DrawTrailingHitch(double trailingTool)
         {
+            XyCoord[] vertices = {
+                new XyCoord(-0.65 + mf.tool.offset, trailingTool),
+                new XyCoord(0.0, 0.0),
+                new XyCoord(0.65 + mf.tool.offset, trailingTool)
+            };
             LineStyle backgroundLineStyle = new LineStyle(6.0f, Colors.Black);
             LineStyle foregroundLineStyle = new LineStyle(1.0f, Colors.HitchTrailingColor);
             LineStyle[] lineStyles = { backgroundLineStyle, foregroundLineStyle };
-
-            foreach (LineStyle lineStyle in lineStyles)
-            {
-                GLW.SetLineStyle(lineStyle);
-
-                GL.Begin(PrimitiveType.LineLoop);
-                GL.Vertex3(-0.65 + mf.tool.offset, trailingTool, 0);
-                GL.Vertex3(0, 0, 0);
-                GL.Vertex3(0.65 + mf.tool.offset, trailingTool, 0);
-                GL.End();
-            }
+            GLW.DrawPrimitiveLayered(PrimitiveType.LineLoop, lineStyles, vertices);
         }
 
         public void DrawTool()
@@ -274,38 +264,23 @@ namespace AgOpenGPS
                 }
 
                 double mid = (mf.section[j].positionRight - mf.section[j].positionLeft) / 2 + mf.section[j].positionLeft;
-
-                GL.Begin(PrimitiveType.TriangleFan);
-                {
-                    GL.Vertex3(mf.section[j].positionLeft, trailingTool, 0);
-                    GL.Vertex3(mf.section[j].positionLeft, trailingTool - hite, 0);
-
-                    GL.Vertex3(mid, trailingTool - hite * 1.5, 0);
-
-                    GL.Vertex3(mf.section[j].positionRight, trailingTool - hite, 0);
-                    GL.Vertex3(mf.section[j].positionRight, trailingTool, 0);
-                }
-                GL.End();
+                XyCoord[] vertices = {
+                    new XyCoord(mf.section[j].positionLeft, trailingTool),
+                    new XyCoord(mf.section[j].positionLeft, trailingTool - hite),
+                    new XyCoord(mid, trailingTool - hite * 1.5),
+                    new XyCoord(mf.section[j].positionRight, trailingTool - hite),
+                    new XyCoord(mf.section[j].positionRight, trailingTool),
+                };
+                GLW.DrawPrimitive(PrimitiveType.TriangleFan, vertices);
 
                 if (mf.camera.camSetDistance > -width * 200)
                 {
-                    GL.Begin(PrimitiveType.LineLoop);
-                    {
-                        GL.Color3(0.0, 0.0, 0.0);
-                        GL.Vertex3(mf.section[j].positionLeft, trailingTool, 0);
-                        GL.Vertex3(mf.section[j].positionLeft, trailingTool - hite, 0);
-
-                        GL.Vertex3(mid, trailingTool - hite * 1.5, 0);
-
-                        GL.Vertex3(mf.section[j].positionRight, trailingTool - hite, 0);
-                        GL.Vertex3(mf.section[j].positionRight, trailingTool, 0);
-                    }
-                    GL.End();
+                    GLW.SetColor(Colors.Black);
+                    GLW.DrawPrimitive(PrimitiveType.LineLoop, vertices);
                 }
             }
 
             //zones
-
             if (!isSectionsNotZones && zones > 0 && mf.camera.camSetDistance > -150)
             {
                 //GL.PointSize(8);

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -1,5 +1,6 @@
 ﻿//Please, if you use this, share the improvements
 
+using AgOpenGPS.Core.Drawing;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 using System;
@@ -130,36 +131,12 @@ namespace AgOpenGPS
 
                 goalPointDistance *= LoekiAheadHold; 
                 goalPointDistance += LoekiAheadHold;
-
             }
             else
             {
                 goalPointDistance *= LoekiAheadAcquire; 
                 goalPointDistance += LoekiAheadAcquire;
             }
-
-            ////how far should goal point be away  - speed * seconds * kmph -> m/s then limit min value
-            ////double goalPointDistance = mf.avgSpeed * goalPointLookAhead * 0.05 * goalPointLookAheadMult;
-            //double goalPointDistance = mf.avgSpeed * goalPointLookAhead * 0.07; //0.05 * 1.4
-            //goalPointDistance += goalPointLookAhead;
-
-            //if (xTE < (modeXTE))
-            //{
-            //    if (modeTimeCounter > modeTime * 10)
-            //    {
-            //        //goalPointDistance = mf.avgSpeed * goalPointLookAheadHold * 0.05 * goalPointLookAheadMult;
-            //        goalPointDistance = mf.avgSpeed * goalPointLookAheadHold * 0.07; //0.05 * 1.4
-            //        goalPointDistance += goalPointLookAheadHold;
-            //    }
-            //    else
-            //    {
-            //        modeTimeCounter++;
-            //    }
-            //}
-            //else
-            //{
-            //    modeTimeCounter = 0;
-            //}
 
             if (goalPointDistance < 2) goalPointDistance = 2;
             goalDistance = goalPointDistance;
@@ -169,54 +146,32 @@ namespace AgOpenGPS
 
         public void DrawVehicle()
         {
-            //draw vehicle
             GL.Rotate(glm.toDegrees(-mf.fixHeading), 0.0, 0.0, 1.0);
             //mf.font.DrawText3D(0, 0, "&TGF");
             if (mf.isFirstHeadingSet && !mf.tool.isToolFrontFixed)
             {
+                // Draw the rigid hitch
+               XyCoord[] vertices;
                 if (!mf.tool.isToolRearFixed)
                 {
-                    GL.LineWidth(4);
-                    //draw the rigid hitch
-                    GL.Color3(0, 0, 0);
-                    GL.Begin(PrimitiveType.Lines);
-                    GL.Vertex3(0, mf.tool.hitchLength, 0);
-                    GL.Vertex3(0, 0, 0);
-                    GL.End();
-
-                    GL.LineWidth(1);
-                    GL.Color3(1.237f, 0.037f, 0.0397f);
-                    GL.Begin(PrimitiveType.Lines);
-                    GL.Vertex3(0, mf.tool.hitchLength, 0);
-                    GL.Vertex3(0, 0, 0);
-                    GL.End();
+                    vertices = new XyCoord[] {
+                        new XyCoord(0, mf.tool.hitchLength), new XyCoord(0, 0)
+                    };
                 }
                 else
                 {
-                    GL.LineWidth(4);
-                    //draw the rigid hitch
-                    GL.Color3(0, 0, 0);
-                    GL.Begin(PrimitiveType.Lines);
-                    GL.Vertex3(-0.35, mf.tool.hitchLength, 0);
-                    GL.Vertex3(-0.350, 0, 0);
-                    GL.Vertex3(0.35, mf.tool.hitchLength, 0);
-                    GL.Vertex3(0.350, 0, 0);
-                    GL.End();
-
-                    GL.LineWidth(1);
-                    GL.Color3(1.237f, 0.037f, 0.0397f);
-                    GL.Begin(PrimitiveType.Lines);
-                    GL.Vertex3(-0.35, mf.tool.hitchLength, 0);
-                    GL.Vertex3(-0.35, 0, 0);
-                    GL.Vertex3(0.35, mf.tool.hitchLength, 0);
-                    GL.Vertex3(0.35, 0, 0);
-                    GL.End();
+                    vertices = new XyCoord[] {
+                        new XyCoord(-0.35, mf.tool.hitchLength), new XyCoord(-0.35, 0),
+                        new XyCoord( 0.35, mf.tool.hitchLength), new XyCoord( 0.35, 0)
+                    };
                 }
+                LineStyle backgroundLineStyle = new LineStyle(4, Colors.Black);
+                LineStyle foregroundLineStyle = new LineStyle(1, Colors.HitchRigidColor);
+                LineStyle[] layerStyles = { backgroundLineStyle, foregroundLineStyle };
+                GLW.DrawPrimitiveLayered(PrimitiveType.Lines, layerStyles, vertices);
             }
-            //GL.Enable(EnableCap.Blend);
 
             //draw the vehicle Body
-
             if (!mf.isFirstHeadingSet && mf.headingFromSource != "Dual")
             {
                 GL.Color4(1,1,1, 0.75);
@@ -348,17 +303,10 @@ namespace AgOpenGPS
             if (mf.camera.camSetDistance > -75 && mf.isFirstHeadingSet)
             {
                 //draw the bright antenna dot
-                GL.PointSize(16);
-                GL.Begin(PrimitiveType.Points);
-                GL.Color3(0, 0, 0);
-                GL.Vertex3(-VehicleConfig.AntennaOffset, VehicleConfig.AntennaPivot, 0.1);
-                GL.End();
-
-                GL.PointSize(10);
-                GL.Begin(PrimitiveType.Points);
-                GL.Color3(0.20, 0.98, 0.98);
-                GL.Vertex3(-VehicleConfig.AntennaOffset, VehicleConfig.AntennaPivot, 0.1);
-                GL.End();
+                PointStyle antennaBackgroundStyle = new PointStyle(16, Colors.Black);
+                PointStyle antennaForegroundStyle = new PointStyle(10, Colors.AntennaColor);
+                PointStyle[] layerStyles = { antennaBackgroundStyle, antennaForegroundStyle };
+                GLW.DrawPointLayered(layerStyles , - VehicleConfig.AntennaOffset, VehicleConfig.AntennaPivot, 0.1);
             }
 
             if (mf.bnd.isBndBeingMade && mf.bnd.isDrawAtPivot)
@@ -376,7 +324,6 @@ namespace AgOpenGPS
                     }
                     GL.End();
                 }
-
                 //draw on left side
                 else
                 {
@@ -399,15 +346,14 @@ namespace AgOpenGPS
                 //double offs = mf.curve.distanceFromCurrentLinePivot * 0.3;
                 double svennDist = mf.camera.camSetDistance * -0.07;
                 double svennWidth = svennDist * 0.22;
-                GL.LineWidth(mf.ABLine.lineWidth);
-                GL.Color3(0.95, 0.95, 0.10);
-                GL.Begin(PrimitiveType.LineStrip);
-                {
-                    GL.Vertex3(svennWidth, VehicleConfig.Wheelbase + svennDist, 0.0);
-                    GL.Vertex3(0, VehicleConfig.Wheelbase + svennWidth + 0.5 + svennDist, 0.0);
-                    GL.Vertex3(-svennWidth, VehicleConfig.Wheelbase + svennDist, 0.0);
-                }
-                GL.End();
+                LineStyle svenArrowLineStyle = new LineStyle(mf.ABLine.lineWidth, Colors.SvenArrowColor);
+                GLW.SetLineStyle(svenArrowLineStyle);
+                XyCoord[] vertices = {
+                    new XyCoord(svennWidth, VehicleConfig.Wheelbase + svennDist),
+                    new XyCoord(0, VehicleConfig.Wheelbase + svennWidth + 0.5 + svennDist),
+                    new XyCoord(-svennWidth, VehicleConfig.Wheelbase + svennDist)
+                };
+                GLW.DrawPrimitive(PrimitiveType.LineStrip, vertices);
             }
             GL.LineWidth(1);
         }

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -179,15 +179,13 @@ namespace AgOpenGPS
             }
 
             //3 vehicle types  tractor=0 harvestor=1 Articulated=2
-
+            ColorRgba vehicleColor = new ColorRgba(VehicleConfig.Color, (float)VehicleConfig.Opacity);
             if (mf.isVehicleImage)
             {
-                byte vehicleOpacityByte = (byte)(255 * VehicleConfig.Opacity);
-
                 if (VehicleConfig.Type == VehicleType.Tractor)
                 {
                     //vehicle body
-                    GL.Color4(VehicleConfig.Color.Red, VehicleConfig.Color.Green, VehicleConfig.Color.Blue, vehicleOpacityByte);
+                    GLW.SetColor(vehicleColor);
 
                     AckermannAngles(
                         - (mf.timerSim.Enabled ? mf.sim.steerangleAve : mf.mc.actualSteerAngleDegrees),
@@ -202,8 +200,6 @@ namespace AgOpenGPS
                     GL.PushMatrix();
                     GL.Translate(0.5 * VehicleConfig.TrackWidth, VehicleConfig.Wheelbase, 0);
                     GL.Rotate(rightAckermann, 0, 0, 1);
-
-                    GL.Color4(VehicleConfig.Color.Red, VehicleConfig.Color.Green, VehicleConfig.Color.Blue, vehicleOpacityByte);
 
                     XyDelta frontWheelDelta = new XyDelta(0.5 * VehicleConfig.TrackWidth, -0.75 * VehicleConfig.Wheelbase);
                     mf.VehicleTextures.FrontWheel.DrawCenteredAroundOrigin(frontWheelDelta);
@@ -229,8 +225,8 @@ namespace AgOpenGPS
                         mf.timerSim.Enabled ? mf.sim.steerAngle : mf.mc.actualSteerAngleDegrees,
                         out double leftAckermannAngle,
                         out double rightAckermannAngle);
-
-                    GL.Color4((byte)20, (byte)20, (byte)20, vehicleOpacityByte);
+                    ColorRgba harvesterWheelColor = new ColorRgba(Colors.HarvesterWheelColor, (float)VehicleConfig.Opacity);
+                    GLW.SetColor(harvesterWheelColor);
                     //right wheel
                     GL.PushMatrix();
                     GL.Translate(VehicleConfig.TrackWidth * 0.5, -VehicleConfig.Wheelbase, 0);
@@ -246,21 +242,15 @@ namespace AgOpenGPS
                     mf.VehicleTextures.FrontWheel.DrawCenteredAroundOrigin(forntWheelDelta);
                     GL.PopMatrix();
 
-                    GL.Color4(VehicleConfig.Color.Red, VehicleConfig.Color.Green, VehicleConfig.Color.Blue, vehicleOpacityByte);
+                    GLW.SetColor(vehicleColor);
                     mf.VehicleTextures.Harvester.DrawCenteredAroundOrigin(
                         new XyDelta(VehicleConfig.TrackWidth, -1.5 * VehicleConfig.Wheelbase));
                     //disable, straight color
                 }
                 else if (VehicleConfig.Type == VehicleType.Articulated)
                 {
-                    double modelSteerAngle;
-
-                    if (mf.timerSim.Enabled)
-                        modelSteerAngle = 0.5 * mf.sim.steerAngle;
-                    else
-                        modelSteerAngle = 0.5 * mf.mc.actualSteerAngleDegrees;
-
-                    GL.Color4(VehicleConfig.Color.Red, VehicleConfig.Color.Green, VehicleConfig.Color.Blue, vehicleOpacityByte);
+                    double modelSteerAngle = 0.5 * (mf.timerSim.Enabled ? mf.sim.steerAngle : mf.mc.actualSteerAngleDegrees);
+                    GLW.SetColor(vehicleColor);
 
                     XyDelta articulated = new XyDelta(VehicleConfig.TrackWidth, -0.65 * VehicleConfig.Wheelbase);
                     GL.PushMatrix();
@@ -299,7 +289,6 @@ namespace AgOpenGPS
                 }
                 GL.End();
             }
-
             if (mf.camera.camSetDistance > -75 && mf.isFirstHeadingSet)
             {
                 //draw the bright antenna dot

--- a/SourceCode/GPS/Classes/CWorldGrid.cs
+++ b/SourceCode/GPS/Classes/CWorldGrid.cs
@@ -121,7 +121,9 @@ namespace AgOpenGPS
         public void DrawWorldGrid(double _gridZoom)
         {
             GL.Rotate(-gridRotation, 0, 0, 1.0);
-            LineStyle worldGridLineStyle = new LineStyle(1.0f, Colors.WorldGridColor(mf.isDay));
+            ColorRgb worldGridColor = mf.isDay ? Colors.WorldGridDayColor : Colors.WorldGridNightColor; 
+
+            LineStyle worldGridLineStyle = new LineStyle(1.0f, worldGridColor);
             GLW.SetLineStyle(worldGridLineStyle);
             List<XyCoord> vertices = new List<XyCoord>();
             for (double num = Math.Round(eastingMin / _gridZoom, MidpointRounding.AwayFromZero) * _gridZoom; num < eastingMax; num += _gridZoom)

--- a/SourceCode/GPS/Classes/CWorldGrid.cs
+++ b/SourceCode/GPS/Classes/CWorldGrid.cs
@@ -5,6 +5,7 @@ using AgOpenGPS.Core.Models;
 using AgOpenGPS.Properties;
 using OpenTK.Graphics.OpenGL;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace AgOpenGPS
@@ -119,38 +120,24 @@ namespace AgOpenGPS
 
         public void DrawWorldGrid(double _gridZoom)
         {
-            //_gridZoom *= 0.5;
-
             GL.Rotate(-gridRotation, 0, 0, 1.0);
-
-            if (mf.isDay)
-            {
-                GL.Color3(0.25, 0.25, 0.25);
-            }
-            else
-            {
-                GL.Color3(0.12, 0.12, 0.12);
-            }
-            GL.LineWidth(1);
-            GL.Begin(PrimitiveType.Lines);
+            LineStyle worldGridLineStyle = new LineStyle(1.0f, Colors.WorldGridColor(mf.isDay));
+            GLW.SetLineStyle(worldGridLineStyle);
+            List<XyCoord> vertices = new List<XyCoord>();
             for (double num = Math.Round(eastingMin / _gridZoom, MidpointRounding.AwayFromZero) * _gridZoom; num < eastingMax; num += _gridZoom)
             {
                 if (num < eastingMin) continue;
-
-                GL.Vertex3(num, northingMax, 0.1);
-                GL.Vertex3(num, northingMin, 0.1);
+                vertices.Add(new XyCoord(num, northingMax));
+                vertices.Add(new XyCoord(num, northingMin));
             }
             for (double num2 = Math.Round(northingMin / _gridZoom, MidpointRounding.AwayFromZero) * _gridZoom; num2 < northingMax; num2 += _gridZoom)
             {
                 if (num2 < northingMin) continue;
-
-                GL.Vertex3(eastingMax, num2, 0.1);
-                GL.Vertex3(eastingMin, num2, 0.1);
+                vertices.Add(new XyCoord(eastingMax, num2));
+                vertices.Add(new XyCoord(eastingMin, num2));
             }
-            GL.End();
-
+            GLW.DrawPrimitive(PrimitiveType.Lines, vertices.ToArray());
             GL.Rotate(gridRotation, 0, 0, 1.0);
-
         }
 
         public void checkZoomWorldGrid(GeoCoord geoCoord)

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -439,39 +439,15 @@ namespace AgOpenGPS
                     {
                         if (trk.idx > -1)
                         {
-                            if (trk.gArr[trk.idx].mode == TrackMode.AB)
-                            {
-                                GL.PointSize(12);
-                                GL.Begin(PrimitiveType.Points);
-                                GL.Color3(0, 0, 0);
-                                GL.Vertex3(ABLine.goalPointAB.easting, ABLine.goalPointAB.northing, 0.0);
-                                GL.End();
-
-                                GL.PointSize(6);
-                                GL.Begin(PrimitiveType.Points);
-                                GL.Color3(0.98, 0.98, 0.098);
-                                GL.Vertex3(ABLine.goalPointAB.easting, ABLine.goalPointAB.northing, 0.0);
-                                GL.End();
-                            }
-                            else
-                            {
-                                GL.PointSize(12);
-                                GL.Begin(PrimitiveType.Points);
-                                GL.Color3(0, 0, 0);
-                                GL.Vertex3(curve.goalPointCu.easting, curve.goalPointCu.northing, 0.0);
-                                GL.End();
-
-                                GL.PointSize(6);
-                                GL.Begin(PrimitiveType.Points);
-                                GL.Color3(0.98, 0.98, 0.098);
-                                GL.Vertex3(curve.goalPointCu.easting, curve.goalPointCu.northing, 0.0);
-                                GL.End();
-                            }
+                            PointStyle backgroundPointStyle = new PointStyle(12.0f, Colors.Black);
+                            PointStyle foregroundPointStyle = new PointStyle(6.0f, Colors.GoalPointColor);
+                            PointStyle[] pointStyles = { backgroundPointStyle, foregroundPointStyle};
+                            vec2 goalPoint = trk.gArr[trk.idx].mode == TrackMode.AB ? ABLine.goalPointAB : curve.goalPointCu;
+                            GLW.DrawPointLayered(pointStyles, goalPoint.easting, goalPoint.northing, 0.0);
                         }
                     }
 
                     // 2D Ortho ---------------------------------------////////-------------------------------------------------
-
                     GL.MatrixMode(MatrixMode.Projection);
                     GL.PushMatrix();
                     GL.LoadIdentity();
@@ -1939,20 +1915,20 @@ namespace AgOpenGPS
 
                     font.DrawText3D(flag.easting, flag.northing, flagColor + flag.notes);
                 }
-
                 if (flagNumberPicked != 0)
                 {
                     ////draw the box around flag
                     double offSet = (camera.zoomValue * camera.zoomValue * 0.01);
-                    GL.LineWidth(4);
-                    GL.Color3(0.980f, 0.0f, 0.980f);
-                    GL.Begin(PrimitiveType.LineStrip);
-                    GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing + offSet, 0);
-                    GL.Vertex3(flagPts[flagNumberPicked - 1].easting - offSet, flagPts[flagNumberPicked - 1].northing, 0);
-                    GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing - offSet, 0);
-                    GL.Vertex3(flagPts[flagNumberPicked - 1].easting + offSet, flagPts[flagNumberPicked - 1].northing, 0);
-                    GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing + offSet, 0);
-                    GL.End();
+                    LineStyle boxLineStyle = new LineStyle(4.0f, Colors.FlagSelectedBoxColor);
+                    GLW.SetLineStyle(boxLineStyle);
+                    CFlag flag = flagPts[flagNumberPicked - 1];
+                    XyCoord[] squareCorners = {
+                        new XyCoord(flag.easting         , flag.northing + offSet),
+                        new XyCoord(flag.easting - offSet, flag.northing),
+                        new XyCoord(flag.easting         , flag.northing - offSet),
+                        new XyCoord(flag.easting + offSet, flag.northing),
+                    };
+                    GLW.DrawPrimitive(PrimitiveType.LineLoop, squareCorners);
                 }
             }
             catch { }


### PR DESCRIPTION
I introduced functions for drawing OpenGL primitives in GLW (OpenGL Wrapper)
I replaced some code with calls to the new functions.
As a result, the number of direct dependencies to the current ToolKit is lowered from ~1600 to ~1500