### PR TITLE
Refactor: move OpenGl wrapper code from Drawing to drawLib

### DIFF
--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.cs
@@ -2,7 +2,7 @@
 using OpenTK.Graphics.OpenGL;
 using System.Collections.Generic;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     // GLW is short for GL Wrapper.
     // Please use this class in stead of direct calls to functions in the GL toolkit.

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GeoTexture2D.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GeoTexture2D.cs
@@ -2,7 +2,7 @@
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public class GeoTexture2D : Texture2D
     {

--- a/SourceCode/AgOpenGPS.Core/DrawLib/LineStyle.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/LineStyle.cs
@@ -1,6 +1,6 @@
 ﻿using AgOpenGPS.Core.Models;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public class LineStyle
     {

--- a/SourceCode/AgOpenGPS.Core/DrawLib/PointStyle.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/PointStyle.cs
@@ -1,6 +1,6 @@
 ﻿using AgOpenGPS.Core.Models;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public class PointStyle
     {

--- a/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
@@ -3,7 +3,7 @@ using System.Drawing.Imaging;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public class Texture2D
     {

--- a/SourceCode/AgOpenGPS.Core/DrawLib/Vertex2Array.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Vertex2Array.cs
@@ -2,7 +2,7 @@
 using OpenTK.Graphics.OpenGL;
 using System;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public class Vertex2Array : VertexArrayBase
     {

--- a/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
@@ -2,7 +2,7 @@
 using OpenTK.Graphics.OpenGL;
 using System;
 
-namespace AgOpenGPS.Core.Drawing
+namespace AgOpenGPS.Core.DrawLib
 {
     public abstract class VertexArrayBase
     {

--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -1,4 +1,5 @@
 ﻿using AgOpenGPS.Core.Drawing;
+using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 using System;

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -1,6 +1,7 @@
 ﻿//Please, if you use this, share the improvements
 
 using AgOpenGPS.Core.Drawing;
+using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 using System;

--- a/SourceCode/GPS/Classes/CWorldGrid.cs
+++ b/SourceCode/GPS/Classes/CWorldGrid.cs
@@ -1,6 +1,7 @@
 ﻿//Please, if you use this, share the improvements
 
 using AgOpenGPS.Core.Drawing;
+using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Properties;
 using OpenTK.Graphics.OpenGL;

--- a/SourceCode/GPS/Classes/ScreenTextures.cs
+++ b/SourceCode/GPS/Classes/ScreenTextures.cs
@@ -1,4 +1,4 @@
-﻿using AgOpenGPS.Core.Drawing;
+﻿using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Properties;
 
 namespace AgOpenGPS.Classes

--- a/SourceCode/GPS/Classes/VehicleTextures.cs
+++ b/SourceCode/GPS/Classes/VehicleTextures.cs
@@ -1,4 +1,4 @@
-﻿using AgOpenGPS.Core.Drawing;
+﻿using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Properties;
 using System.Drawing;
 

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Drawing;
 using AgLibrary.Logging;
 using AgOpenGPS.Core.Drawing;
+using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Properties;
 


### PR DESCRIPTION
I want to keep application drawing code separated from the OpenGL wrapper code. So, let's move the wrapper code to folder DrawLib, before I start moving application drawing code to folder Drawing