### PR TITLE
Auto lift function changes

### DIFF
--- a/SourceCode/GPS/Classes/CHead.cs
+++ b/SourceCode/GPS/Classes/CHead.cs
@@ -11,7 +11,7 @@ namespace AgOpenGPS
 
         public void SetHydPosition()
         {
-            if (mf.vehicle.isHydLiftOn && mf.avgSpeed > 0.2 && mf.autoBtnState == btnStates.Auto && !mf.isReverse)
+            if (mf.vehicle.isHydLiftOn && mf.avgSpeed > 0.2 && !mf.isReverse)
             {
                 if (isToolInHeadland)
                 {

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -816,7 +816,7 @@ namespace AgOpenGPS
 
 
                 //draw 250 green for the headland
-                if (bnd.isHeadlandOn && bnd.isSectionControlledByHeadland)
+                if (bnd.isHeadlandOn)
                 {
                     GL.LineWidth(3);
                     GL.Color3((byte)0, (byte)250, (byte)0);
@@ -898,7 +898,7 @@ namespace AgOpenGPS
             //10 % min is required for overlap, otherwise it never would be on.
             int pixLimit = (int)((double)(section[0].rpSectionWidth * rpOnHeight) / (double)(5.0));
 
-            if ((rpOnHeight < rpToolHeight && bnd.isHeadlandOn && bnd.isSectionControlledByHeadland)) rpHeight = rpToolHeight + 2;
+            if ((rpOnHeight < rpToolHeight && bnd.isHeadlandOn)) rpHeight = rpToolHeight + 2;
             else rpHeight = rpOnHeight + 2;
 
             if (rpHeight > 290) rpHeight = 290;


### PR DESCRIPTION
Two related changes that I have tested in the simulator with AgDiag but not on a real machine. 

**Use the hydraulic lower look-ahead timer regardless of the apply-to-headland button state** (see #758)
The purple look-ahead line lowers the implement as it crosses the yellow headland line. This button no longer affects look-ahead. 
![image](https://github.com/user-attachments/assets/cdf17eae-8d59-43e3-a1e8-b849e804e643)

**Allow use of hydraulic lift/lower without Auto Section Control active** (see #766)
Decouples hydraulic lift/lower operation from Auto Sections state. Work switch on implement will no longer cause a conflict with the operation of hydraulic lift/lower. If this button is green, then hydraulic lift/lower is operational. 
![image](https://github.com/user-attachments/assets/c2b2bfe5-be7f-444e-9d5c-33f2760fcfe6)