### PR TITLE
Properly close Quick AB Curve creator form if insufficient points are recorded

### DIFF
--- a/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormQuickAB.cs
@@ -227,10 +227,12 @@ namespace AgOpenGPS
             }
             else
             {
+                //insufficient points recorded - close the form
                 mf.curve.desList?.Clear();
                 panelCurve.Visible = false;
                 panelName.Visible = false;
                 panelChoose.Visible = false;
+                Close();
             }
             mf.Activate();
         }


### PR DESCRIPTION
This fixes #738 by making sure the form closes