### PR TITLE
ISOXML from raven

### DIFF
--- a/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
@@ -84,7 +84,7 @@ namespace AgOpenGPS
 
                         // PFD - A=ID, C=FieldName, D = Area in sq m
                         tree.Nodes.Add(nodePFD.Attributes["C"].Value + " Area: " + area + " Ha  " + nodePFD.Attributes["A"].Value);
-                        tree.Nodes[tree.Nodes.Count - 1].Nodes.Add("" + index++);
+                        tree.Nodes[tree.Nodes.Count - 1].Tag = index++;
 
                         //nodes in current Partial Field like PLN, GGP, LSG etc
                         XmlNodeList fieldParts = nodePFD.ChildNodes;
@@ -181,7 +181,7 @@ namespace AgOpenGPS
             //top node selected (ie the field)
             if (tree.SelectedNode.Parent == null)
             {
-                idxFieldSelected = Int32.Parse(tree.SelectedNode.FirstNode.Text );
+                idxFieldSelected = (int)tree.SelectedNode.Tag;
                 labelField.Text = idxFieldSelected.ToString() + " " + pfd[idxFieldSelected].Attributes["C"].Value;
                 tboxFieldName.Text = pfd[idxFieldSelected].Attributes["C"].Value;
             }
@@ -189,7 +189,7 @@ namespace AgOpenGPS
             //one of the lines or bnds selected - so set the field selected
             else
             {
-                idxFieldSelected = Int32.Parse(tree.SelectedNode.Parent.FirstNode.Text);
+                idxFieldSelected = (int)tree.SelectedNode.Parent.Tag;
                 labelField.Text = idxFieldSelected.ToString() + " " + pfd[idxFieldSelected].Attributes["C"].Value;
                 tboxFieldName.Text = pfd[idxFieldSelected].Attributes["C"].Value;
             }


### PR DESCRIPTION
When loading from Raven system there's a concept of owner / farm which is not displayed at all and we get everything out of order.

Another problem is fields without Boundaries. these still have the AB lines and curves. I tried to calculate all the points from AB and use those instead of boundaries to estimate where the center is.

[raven export.zip](https://github.com/user-attachments/files/19354183/raven.export.zip)

Check the ISOXML and "Bs" file for example.