### PR TITLE
Remove dependencies from Field and Fields and FieldDescription to streamers

### DIFF
--- a/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
+++ b/SourceCode/AgOpenGPS.Core/ApplicationCore.cs
@@ -1,6 +1,7 @@
 ﻿using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Presenters;
+using AgOpenGPS.Core.Streamers;
 using AgOpenGPS.Core.ViewModels;
 using System.IO;
 
@@ -18,9 +19,14 @@ namespace AgOpenGPS.Core
         {
             AppModel = new ApplicationModel(baseDirectory);
 
+            FieldStreamerPresenter fieldStreamerPresenter = new FieldStreamerPresenter(errorPresenter);
+            FieldStreamer fieldStreamer = new FieldStreamer(fieldStreamerPresenter);
+            FieldDescriptionStreamer fieldDescriptionStreamer =
+                new FieldDescriptionStreamer(AppModel.FieldsDirectory, fieldStreamerPresenter);
+
             _panelPresenter = panelPresenter;
             _errorPresenter = errorPresenter;
-            AppViewModel = new ApplicationViewModel(AppModel);
+            AppViewModel = new ApplicationViewModel(AppModel, fieldDescriptionStreamer, fieldStreamer);
             AppPresenter = new ApplicationPresenter(
                 AppViewModel,
                 _panelPresenter,

--- a/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/ApplicationModel.cs
@@ -30,8 +30,6 @@ namespace AgOpenGPS.Core
         public SharedFieldProperties SharedFieldProperties { get; }
         public Fields Fields { get; }
 
-        public FieldStreamer FieldStreamer => Fields.FieldStreamer;
-
         public Wgs84 CurrentLatLon { get; set; }
         public GeoDir FixHeading { get; set; }
 

--- a/SourceCode/AgOpenGPS.Core/Models/Field/Field.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/Field.cs
@@ -6,15 +6,16 @@ namespace AgOpenGPS.Core.Models
 {
     public class Field
     {
-        private readonly DirectoryInfo _fieldDirectory;
 
         // Read a Field from an already existing directory
         public Field(DirectoryInfo fieldDirectory)
         {
-            _fieldDirectory = fieldDirectory;
+            FieldDirectory = fieldDirectory;
         }
 
-        public string Name => _fieldDirectory.Name;
+        public DirectoryInfo FieldDirectory { get; }
+
+        public string Name => FieldDirectory.Name;
         public BackgroundPicture BackgroundPicture { get; set; }
         public Boundary Boundary { get; set; }
         public Contour Contour { get; set; }

--- a/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/FieldDescription.cs
@@ -1,5 +1,4 @@
 ﻿using AgLibrary.Logging;
-using AgOpenGPS.Core.Streamers;
 using System;
 using System.Diagnostics.Tracing;
 using System.IO;
@@ -18,31 +17,6 @@ namespace AgOpenGPS.Core.Models
         }
 
         public DirectoryInfo FieldDirectory { get; }
-
-        public static FieldDescription CreateFieldDescription(DirectoryInfo fieldDirectory)
-        {
-            Wgs84? wgs84Start = null;
-            double? area = null;
-            try
-            {
-                var overview = new OverviewStreamer().Read(fieldDirectory);
-                wgs84Start = overview.Start;
-            }
-            catch (Exception)
-            {
-                Log.EventWriter("Field (" + fieldDirectory.Name + ") file (Field.txt) could not be read.");
-            }
-            try
-            {
-                var boundary = new BoundaryStreamer().Read(fieldDirectory);
-                area = boundary.Area;
-            }
-            catch (Exception)
-            {
-                Log.EventWriter("Field (" + fieldDirectory.Name + ") file (Boundary.txt) could not be read.");
-            }
-            return new FieldDescription(fieldDirectory, wgs84Start, area);
-        }
 
         public string Name => FieldDirectory.Name;
         public Wgs84? Wgs84Start { get; set; } // No value indicates error in Field.txt file

--- a/SourceCode/AgOpenGPS.Core/Models/Field/Fields.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/Fields.cs
@@ -8,8 +8,6 @@ namespace AgOpenGPS.Core.Models
     public class Fields
     {
         private readonly DirectoryInfo _fieldsDirectory;
-        private Field _activeField;
-        private FieldStreamer _fieldStreamer;
 
         public Fields(DirectoryInfo fieldsDirectory)
         {
@@ -19,42 +17,8 @@ namespace AgOpenGPS.Core.Models
         public DirectoryInfo CurrentField { get; set; }
         public string CurrentFieldName => CurrentField != null ? CurrentField.Name : "";
 
-        // Is null if no job is started.
-        public Field ActiveField
-        {
-            get { return _activeField; }
-            private set
-            {
-                _activeField = value;
-                _fieldStreamer = _activeField != null ? new FieldStreamer(_activeField) : null;
-            }
-        }
-
-        public FieldStreamer FieldStreamer
-        {
-            get { return _fieldStreamer; }
-        }
-
-        public ReadOnlyCollection<FieldDescription> GetFieldDescriptions()
-        {
-            DirectoryInfo[] fieldDirectories = _fieldsDirectory.GetDirectories();
-            List<FieldDescription> list = new List<FieldDescription>();
-
-            foreach(DirectoryInfo fieldDirectory in fieldDirectories)
-            {
-                FileInfo[] fileInfos = fieldDirectory.GetFiles("Field.txt");
-
-                if (0 < fileInfos.Length)
-                {
-                    var fieldDescription = FieldDescription.CreateFieldDescription(fieldDirectory);
-                    if (fieldDescription.Wgs84Start.HasValue)
-                    {
-                        list.Add(fieldDescription);
-                    }
-                }
-            }
-            return list.AsReadOnly();
-        }
+        // Null if no job is started.
+        public Field ActiveField { get; set; }
 
         public void DeleteField(DirectoryInfo fieldDirectory)
         {

--- a/SourceCode/AgOpenGPS.Core/Presenters/FieldStreamerPresenter.cs
+++ b/SourceCode/AgOpenGPS.Core/Presenters/FieldStreamerPresenter.cs
@@ -1,0 +1,77 @@
+﻿﻿using AgOpenGPS.Core.Interfaces;
+using AgOpenGPS.Core.Translations;
+using System;
+
+namespace AgOpenGPS.Core.Presenters
+{
+    public class FieldStreamerPresenter : IFieldStreamerPresenter
+    {
+        private readonly IErrorPresenter _errorPresenter;
+
+        public FieldStreamerPresenter(IErrorPresenter errorPresenter)
+        {
+            _errorPresenter = errorPresenter;
+        }
+
+        void IFieldStreamerPresenter.PresentBoundaryFileMissing()
+        {
+            ShowStreamingError(gStr.gsMissingBoundaryFile);
+        }
+
+        void IFieldStreamerPresenter.PresentBoundaryFileCorrupt()
+        {
+            ShowStreamingError(gStr.gsBoundaryLineFilesAreCorrupt);
+        }
+
+        void IFieldStreamerPresenter.PresentContourFileMissing()
+        {
+            ShowStreamingError(gStr.gsMissingContourFile);
+        }
+
+        void IFieldStreamerPresenter.PresentContourFileCorrupt()
+        {
+            ShowStreamingError(gStr.gsContourFileIsCorrupt);
+        }
+
+        void IFieldStreamerPresenter.PresentCurveLineFileCorrupt()
+        {
+            ShowStreamingError(gStr.gsCurveLineFileIsCorrupt);
+        }
+
+        void IFieldStreamerPresenter.PresentFlagsFileMissing()
+        {
+            ShowStreamingError(gStr.gsMissingFlagsFile);
+        }
+
+        void IFieldStreamerPresenter.PresentFlagsFileCorrupt()
+        {
+            ShowStreamingError(gStr.gsFlagFileIsCorrupt);
+        }
+
+        void IFieldStreamerPresenter.PresentRecordedPathFileCorrupt()
+        {
+            ShowStreamingError(gStr.gsRecordedPathFileIsCorrupt);
+        }
+
+        void IFieldStreamerPresenter.PresentSectionFileMissing()
+        {
+            ShowStreamingError(gStr.gsMissingSectionFile);
+        }
+
+        void IFieldStreamerPresenter.PresentSectionFileCorrupt()
+        {
+            ShowStreamingError("Section File is Corrupt");
+        }
+
+        void IFieldStreamerPresenter.PresentTramLinesFileCorrupt()
+        {
+            ShowStreamingError("Tram is corrupt");
+        }
+
+        private void ShowStreamingError(string errorMsg)
+        {
+            TimeSpan timeSpan = TimeSpan.FromSeconds(2.0);
+            _errorPresenter.PresentTimedMessage(timeSpan, errorMsg, gStr.gsButFieldIsLoaded);
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/BoundaryStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/BoundaryStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System;
 using System.IO;
@@ -7,7 +8,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class BoundaryStreamer : FieldAspectStreamer
     {
-        public BoundaryStreamer() : base("Boundary.txt")
+        public BoundaryStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Boundary.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/ContourStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/ContourStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System.IO;
 
@@ -6,7 +7,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class ContourStreamer : FieldAspectStreamer
     {
-        public ContourStreamer() : base("Contour.txt")
+        public ContourStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Contour.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldAspectStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldAspectStreamer.cs
@@ -6,16 +6,13 @@ namespace AgOpenGPS.Core.Streamers
     public abstract class FieldAspectStreamer
     {
         protected readonly string _defaultFileName;
-
         protected IFieldStreamerPresenter _presenter;
 
-        public FieldAspectStreamer(string defaultFileName)
+        public FieldAspectStreamer(
+            string defaultFileName,
+            IFieldStreamerPresenter presenter)
         {
             _defaultFileName = defaultFileName;
-        }
-
-        public void SetPresenter(IFieldStreamerPresenter presenter)
-        {
             _presenter = presenter;
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldDescriptionStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldDescriptionStreamer.cs
@@ -1,0 +1,72 @@
+﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
+using AgOpenGPS.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace AgOpenGPS.Core.Streamers
+{
+    public class FieldDescriptionStreamer
+    {
+        private readonly DirectoryInfo _fieldsDirectory;
+        private readonly OverviewStreamer _overviewStreamer;
+        private readonly BoundaryStreamer _boundaryStreamer;
+
+        public FieldDescriptionStreamer(
+            DirectoryInfo fieldsDirectory,
+            IFieldStreamerPresenter presenter)
+        {
+            _fieldsDirectory = fieldsDirectory;
+            _overviewStreamer = new OverviewStreamer(presenter);
+            _boundaryStreamer = new BoundaryStreamer(presenter);
+        }
+
+        public FieldDescription CreateFieldDescription(DirectoryInfo fieldDirectory)
+        {
+            Wgs84? wgs84Start = null;
+            double? area = null;
+            try
+            {
+                var overview = _overviewStreamer.Read(fieldDirectory);
+                wgs84Start = overview.Start;
+            }
+            catch (Exception)
+            {
+                Log.EventWriter("Field (" + fieldDirectory.Name + ") file (Field.txt) could not be read.");
+            }
+            try
+            {
+                var boundary = _boundaryStreamer.Read(fieldDirectory);
+                area = boundary.Area;
+            }
+            catch (Exception)
+            {
+                Log.EventWriter("Field (" + fieldDirectory.Name + ") file (Boundary.txt) could not be read.");
+            }
+            return new FieldDescription(fieldDirectory, wgs84Start, area);
+        }
+
+        public ReadOnlyCollection<FieldDescription> GetFieldDescriptions()
+        {
+            DirectoryInfo[] fieldDirectories = _fieldsDirectory.GetDirectories();
+            List<FieldDescription> list = new List<FieldDescription>();
+
+            foreach (DirectoryInfo fieldDirectory in fieldDirectories)
+            {
+                FileInfo[] fileInfos = fieldDirectory.GetFiles("Field.txt");
+
+                if (0 < fileInfos.Length)
+                {
+                    var fieldDescription = CreateFieldDescription(fieldDirectory);
+                    if (fieldDescription.Wgs84Start.HasValue)
+                    {
+                        list.Add(fieldDescription);
+                    }
+                }
+            }
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/FieldStreamer.cs
@@ -6,8 +6,6 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class FieldStreamer
     {
-        private readonly Field _field;
-
         private readonly BoundaryStreamer _boundaryStreamer;
         private readonly ContourStreamer _contourStreamer;
         private readonly FlagListStreamer _flagsStreamer;
@@ -15,100 +13,84 @@ namespace AgOpenGPS.Core.Streamers
         private readonly TramLinesStreamer _tramLinesStreamer;
         private readonly WorkedAreaStreamer _workedAreaStreamer;
 
-        private IFieldStreamerPresenter _presenter;
-
-        public FieldStreamer(Field field)
+        public FieldStreamer(IFieldStreamerPresenter fieldStreamerPresenter)
         {
-            _field = field;
-            _boundaryStreamer = new BoundaryStreamer();
-            _contourStreamer = new ContourStreamer();
-            _flagsStreamer = new FlagListStreamer();
-            _recordedPathStreamer = new RecordedPathStreamer();
-            _tramLinesStreamer = new TramLinesStreamer();
-            _workedAreaStreamer = new WorkedAreaStreamer();
+            _boundaryStreamer = new BoundaryStreamer(fieldStreamerPresenter);
+            _contourStreamer = new ContourStreamer(fieldStreamerPresenter);
+            _flagsStreamer = new FlagListStreamer(fieldStreamerPresenter);
+            _recordedPathStreamer = new RecordedPathStreamer(fieldStreamerPresenter);
+            _tramLinesStreamer = new TramLinesStreamer(fieldStreamerPresenter);
+            _workedAreaStreamer = new WorkedAreaStreamer(fieldStreamerPresenter);
         }
-
-        public void SetPresenter(IFieldStreamerPresenter presenter)
-        {
-            _presenter = presenter;
-            _boundaryStreamer.SetPresenter(presenter);
-            _contourStreamer.SetPresenter(presenter);
-            _flagsStreamer.SetPresenter(presenter);
-            _recordedPathStreamer.SetPresenter(presenter);
-            _tramLinesStreamer.SetPresenter(presenter);
-            _workedAreaStreamer.SetPresenter(presenter);
-        }
-
-        public DirectoryInfo CurrentFieldDirectory { get; set; }
 
         public Boundary ReadBoundary(DirectoryInfo fieldDirectory)
         {
             return _boundaryStreamer.Read(fieldDirectory);
         }
 
-        public void ReadBoundary()
+        public void ReadBoundary(Field field)
         {
-            _field.Boundary = _boundaryStreamer.Read(CurrentFieldDirectory);
+            field.Boundary = _boundaryStreamer.Read(field.FieldDirectory);
         }
 
-        public void WriteBoundary()
+        public void WriteBoundary(Field field)
         {
-            _boundaryStreamer.Write(_field.Boundary, CurrentFieldDirectory);
+            _boundaryStreamer.Write(field.Boundary, field.FieldDirectory);
         }
 
-        public void ReadFlagList()
+        public void ReadFlagList(Field field)
         {
-            _field.Flags = _flagsStreamer.TryRead(CurrentFieldDirectory);
+            field.Flags = _flagsStreamer.TryRead(field.FieldDirectory);
         }
 
-        public void WriteFlagList()
+        public void WriteFlagList(Field field)
         {
-            _flagsStreamer.TryWrite(_field.Flags, CurrentFieldDirectory);
+            _flagsStreamer.TryWrite(field.Flags, field.FieldDirectory);
         }
 
-        public void ReadContour()
+        public void ReadContour(Field field)
         {
-            _field.Contour = _contourStreamer.TryRead(CurrentFieldDirectory);
+            field.Contour = _contourStreamer.TryRead(field.FieldDirectory);
         }
 
-        public void ContourAppendUnsavedWork()
+        public void ContourAppendUnsavedWork(Field field)
         {
-            _contourStreamer.AppendUnsavedWork(_field.Contour, CurrentFieldDirectory);
+            _contourStreamer.AppendUnsavedWork(field.Contour, field.FieldDirectory);
         }
 
-        public void ReadRecordedPath(string fileName = null)
+        public void ReadRecordedPath(Field field, string fileName = null)
         {
-            _field.RecordedPath = _recordedPathStreamer.TryRead(CurrentFieldDirectory, fileName);
+            field.RecordedPath = _recordedPathStreamer.TryRead(field.FieldDirectory, fileName);
         }
 
-        public void WriteRecordedPath(string fileName = null)
+        public void WriteRecordedPath(Field field, string fileName = null)
         {
-            _recordedPathStreamer.Write(_field.RecordedPath, CurrentFieldDirectory, fileName);
+            _recordedPathStreamer.Write(field.RecordedPath, field.FieldDirectory, fileName);
         }
 
-        public void CreateRecordedPathFile()
+        public void CreateRecordedPathFile(Field field)
         {
-            _recordedPathStreamer.CreateFile(CurrentFieldDirectory);
+            _recordedPathStreamer.CreateFile(field.FieldDirectory);
         }
 
-        public void ReadTramLines()
+        public void ReadTramLines(Field field)
         {
-            _field.TramLines = _tramLinesStreamer.TryRead(CurrentFieldDirectory);
+            field.TramLines = _tramLinesStreamer.TryRead(field.FieldDirectory);
         }
 
-        public void WriteTramLines()
+        public void WriteTramLines(Field field)
         {
-            _tramLinesStreamer.Write(_field.TramLines, CurrentFieldDirectory);
+            _tramLinesStreamer.Write(field.TramLines, field.FieldDirectory);
         }
 
-        public void ReadWorkedAera()
+        public void ReadWorkedAera(Field field)
         {
-            _field.WorkedArea = _workedAreaStreamer.Read(CurrentFieldDirectory);
+            field.WorkedArea = _workedAreaStreamer.Read(field.FieldDirectory);
         }
 
-        public void WorkedAreaAppendUnsaveWork()
+        public void WorkedAreaAppendUnsaveWork(Field field)
         {
-            _workedAreaStreamer.AppendUnsavedWork(_field.WorkedArea, CurrentFieldDirectory);
+            _workedAreaStreamer.AppendUnsavedWork(field.WorkedArea, field.FieldDirectory);
         }
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/FlagListStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/FlagListStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class FlagListStreamer : FieldAspectStreamer
     {
-        public FlagListStreamer() : base("Flags.txt")
+        public FlagListStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Flags.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/OverviewStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/OverviewStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System;
 using System.IO;
@@ -7,7 +8,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class OverviewStreamer : FieldAspectStreamer
     {
-        public OverviewStreamer() : base("Field.txt")
+        public OverviewStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Field.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/RecordedPathStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/RecordedPathStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System;
 using System.IO;
@@ -7,7 +8,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class RecordedPathStreamer : FieldAspectStreamer
     {
-        public RecordedPathStreamer() : base("RecPath.txt")
+        public RecordedPathStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("RecPath.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/TramLinesStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/TramLinesStreamer.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.IO;
 using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 
 namespace AgOpenGPS.Core.Streamers
 {
     public class TramLinesStreamer : FieldAspectStreamer
     {
-        public TramLinesStreamer() : base("Tram.txt")
+        public TramLinesStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Tram.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/Streamers/Field/WorkAreaStreamer.cs
+++ b/SourceCode/AgOpenGPS.Core/Streamers/Field/WorkAreaStreamer.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgOpenGPS.Core.Interfaces;
 using AgOpenGPS.Core.Models;
 using System.IO;
 
@@ -6,7 +7,10 @@ namespace AgOpenGPS.Core.Streamers
 {
     public class WorkedAreaStreamer : FieldAspectStreamer
     {
-        public WorkedAreaStreamer() : base("Sections.txt")
+        public WorkedAreaStreamer(
+            IFieldStreamerPresenter presenter
+        ) :
+            base("Sections.txt", presenter)
         {
         }
 

--- a/SourceCode/AgOpenGPS.Core/ViewModels/ApplicationViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/ApplicationViewModel.cs
@@ -1,20 +1,29 @@
-﻿﻿using AgLibrary.ViewModels;
+﻿using AgLibrary.ViewModels;
 using AgOpenGPS.Core.Interfaces;
+using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Presenters;
+using AgOpenGPS.Core.Streamers;
 using System.Windows.Input;
 
 namespace AgOpenGPS.Core.ViewModels
 {
     public class ApplicationViewModel : DayNightAndUnitsViewModel
     {
-        private readonly ApplicationModel _appModel;
+        private readonly ApplicationModel _applicationModel;
+        private readonly FieldDescriptionStreamer _fieldDescriptionStreamer;
+        private readonly FieldStreamer _fieldStreamer;
         private ApplicationPresenter _applicationPresenter;
         private ConfigMenuViewModel _configMenuViewModel;
         private SelectFieldMenuViewModel _selectFieldMenuViewModel;
 
-        public ApplicationViewModel(ApplicationModel appModel)
+        public ApplicationViewModel(
+            ApplicationModel applicationModel,
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer)
         {
-            _appModel = appModel;
+            _applicationModel = applicationModel;
+            _fieldDescriptionStreamer = fieldDescriptionStreamer;
+            _fieldStreamer = fieldStreamer;
             ShowConfigMenuCommand = new RelayCommand(ShowConfigMenu);
             ShowSelectFieldMenuCommand = new RelayCommand(ShowSelectFieldMenu);
         }
@@ -37,7 +46,7 @@ namespace AgOpenGPS.Core.ViewModels
                 {
                     _configMenuViewModel =
                         new ConfigMenuViewModel(
-                            _appModel,
+                            _applicationModel,
                             _applicationPresenter.PanelPresenter.ConfigMenuPanelPresenter);
                     AddChild(_configMenuViewModel);
                 }
@@ -53,7 +62,9 @@ namespace AgOpenGPS.Core.ViewModels
                 {
                     _selectFieldMenuViewModel =
                         new SelectFieldMenuViewModel(
-                            _appModel,
+                            _applicationModel,
+                            _fieldDescriptionStreamer,
+                            _fieldStreamer,
                             _applicationPresenter.PanelPresenter.SelectFieldPanelPresenter);
                     AddChild(_selectFieldMenuViewModel);
                 }

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/CreateFromExistingFieldViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/CreateFromExistingFieldViewModel.cs
@@ -4,21 +4,24 @@ using AgOpenGPS.Core.Models;
 using System.Globalization;
 using System;
 using System.Windows.Input;
+using AgOpenGPS.Core.Streamers;
 
 namespace AgOpenGPS.Core.ViewModels
 {
     public class CreateFromExistingFieldViewModel : FieldTableViewModel
     {
-        private readonly ISelectFieldPanelPresenter _newFieldPanelPresenter;
+        private readonly ISelectFieldPanelPresenter _selectFieldPanelPresenter;
         private string _newFieldName = "";
 
         public CreateFromExistingFieldViewModel(
             ApplicationModel appModel,
-            ISelectFieldPanelPresenter newFieldPanelPresenter
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer,
+            ISelectFieldPanelPresenter selectFieldPanelPresenter
         )
-            : base(appModel)
+            : base(appModel, fieldDescriptionStreamer, fieldStreamer)
         {
-            _newFieldPanelPresenter = newFieldPanelPresenter;
+            _selectFieldPanelPresenter = selectFieldPanelPresenter;
             AddVehicleCommand = new RelayCommand(AddVehicle);
             AddDateCommand = new RelayCommand(AddDate);
             AddTimeCommand = new RelayCommand(AddTime);
@@ -84,7 +87,7 @@ namespace AgOpenGPS.Core.ViewModels
 
         protected override void SelectField()
         {
-            _newFieldPanelPresenter.CloseCreateFromExistingFieldDialog();
+            _selectFieldPanelPresenter.CloseCreateFromExistingFieldDialog();
             // TODO finish streamers, finish Copy method in Fields, finish this.
             base.SelectField();
         }

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/NearFieldTableViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/NearFieldTableViewModel.cs
@@ -1,11 +1,17 @@
 ﻿using AgOpenGPS.Core.Models;
+using AgOpenGPS.Core.Streamers;
 using System.Collections.ObjectModel;
 
 namespace AgOpenGPS.Core.ViewModels
 {
     public class NearFieldTableViewModel : FieldTableViewModel
     {
-        public NearFieldTableViewModel(ApplicationModel appModel) : base(appModel)
+        public NearFieldTableViewModel(
+            ApplicationModel appModel,
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer
+        ) :
+            base(appModel, fieldDescriptionStreamer, fieldStreamer)
         {
             SortMode = FieldSortMode.ByDistance;
         }
@@ -13,7 +19,7 @@ namespace AgOpenGPS.Core.ViewModels
         public override void UpdateFields()
         {
             Collection<FieldDescriptionViewModel> viewModels = new Collection<FieldDescriptionViewModel>();
-            var descriptions = _appModel.Fields.GetFieldDescriptions();
+            var descriptions = _fieldDescriptionStreamer.GetFieldDescriptions();
             foreach (FieldDescription description in descriptions)
             {
                 if (description.Wgs84Start.HasValue)

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectFieldMenuViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectFieldMenuViewModel.cs
@@ -11,22 +11,27 @@ namespace AgOpenGPS.Core.ViewModels
     public class SelectFieldMenuViewModel : DayNightAndUnitsViewModel
     {
         private readonly ApplicationModel _appModel;
-        private readonly ISelectFieldPanelPresenter _newFieldPanelPresenter;
+        private readonly FieldDescriptionStreamer _fieldDescriptionStreamer;
+        private readonly FieldStreamer _fieldStreamer;
+        private readonly ISelectFieldPanelPresenter _selectFieldPanelPresenter;
         private SelectNearFieldViewModel _selectNearFieldViewModel;
         private CreateFromExistingFieldViewModel _createFromExistingFieldViewModel;
         private SelectFieldViewModel _selectFieldViewModel;
 
         public SelectFieldMenuViewModel(
             ApplicationModel appModel,
-            ISelectFieldPanelPresenter newFieldPanelPresenter)
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer,
+            ISelectFieldPanelPresenter selectFieldPanelPresenter)
         {
             _appModel = appModel;
-            _newFieldPanelPresenter = newFieldPanelPresenter;
+            _fieldDescriptionStreamer = fieldDescriptionStreamer;
+            _fieldStreamer = fieldStreamer;
+            _selectFieldPanelPresenter = selectFieldPanelPresenter;
             StartSelectNearFieldCommand = new RelayCommand(StartSelectNearField);
             StartCreateFieldFromExistingCommand = new RelayCommand(StartCreateFieldFromExisting);
             StartSelectFieldCommand = new RelayCommand(StartSelectField);
             CancelCommand = new RelayCommand(Cancel);
-            _newFieldPanelPresenter = newFieldPanelPresenter;
         }
 
         public SelectNearFieldViewModel SelectNearFieldViewModel
@@ -36,7 +41,11 @@ namespace AgOpenGPS.Core.ViewModels
                 if (_selectNearFieldViewModel == null)
                 {
                     _selectNearFieldViewModel =
-                        new SelectNearFieldViewModel(_appModel, _newFieldPanelPresenter);
+                        new SelectNearFieldViewModel(
+                            _appModel,
+                            _fieldDescriptionStreamer,
+                            _fieldStreamer,
+                            _selectFieldPanelPresenter);
                     AddChild(_selectNearFieldViewModel);
                 }
                 return _selectNearFieldViewModel;
@@ -50,7 +59,11 @@ namespace AgOpenGPS.Core.ViewModels
                 if (_createFromExistingFieldViewModel == null)
                 {
                     _createFromExistingFieldViewModel =
-                        new CreateFromExistingFieldViewModel(_appModel, _newFieldPanelPresenter);
+                        new CreateFromExistingFieldViewModel(
+                            _appModel,
+                            _fieldDescriptionStreamer,
+                            _fieldStreamer,
+                            _selectFieldPanelPresenter);
                     AddChild(_createFromExistingFieldViewModel);
                 }
                 return _createFromExistingFieldViewModel;
@@ -63,7 +76,12 @@ namespace AgOpenGPS.Core.ViewModels
             {
                 if (_selectFieldViewModel == null)
                 {
-                    _selectFieldViewModel = new SelectFieldViewModel(_appModel, _newFieldPanelPresenter);
+                    _selectFieldViewModel =
+                        new SelectFieldViewModel(
+                            _appModel,
+                            _fieldDescriptionStreamer,
+                            _fieldStreamer,
+                            _selectFieldPanelPresenter);
                     AddChild(_selectFieldViewModel);
                 }
                 return _selectFieldViewModel;
@@ -80,30 +98,30 @@ namespace AgOpenGPS.Core.ViewModels
         private void StartSelectNearField()
         {
             // TODO implement different behaviour if number of fields is 0 or 1
-            _newFieldPanelPresenter.CloseSelectFieldMenuDialog();
+            _selectFieldPanelPresenter.CloseSelectFieldMenuDialog();
             SelectNearFieldViewModel.UpdateFields();
-            _newFieldPanelPresenter.ShowSelectNearFieldDialog(SelectNearFieldViewModel);
+            _selectFieldPanelPresenter.ShowSelectNearFieldDialog(SelectNearFieldViewModel);
         }
 
         private void StartCreateFieldFromExisting()
         {
             // TODO implement different behaviour if number of fields is 0 or 1
-            _newFieldPanelPresenter.CloseSelectFieldMenuDialog();
+            _selectFieldPanelPresenter.CloseSelectFieldMenuDialog();
             CreateFromExistingFieldViewModel.UpdateFields();
-            _newFieldPanelPresenter.ShowCreateFromExistingFieldDialog(CreateFromExistingFieldViewModel);
+            _selectFieldPanelPresenter.ShowCreateFromExistingFieldDialog(CreateFromExistingFieldViewModel);
         }
 
         private void StartSelectField()
         {
             // TODO implement different behaviour if number of fields is 0 or 1
-            _newFieldPanelPresenter.CloseSelectFieldMenuDialog();
+            _selectFieldPanelPresenter.CloseSelectFieldMenuDialog();
             SelectFieldViewModel.UpdateFields();
-            _newFieldPanelPresenter.ShowSelectFieldDialog(SelectFieldViewModel);
+            _selectFieldPanelPresenter.ShowSelectFieldDialog(SelectFieldViewModel);
         }
 
         private void Cancel()
         {
-            _newFieldPanelPresenter.CloseSelectFieldMenuDialog();
+            _selectFieldPanelPresenter.CloseSelectFieldMenuDialog();
         }
 
     }

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectFieldViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectFieldViewModel.cs
@@ -1,20 +1,23 @@
 ﻿using AgLibrary.ViewModels;
 using AgOpenGPS.Core.Interfaces;
-using AgOpenGPS.Core.Models;
+using AgOpenGPS.Core.Streamers;
 using System.Windows.Input;
 
 namespace AgOpenGPS.Core.ViewModels
 {
     public class SelectFieldViewModel : FieldTableViewModel
     {
-        private readonly ISelectFieldPanelPresenter _newFieldPanelPresenter;
+        private readonly ISelectFieldPanelPresenter _selectFieldPanelPresenter;
+
         public SelectFieldViewModel(
             ApplicationModel appModel,
-            ISelectFieldPanelPresenter newFieldPanelPresenter
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer,
+            ISelectFieldPanelPresenter selectFieldPanelPresenter
         )
-            : base(appModel)
+            : base(appModel, fieldDescriptionStreamer, fieldStreamer)
         {
-            _newFieldPanelPresenter = newFieldPanelPresenter;
+            _selectFieldPanelPresenter = selectFieldPanelPresenter;
             DeleteFieldCommand = new RelayCommand(DeleteField);
         }
 
@@ -25,7 +28,7 @@ namespace AgOpenGPS.Core.ViewModels
             var selectedField = LocalSelectedField;
             if (null != selectedField)
             {
-                if (_newFieldPanelPresenter.ShowConfirmDeleteMessageBox(selectedField.FieldName))
+                if (_selectFieldPanelPresenter.ShowConfirmDeleteMessageBox(selectedField.FieldName))
                 {
                     _appModel.Fields.DeleteField(selectedField.DirectoryInfo);
                     LocalSelectedField = null;
@@ -36,7 +39,7 @@ namespace AgOpenGPS.Core.ViewModels
 
         protected override void SelectField()
         {
-            _newFieldPanelPresenter.CloseSelectFieldDialog();
+            _selectFieldPanelPresenter.CloseSelectFieldDialog();
             base.SelectField();
         }
 

--- a/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectNearFieldViewModel.cs
+++ b/SourceCode/AgOpenGPS.Core/ViewModels/SelectFieldViewModels/SelectNearFieldViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using AgOpenGPS.Core.Interfaces;
+using AgOpenGPS.Core.Streamers;
 
 namespace AgOpenGPS.Core.ViewModels
 {
@@ -8,9 +9,11 @@ namespace AgOpenGPS.Core.ViewModels
 
         public SelectNearFieldViewModel(
             ApplicationModel appModel,
+            FieldDescriptionStreamer fieldDescriptionStreamer,
+            FieldStreamer fieldStreamer,
             ISelectFieldPanelPresenter newFieldPanelPresenter
         )
-            : base(appModel)
+            : base(appModel, fieldDescriptionStreamer, fieldStreamer)
         {
             _newFieldPanelPresenter = newFieldPanelPresenter;
         }


### PR DESCRIPTION
Same content as other recent pull request. The other one has so many merge related changes that I decided to make this new PR.

In order to keep the Models small and reusable, I removed the dependencies from the models to the streamers.
The streamers know how to stream the models, but the models do not know anything about streaming anymore.