### PR TITLE
Invalidate AB line / curve when settings loaded

### DIFF
--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -604,6 +604,11 @@ namespace AgOpenGPS
 
             ahrs = new CAHRS();
 
+            // invalidate curve/ab line to force recalculation in case dependent settings were chagned,
+            // for example, change of tool offset or tool width
+            curve.isCurveValid = false;
+            ABLine.isABValid = false;
+
             fd.UpdateFieldBoundaryGUIAreas();
 
             btnSection1Man.Visible = false;


### PR DESCRIPTION
A possibly naïve fix for #744.

I didn't think the line should be recalculated while the settings window is still open (i.e. on each change of offset distance or on press of left/right offset buttons), because the driver probably wants the main window visible to see what the autosteer is about to do.

It also applies when tool width changes (not that many people would be changing that live).