### PR TITLE
Load flags using a text or CSV file

### DIFF
--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
@@ -39,6 +39,7 @@
             this.btnYellow = new System.Windows.Forms.Button();
             this.btnRed = new System.Windows.Forms.Button();
             this.btnGreen = new System.Windows.Forms.Button();
+            this.btnLoadFlags = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.nudLatitude)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudLongitude)).BeginInit();
             this.SuspendLayout();
@@ -220,6 +221,17 @@
             this.btnGreen.UseVisualStyleBackColor = false;
             this.btnGreen.Click += new System.EventHandler(this.btnRed_Click);
             // 
+            // btnLoadFlags
+            // 
+            this.btnLoadFlags.Font = new System.Drawing.Font("Tahoma", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnLoadFlags.Location = new System.Drawing.Point(44, 168);
+            this.btnLoadFlags.Name = "btnLoadFlags";
+            this.btnLoadFlags.Size = new System.Drawing.Size(196, 71);
+            this.btnLoadFlags.TabIndex = 434;
+            this.btnLoadFlags.Text = "Load Flags";
+            this.btnLoadFlags.UseVisualStyleBackColor = true;
+            this.btnLoadFlags.Click += new System.EventHandler(this.btnLoadFlags_Click);
+            // 
             // FormEnterFlag
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -227,6 +239,7 @@
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(771, 266);
             this.ControlBox = false;
+            this.Controls.Add(this.btnLoadFlags);
             this.Controls.Add(this.btnGreen);
             this.Controls.Add(this.btnRed);
             this.Controls.Add(this.btnYellow);
@@ -263,5 +276,6 @@
         private System.Windows.Forms.Button btnYellow;
         private System.Windows.Forms.Button btnRed;
         private System.Windows.Forms.Button btnGreen;
+        private System.Windows.Forms.Button btnLoadFlags;
     }
 }

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
@@ -32,14 +32,15 @@
             this.label8 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
-            this.nudLatitude = new AgOpenGPS.NudlessNumericUpDown();
-            this.nudLongitude = new AgOpenGPS.NudlessNumericUpDown();
             this.labelPoint = new System.Windows.Forms.Label();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnYellow = new System.Windows.Forms.Button();
             this.btnRed = new System.Windows.Forms.Button();
             this.btnGreen = new System.Windows.Forms.Button();
             this.btnLoadFlags = new System.Windows.Forms.Button();
+            this.nudLatitude = new AgOpenGPS.NudlessNumericUpDown();
+            this.nudLongitude = new AgOpenGPS.NudlessNumericUpDown();
+            this.btnSaveFlags = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.nudLatitude)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudLongitude)).BeginInit();
             this.SuspendLayout();
@@ -49,9 +50,10 @@
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label9.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label9.Location = new System.Drawing.Point(510, 40);
+            this.label9.Location = new System.Drawing.Point(680, 49);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(163, 25);
+            this.label9.Size = new System.Drawing.Size(211, 33);
             this.label9.TabIndex = 202;
             this.label9.Text = "( +180 to -180 )";
             // 
@@ -60,9 +62,10 @@
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label8.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label8.Location = new System.Drawing.Point(215, 40);
+            this.label8.Location = new System.Drawing.Point(287, 49);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(134, 25);
+            this.label8.Size = new System.Drawing.Size(173, 33);
             this.label8.TabIndex = 201;
             this.label8.Text = "( +90 to -90)";
             // 
@@ -70,9 +73,10 @@
             // 
             this.label1.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label1.Location = new System.Drawing.Point(457, 15);
+            this.label1.Location = new System.Drawing.Point(609, 18);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(269, 25);
+            this.label1.Size = new System.Drawing.Size(359, 31);
             this.label1.TabIndex = 200;
             this.label1.Text = "Longitude";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -81,74 +85,22 @@
             // 
             this.label18.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label18.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label18.Location = new System.Drawing.Point(160, 15);
+            this.label18.Location = new System.Drawing.Point(213, 18);
+            this.label18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(252, 25);
+            this.label18.Size = new System.Drawing.Size(336, 31);
             this.label18.TabIndex = 199;
             this.label18.Text = "Latitude";
             this.label18.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // nudLatitude
