### PR TITLE
Don't double-zip the build output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,8 @@ jobs:
     - name: Test
       run: dotnet test --no-restore ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Create AgOpenGPS.zip
-      shell: powershell
-      run: Compress-Archive -Path "AgOpenGPS" -Destination "AgOpenGPS.zip"
-
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: AgOpenGPS.zip
-        path: AgOpenGPS.zip
+        name: AgOpenGPS
+        path: AgOpenGPS


### PR DESCRIPTION
When I download a build artifact (e.g. one built as part of a pull request Action) I get `AgOpenGPS.zip` within `AgOpenGPS.zip`. The `release` Action doesn't suffer from this problem.

`actions/upload-artifact@v4` apparently creates a .zip of whatever files you give it.