### PR TITLE
Exit loading flags function if a line does not have the correct format

### DIFF
--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.cs
@@ -141,7 +141,8 @@ namespace AgOpenGPS
                         }
                         else
                         {
-                            MessageBox.Show($"Invalid line in file: {line}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            MessageBox.Show($"Invalid line: {line}", "Error check format", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            return;
                         }
                     }
                     MessageBox.Show("Flags successfully added!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);


### PR DESCRIPTION
I found if by accident you tried to load a text file containing multiple lines (with the wrong format) the error message just keep showing up, so I added a return line to exit the loading function after the first incorrect line