-            // 
-            this.nudLatitude.BackColor = System.Drawing.Color.AliceBlue;
-            this.nudLatitude.DecimalPlaces = 7;
-            this.nudLatitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.nudLatitude.Location = new System.Drawing.Point(152, 68);
-            this.nudLatitude.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.nudLatitude.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.nudLatitude.Name = "nudLatitude";
-            this.nudLatitude.Size = new System.Drawing.Size(274, 52);
-            this.nudLatitude.TabIndex = 198;
-            this.nudLatitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.nudLatitude.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudLatitude.Click += new System.EventHandler(this.nudLatitude_Click);
-            // 
-            // nudLongitude
-            // 
-            this.nudLongitude.BackColor = System.Drawing.Color.AliceBlue;
-            this.nudLongitude.DecimalPlaces = 7;
-            this.nudLongitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.nudLongitude.Location = new System.Drawing.Point(448, 68);
-            this.nudLongitude.Maximum = new decimal(new int[] {
-            180,
-            0,
-            0,
-            0});
-            this.nudLongitude.Minimum = new decimal(new int[] {
-            180,
-            0,
-            0,
-            -2147483648});
-            this.nudLongitude.Name = "nudLongitude";
-            this.nudLongitude.Size = new System.Drawing.Size(298, 52);
-            this.nudLongitude.TabIndex = 197;
-            this.nudLongitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.nudLongitude.Value = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.nudLongitude.Click += new System.EventHandler(this.nudLongitude_Click);
             // 
             // labelPoint
             // 
             this.labelPoint.Font = new System.Drawing.Font("Tahoma", 21.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelPoint.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelPoint.Location = new System.Drawing.Point(22, 76);
+            this.labelPoint.Location = new System.Drawing.Point(29, 94);
+            this.labelPoint.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelPoint.Name = "labelPoint";
-            this.labelPoint.Size = new System.Drawing.Size(125, 34);
+            this.labelPoint.Size = new System.Drawing.Size(167, 42);
             this.labelPoint.TabIndex = 205;
             this.labelPoint.Text = "Point A";
             this.labelPoint.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -163,9 +115,10 @@
             this.btnCancel.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnCancel.Image = global::AgOpenGPS.Properties.Resources.Cancel64;
             this.btnCancel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnCancel.Location = new System.Drawing.Point(275, 193);
+            this.btnCancel.Location = new System.Drawing.Point(422, 238);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(87, 58);
+            this.btnCancel.Size = new System.Drawing.Size(116, 71);
             this.btnCancel.TabIndex = 430;
             this.btnCancel.UseVisualStyleBackColor = false;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
@@ -179,9 +132,10 @@
             this.btnYellow.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnYellow.Image = global::AgOpenGPS.Properties.Resources.FlagYel;
             this.btnYellow.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnYellow.Location = new System.Drawing.Point(441, 193);
+            this.btnYellow.Location = new System.Drawing.Point(588, 238);
+            this.btnYellow.Margin = new System.Windows.Forms.Padding(4);
             this.btnYellow.Name = "btnYellow";
-            this.btnYellow.Size = new System.Drawing.Size(87, 58);
+            this.btnYellow.Size = new System.Drawing.Size(116, 71);
             this.btnYellow.TabIndex = 431;
             this.btnYellow.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnYellow.UseVisualStyleBackColor = false;
@@ -196,9 +150,10 @@
             this.btnRed.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnRed.Image = global::AgOpenGPS.Properties.Resources.FlagRed;
             this.btnRed.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnRed.Location = new System.Drawing.Point(672, 193);
+            this.btnRed.Location = new System.Drawing.Point(896, 238);
+            this.btnRed.Margin = new System.Windows.Forms.Padding(4);
             this.btnRed.Name = "btnRed";
-            this.btnRed.Size = new System.Drawing.Size(87, 58);
+            this.btnRed.Size = new System.Drawing.Size(116, 71);
             this.btnRed.TabIndex = 432;
             this.btnRed.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnRed.UseVisualStyleBackColor = false;
@@ -213,9 +168,10 @@
             this.btnGreen.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnGreen.Image = global::AgOpenGPS.Properties.Resources.FlagGrn;
             this.btnGreen.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnGreen.Location = new System.Drawing.Point(556, 193);
+            this.btnGreen.Location = new System.Drawing.Point(741, 238);
+            this.btnGreen.Margin = new System.Windows.Forms.Padding(4);
             this.btnGreen.Name = "btnGreen";
-            this.btnGreen.Size = new System.Drawing.Size(87, 58);
+            this.btnGreen.Size = new System.Drawing.Size(116, 71);
             this.btnGreen.TabIndex = 433;
             this.btnGreen.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnGreen.UseVisualStyleBackColor = false;
@@ -223,22 +179,92 @@
             // 
             // btnLoadFlags
             // 
-            this.btnLoadFlags.Font = new System.Drawing.Font("Tahoma", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnLoadFlags.Location = new System.Drawing.Point(44, 168);
+            this.btnLoadFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
+            this.btnLoadFlags.Location = new System.Drawing.Point(8, 209);
+            this.btnLoadFlags.Margin = new System.Windows.Forms.Padding(4);
             this.btnLoadFlags.Name = "btnLoadFlags";
-            this.btnLoadFlags.Size = new System.Drawing.Size(196, 71);
+            this.btnLoadFlags.Size = new System.Drawing.Size(211, 87);
             this.btnLoadFlags.TabIndex = 434;
             this.btnLoadFlags.Text = "Load Flags";
             this.btnLoadFlags.UseVisualStyleBackColor = true;
             this.btnLoadFlags.Click += new System.EventHandler(this.btnLoadFlags_Click);
             // 
+            // nudLatitude
+            // 
+            this.nudLatitude.BackColor = System.Drawing.Color.AliceBlue;
+            this.nudLatitude.DecimalPlaces = 7;
+            this.nudLatitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.nudLatitude.Location = new System.Drawing.Point(203, 84);
+            this.nudLatitude.Margin = new System.Windows.Forms.Padding(4);
+            this.nudLatitude.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.nudLatitude.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.nudLatitude.Name = "nudLatitude";
+            this.nudLatitude.Size = new System.Drawing.Size(365, 63);
+            this.nudLatitude.TabIndex = 198;
+            this.nudLatitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.nudLatitude.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.nudLatitude.Click += new System.EventHandler(this.nudLatitude_Click);
+            // 
+            // nudLongitude
+            // 
+            this.nudLongitude.BackColor = System.Drawing.Color.AliceBlue;
+            this.nudLongitude.DecimalPlaces = 7;
+            this.nudLongitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.nudLongitude.Location = new System.Drawing.Point(597, 84);
+            this.nudLongitude.Margin = new System.Windows.Forms.Padding(4);
+            this.nudLongitude.Maximum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            0});
+            this.nudLongitude.Minimum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            -2147483648});
+            this.nudLongitude.Name = "nudLongitude";
+            this.nudLongitude.Size = new System.Drawing.Size(397, 63);
+            this.nudLongitude.TabIndex = 197;
+            this.nudLongitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.nudLongitude.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.nudLongitude.Click += new System.EventHandler(this.nudLongitude_Click);
+            // 
+            // btnSaveFlags
+            // 
+            this.btnSaveFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
+            this.btnSaveFlags.Location = new System.Drawing.Point(227, 209);
+            this.btnSaveFlags.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSaveFlags.Name = "btnSaveFlags";
+            this.btnSaveFlags.Size = new System.Drawing.Size(211, 87);
+            this.btnSaveFlags.TabIndex = 435;
+            this.btnSaveFlags.Text = "Save Flags";
+            this.btnSaveFlags.UseVisualStyleBackColor = true;
+            this.btnSaveFlags.Click += new System.EventHandler(this.btnSaveFlags_Click);
+            // 
             // FormEnterFlag
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.ClientSize = new System.Drawing.Size(771, 266);
+            this.ClientSize = new System.Drawing.Size(1028, 327);
             this.ControlBox = false;
