### PR TITLE
Choose the first visible track when track button is pressed

### DIFF
--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -77,7 +77,12 @@ namespace AgOpenGPS
             {
                 if (trk.idx == -1)
                 {
-                    trk.idx = 0;
+                    //find index of first visible track
+                    trk.idx = trk.gArr.FindIndex(track => track.isVisible);
+
+                    //otherwise default to index 0
+                    if (trk.idx == -1) trk.idx = 0;
+
                     EnableYouTurnButtons();
                     PanelUpdateRightAndBottom();
                     twoSecondCounter = 100;


### PR DESCRIPTION
Tested this out in the simulator and it works as expected. Resolves #739.

When `btnTrack` is pressed:

- [X] All tracks marked "hidden" -> track index 0 selected (as before)
- [X] First and second track marked "hidden", third and fourth marked "visible" -> track index 2 selected
- [X] All tracks marked "visible" -> track index 0 selected (as before)