+            this.Controls.Add(this.btnSaveFlags);
             this.Controls.Add(this.btnLoadFlags);
             this.Controls.Add(this.btnGreen);
             this.Controls.Add(this.btnRed);
@@ -252,6 +278,7 @@
             this.Controls.Add(this.nudLatitude);
             this.Controls.Add(this.nudLongitude);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FormEnterFlag";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -277,5 +304,6 @@
         private System.Windows.Forms.Button btnRed;
         private System.Windows.Forms.Button btnGreen;
         private System.Windows.Forms.Button btnLoadFlags;
+        private System.Windows.Forms.Button btnSaveFlags;
     }
 }

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
@@ -50,10 +50,9 @@
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label9.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label9.Location = new System.Drawing.Point(680, 49);
-            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label9.Location = new System.Drawing.Point(510, 40);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(211, 33);
+            this.label9.Size = new System.Drawing.Size(163, 25);
             this.label9.TabIndex = 202;
             this.label9.Text = "( +180 to -180 )";
             // 
@@ -62,10 +61,9 @@
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label8.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label8.Location = new System.Drawing.Point(287, 49);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.Location = new System.Drawing.Point(215, 40);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(173, 33);
+            this.label8.Size = new System.Drawing.Size(134, 25);
             this.label8.TabIndex = 201;
             this.label8.Text = "( +90 to -90)";
             // 
@@ -73,10 +71,9 @@
             // 
             this.label1.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label1.Location = new System.Drawing.Point(609, 18);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(457, 15);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(359, 31);
+            this.label1.Size = new System.Drawing.Size(269, 25);
             this.label1.TabIndex = 200;
             this.label1.Text = "Longitude";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -85,10 +82,9 @@
             // 
             this.label18.Font = new System.Drawing.Font("Tahoma", 15.75F);
             this.label18.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label18.Location = new System.Drawing.Point(213, 18);
-            this.label18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label18.Location = new System.Drawing.Point(160, 15);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(336, 31);
+            this.label18.Size = new System.Drawing.Size(252, 25);
             this.label18.TabIndex = 199;
             this.label18.Text = "Latitude";
             this.label18.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -97,10 +93,9 @@
             // 
             this.labelPoint.Font = new System.Drawing.Font("Tahoma", 21.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelPoint.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.labelPoint.Location = new System.Drawing.Point(29, 94);
-            this.labelPoint.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelPoint.Location = new System.Drawing.Point(22, 76);
             this.labelPoint.Name = "labelPoint";
-            this.labelPoint.Size = new System.Drawing.Size(167, 42);
+            this.labelPoint.Size = new System.Drawing.Size(125, 34);
             this.labelPoint.TabIndex = 205;
             this.labelPoint.Text = "Point A";
             this.labelPoint.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -115,10 +110,9 @@
             this.btnCancel.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnCancel.Image = global::AgOpenGPS.Properties.Resources.Cancel64;
             this.btnCancel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnCancel.Location = new System.Drawing.Point(464, 236);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCancel.Location = new System.Drawing.Point(348, 192);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(116, 71);
+            this.btnCancel.Size = new System.Drawing.Size(87, 58);
             this.btnCancel.TabIndex = 430;
             this.btnCancel.UseVisualStyleBackColor = false;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
@@ -132,10 +126,9 @@
             this.btnYellow.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnYellow.Image = global::AgOpenGPS.Properties.Resources.FlagYel;
             this.btnYellow.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnYellow.Location = new System.Drawing.Point(588, 238);
-            this.btnYellow.Margin = new System.Windows.Forms.Padding(4);
+            this.btnYellow.Location = new System.Drawing.Point(441, 193);
             this.btnYellow.Name = "btnYellow";
-            this.btnYellow.Size = new System.Drawing.Size(116, 71);
+            this.btnYellow.Size = new System.Drawing.Size(87, 58);
             this.btnYellow.TabIndex = 431;
             this.btnYellow.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnYellow.UseVisualStyleBackColor = false;
@@ -150,10 +143,9 @@
             this.btnRed.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnRed.Image = global::AgOpenGPS.Properties.Resources.FlagRed;
             this.btnRed.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnRed.Location = new System.Drawing.Point(896, 238);
-            this.btnRed.Margin = new System.Windows.Forms.Padding(4);
+            this.btnRed.Location = new System.Drawing.Point(672, 193);
             this.btnRed.Name = "btnRed";
-            this.btnRed.Size = new System.Drawing.Size(116, 71);
+            this.btnRed.Size = new System.Drawing.Size(87, 58);
             this.btnRed.TabIndex = 432;
             this.btnRed.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnRed.UseVisualStyleBackColor = false;
@@ -168,10 +160,9 @@
             this.btnGreen.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnGreen.Image = global::AgOpenGPS.Properties.Resources.FlagGrn;
             this.btnGreen.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnGreen.Location = new System.Drawing.Point(741, 238);
-            this.btnGreen.Margin = new System.Windows.Forms.Padding(4);
+            this.btnGreen.Location = new System.Drawing.Point(556, 193);
             this.btnGreen.Name = "btnGreen";
-            this.btnGreen.Size = new System.Drawing.Size(116, 71);
+            this.btnGreen.Size = new System.Drawing.Size(87, 58);
             this.btnGreen.TabIndex = 433;
             this.btnGreen.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.btnGreen.UseVisualStyleBackColor = false;
@@ -180,10 +171,9 @@
             // btnLoadFlags
             // 
             this.btnLoadFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
-            this.btnLoadFlags.Location = new System.Drawing.Point(22, 225);
-            this.btnLoadFlags.Margin = new System.Windows.Forms.Padding(4);
+            this.btnLoadFlags.Location = new System.Drawing.Point(16, 183);
             this.btnLoadFlags.Name = "btnLoadFlags";
-            this.btnLoadFlags.Size = new System.Drawing.Size(200, 90);
+            this.btnLoadFlags.Size = new System.Drawing.Size(150, 73);
             this.btnLoadFlags.TabIndex = 434;
             this.btnLoadFlags.Text = "Load Flags";
             this.btnLoadFlags.UseVisualStyleBackColor = true;
@@ -192,10 +182,9 @@
             // btnSaveFlags
             // 
             this.btnSaveFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
-            this.btnSaveFlags.Location = new System.Drawing.Point(245, 226);
-            this.btnSaveFlags.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSaveFlags.Location = new System.Drawing.Point(184, 184);
             this.btnSaveFlags.Name = "btnSaveFlags";
-            this.btnSaveFlags.Size = new System.Drawing.Size(200, 90);
+            this.btnSaveFlags.Size = new System.Drawing.Size(150, 73);
             this.btnSaveFlags.TabIndex = 435;
             this.btnSaveFlags.Text = "Save Flags";
             this.btnSaveFlags.UseVisualStyleBackColor = true;
@@ -206,8 +195,7 @@
             this.nudLatitude.BackColor = System.Drawing.Color.AliceBlue;
             this.nudLatitude.DecimalPlaces = 7;
             this.nudLatitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.nudLatitude.Location = new System.Drawing.Point(203, 84);
-            this.nudLatitude.Margin = new System.Windows.Forms.Padding(4);
+            this.nudLatitude.Location = new System.Drawing.Point(152, 68);
             this.nudLatitude.Maximum = new decimal(new int[] {
             90,
             0,
@@ -219,7 +207,7 @@
             0,
             -2147483648});
             this.nudLatitude.Name = "nudLatitude";
-            this.nudLatitude.Size = new System.Drawing.Size(365, 63);
+            this.nudLatitude.Size = new System.Drawing.Size(274, 52);
             this.nudLatitude.TabIndex = 198;
             this.nudLatitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.nudLatitude.Value = new decimal(new int[] {
@@ -234,8 +222,7 @@
             this.nudLongitude.BackColor = System.Drawing.Color.AliceBlue;
             this.nudLongitude.DecimalPlaces = 7;
             this.nudLongitude.Font = new System.Drawing.Font("Tahoma", 27.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.nudLongitude.Location = new System.Drawing.Point(597, 84);
-            this.nudLongitude.Margin = new System.Windows.Forms.Padding(4);
+            this.nudLongitude.Location = new System.Drawing.Point(448, 68);
             this.nudLongitude.Maximum = new decimal(new int[] {
             180,
             0,
@@ -247,7 +234,7 @@
             0,
             -2147483648});
             this.nudLongitude.Name = "nudLongitude";
-            this.nudLongitude.Size = new System.Drawing.Size(397, 63);
+            this.nudLongitude.Size = new System.Drawing.Size(298, 52);
             this.nudLongitude.TabIndex = 197;
             this.nudLongitude.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.nudLongitude.Value = new decimal(new int[] {
@@ -259,10 +246,10 @@
             // 
             // FormEnterFlag
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.ClientSize = new System.Drawing.Size(1028, 327);
+            this.ClientSize = new System.Drawing.Size(771, 266);
             this.ControlBox = false;
             this.Controls.Add(this.btnSaveFlags);
             this.Controls.Add(this.btnLoadFlags);
@@ -278,7 +265,6 @@
             this.Controls.Add(this.nudLatitude);
             this.Controls.Add(this.nudLongitude);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FormEnterFlag";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
@@ -38,9 +38,9 @@
             this.btnRed = new System.Windows.Forms.Button();
             this.btnGreen = new System.Windows.Forms.Button();
             this.btnLoadFlags = new System.Windows.Forms.Button();
+            this.btnSaveFlags = new System.Windows.Forms.Button();
             this.nudLatitude = new AgOpenGPS.NudlessNumericUpDown();
             this.nudLongitude = new AgOpenGPS.NudlessNumericUpDown();
-            this.btnSaveFlags = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.nudLatitude)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudLongitude)).BeginInit();
             this.SuspendLayout();
@@ -115,7 +115,7 @@
             this.btnCancel.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnCancel.Image = global::AgOpenGPS.Properties.Resources.Cancel64;
             this.btnCancel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnCancel.Location = new System.Drawing.Point(422, 238);
+            this.btnCancel.Location = new System.Drawing.Point(464, 236);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(116, 71);
@@ -180,14 +180,26 @@
             // btnLoadFlags
             // 
             this.btnLoadFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
-            this.btnLoadFlags.Location = new System.Drawing.Point(8, 209);
+            this.btnLoadFlags.Location = new System.Drawing.Point(22, 225);
             this.btnLoadFlags.Margin = new System.Windows.Forms.Padding(4);
             this.btnLoadFlags.Name = "btnLoadFlags";
-            this.btnLoadFlags.Size = new System.Drawing.Size(211, 87);
+            this.btnLoadFlags.Size = new System.Drawing.Size(200, 90);
             this.btnLoadFlags.TabIndex = 434;
             this.btnLoadFlags.Text = "Load Flags";
             this.btnLoadFlags.UseVisualStyleBackColor = true;
             this.btnLoadFlags.Click += new System.EventHandler(this.btnLoadFlags_Click);
+            // 
+            // btnSaveFlags
+            // 
+            this.btnSaveFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
+            this.btnSaveFlags.Location = new System.Drawing.Point(245, 226);
+            this.btnSaveFlags.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSaveFlags.Name = "btnSaveFlags";
+            this.btnSaveFlags.Size = new System.Drawing.Size(200, 90);
+            this.btnSaveFlags.TabIndex = 435;
+            this.btnSaveFlags.Text = "Save Flags";
+            this.btnSaveFlags.UseVisualStyleBackColor = true;
+            this.btnSaveFlags.Click += new System.EventHandler(this.btnSaveFlags_Click);
             // 
             // nudLatitude
             // 
@@ -244,18 +256,6 @@
             0,
             0});
             this.nudLongitude.Click += new System.EventHandler(this.nudLongitude_Click);
-            // 
-            // btnSaveFlags
-            // 
-            this.btnSaveFlags.Font = new System.Drawing.Font("Tahoma", 18F, System.Drawing.FontStyle.Bold);
-            this.btnSaveFlags.Location = new System.Drawing.Point(227, 209);
-            this.btnSaveFlags.Margin = new System.Windows.Forms.Padding(4);
-            this.btnSaveFlags.Name = "btnSaveFlags";
-            this.btnSaveFlags.Size = new System.Drawing.Size(211, 87);
-            this.btnSaveFlags.TabIndex = 435;
-            this.btnSaveFlags.Text = "Save Flags";
-            this.btnSaveFlags.UseVisualStyleBackColor = true;
-            this.btnSaveFlags.Click += new System.EventHandler(this.btnSaveFlags_Click);
             // 
             // FormEnterFlag
             // 

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -120,15 +120,44 @@ namespace AgOpenGPS
                 {
                     string[] lines = System.IO.File.ReadAllLines(filePath);
 
-                   foreach(string line in lines.Skip(1))
+                        int startIndex;
+                        string[] headers;
+
+                        if (lines[0].StartsWith("$Flags"))
+                        {
+                            startIndex = 3;
+                            headers = lines[2].Split(',');
+                        }
+                        else
+                        {
+                            startIndex = 1;
+                            headers = lines[0].Split(',');
+                        }
+
+                        int latIndex = Array.IndexOf(headers, "Latitude");
+                        int lonIndex = Array.IndexOf(headers, "Longitude");
+                        int colorIndex = Array.IndexOf(headers, "Color");
+                        int notesIndex = Array.IndexOf(headers, "Notes");
+
+                        if (latIndex == -1) latIndex = Array.IndexOf(headers, "latitude"); 
+                        if (lonIndex == -1) lonIndex = Array.IndexOf(headers, "longitude");
+                        if (colorIndex == -1) colorIndex = Array.IndexOf(headers, "color"); 
+                        if (notesIndex == -1) notesIndex = Array.IndexOf(headers, "notes");
+
+                        if (latIndex == -1 || lonIndex == -1 || colorIndex == -1 || notesIndex == -1)
+                        {
+                            MessageBox.Show("Required columns (Latitude, Longitude, Color, Notes) not found.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            return;
+                        }
+                    foreach (string line in lines.Skip(startIndex))
                     {
                         string[] parts = line.Split(',');
-                        if (parts.Length == 4 &&
-                            double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double latitude) &&
-                            double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double longitude) &&
-                            int.TryParse(parts[2], out int flagColor))
+                        if (parts.Length >= headers.Length &&
+                            double.TryParse(parts[latIndex], NumberStyles.Float, CultureInfo.InvariantCulture, out double latitude) &&
+                            double.TryParse(parts[lonIndex], NumberStyles.Float, CultureInfo.InvariantCulture, out double longitude) &&
+                            int.TryParse(parts[colorIndex], out int flagColor))
                         {
-                            string flagName = (!string.IsNullOrWhiteSpace(parts[3])) ? parts[3].Trim() : $"{mf.flagPts.Count + 1}";
+                            string flagName = (!string.IsNullOrWhiteSpace(parts[notesIndex])) ? parts[notesIndex].Trim() : $"{mf.flagPts.Count + 1}";
                             GeoCoord geoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(latitude, longitude));
                             int nextflag = mf.flagPts.Count + 1;
                             CFlag flagPt = new CFlag(

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -181,10 +181,10 @@ namespace AgOpenGPS
                         foreach (CFlag flag in mf.flagPts)
                         {
                             writer.WriteLine(
-                             mf.flagPts[i].latitude.ToString(CultureInfo.InvariantCulture) + "," +
-                             mf.flagPts[i].longitude.ToString(CultureInfo.InvariantCulture) + "," +
-                             mf.flagPts[i].color.ToString(CultureInfo.InvariantCulture) + "," +
-                             mf.flagPts[i].notes);
+                            flag.latitude.ToString(CultureInfo.InvariantCulture) + "," +
+                            flag.longitude.ToString(CultureInfo.InvariantCulture) + "," +
+                            flag.color.ToString(CultureInfo.InvariantCulture) + "," +
+                            flag.notes);
                         }
                         MessageBox.Show("Flags successfully saved!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -16,8 +16,6 @@ namespace AgOpenGPS
     {
         private readonly FormGPS mf = null;
 
-        //individual points for the flags in a list
-        public List<CFlag> flagPts = new List<CFlag>();
         public FormEnterFlag(Form callingForm)
         {
             //get copy of the calling main form
@@ -109,7 +107,7 @@ namespace AgOpenGPS
             Close();
 
         }
-
+        // load flags from a text file with latitude,longitude,color, notes
         private void btnLoadFlags_Click(object sender, EventArgs e)
         {
             OpenFileDialog fileDialog = new OpenFileDialog();
@@ -125,13 +123,13 @@ namespace AgOpenGPS
                 try
                 {
                     string[] lines = System.IO.File.ReadAllLines(filePath);
-
+                   
                     foreach (string line in lines.Skip(1))
                     {
                         double latitude, longitude;
                         int flagColor;
                         string[] parts = line.Split(',');
-                         if(
+                         if( 
                             double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out latitude) &&
                             double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out longitude) &&
                             int.TryParse(parts[2], out flagColor))
@@ -153,7 +151,6 @@ namespace AgOpenGPS
                     }
                     MessageBox.Show("Flags successfully added!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
-
                 catch (Exception ex)
                 {
                     MessageBox.Show($"Error reading file: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -162,33 +159,28 @@ namespace AgOpenGPS
                 }
             }
         }
-
+        // save a text file using flags info with latitude,longitude,color, notes
         private void btnSaveFlags_Click(object sender, EventArgs e)
         {
             SaveFileDialog fileDialog = new SaveFileDialog();
 
-            // falta metodo para guardar campo, se debe sacar datos del flags.txt
-            // y guardar en el mismo formato que se pide el archivo de texto
             fileDialog.DefaultExt = "txt";
             fileDialog.Filter = "Text Document | *.txt| CSV Document | *.csv| All files| *.*";
             fileDialog.Title = "Save flags information";
             fileDialog.CheckFileExists = false;
             fileDialog.RestoreDirectory = true;
 
-
             if (fileDialog.ShowDialog() == DialogResult.OK)
             {
-                //use Streamwriter to create file
                 using (StreamWriter writer = new StreamWriter(fileDialog.FileName))
                 {
                     try
                     {
                         writer.WriteLine("Latitude,Longitude,Color,Notes");
 
-                        int count2 = Convert.ToInt32(mf.flagPts.Count);
-                        writer.WriteLine(count2);
-
-                        for (int i = 0; i < count2; i++)
+                        int count = mf.flagPts.Count;
+                        
+                        for (int i = 0; i < count; i++)
                         {
                             writer.WriteLine(
                              mf.flagPts[i].latitude.ToString(CultureInfo.InvariantCulture) + "," +
@@ -197,9 +189,7 @@ namespace AgOpenGPS
                              mf.flagPts[i].notes);
                         }
                         MessageBox.Show("Flags successfully saved!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
                     }
-
                     catch (Exception ex)
                     {
                         MessageBox.Show("Error", ex.Message + "\n Cannot write to file.");

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -4,6 +4,7 @@ using AgOpenGPS.Culture;
 using AgOpenGPS.Helpers;
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -119,9 +120,8 @@ namespace AgOpenGPS
                 {
                     string[] lines = System.IO.File.ReadAllLines(filePath);
 
-                    for (int i = 1; i < lines.Length; i++)
+                   foreach(string line in lines.Skip(1))
                     {
-                        string line = lines[i];
                         string[] parts = line.Split(',');
                         if (parts.Length == 4 &&
                             double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double latitude) &&

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -178,9 +178,7 @@ namespace AgOpenGPS
                     {
                         writer.WriteLine("Latitude,Longitude,Color,Notes");
 
-                        int count = mf.flagPts.Count;
-                        
-                        for (int i = 0; i < count; i++)
+                        foreach (CFlag flag in mf.flagPts)
                         {
                             writer.WriteLine(
                              mf.flagPts[i].latitude.ToString(CultureInfo.InvariantCulture) + "," +

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -1882,6 +1882,7 @@ namespace AgOpenGPS
 
                     int count2 = flagPts.Count;
                     writer.WriteLine(count2);
+                    writer.WriteLine("Latitude, Longitude, Elevation, Easting, Northing, Heading, Color, ID, Notes");
 
                     for (int i = 0; i < count2; i++)
                     {

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -1882,7 +1882,6 @@ namespace AgOpenGPS
 
                     int count2 = flagPts.Count;
                     writer.WriteLine(count2);
-                    writer.WriteLine("Latitude, Longitude, Elevation, Easting, Northing, Heading, Color, ID, Notes");
 
                     for (int i = 0; i < count2; i++)
                     {


### PR DESCRIPTION
(Updated) Added a button in the Load flags by lat lon section to be able to load multiple points from a text or CSV file
This helps users to load multiple point without having to type each coordinate 
The format is:
latitude,longitude,flagColor,flagName

Also added a button to save a txt file with the same format

for example:
Latitude,Longitude,Color,Notes
53.4370564,-111.160047,0,pointA
53.4380564,-111.160047,0,
53.4390564,-111.160047,2,pointC

flagColor is 0 for red, 1 for green and 2 for yellow
flagName is optional, but the row must have a comma, if not that line wont be loaded

![flagsscreenCapture](https://github.com/user-attachments/assets/962af8d7-224f-43cd-8fcc-dfc5c56d2065)
