### PR TITLE
Hotfix/6.7-agio-gpsbaud

### DIFF
--- a/SourceCode/AgIO/Source/Forms/FormCommSetGPS.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormCommSetGPS.Designer.cs
@@ -271,7 +271,8 @@
             "19200",
             "38400",
             "57600",
-            "115200"});
+            "115200",
+            "460800"});
             this.cboxBaud.Location = new System.Drawing.Point(395, 37);
             this.cboxBaud.Name = "cboxBaud";
             this.cboxBaud.Size = new System.Drawing.Size(127, 37);
@@ -407,7 +408,8 @@
             "19200",
             "38400",
             "57600",
-            "115200"});
+            "115200",
+            "460800"});
             this.cboxBaud2.Location = new System.Drawing.Point(198, 37);
             this.cboxBaud2.Name = "cboxBaud2";
             this.cboxBaud2.Size = new System.Drawing.Size(127, 37);

--- a/SourceCode/AgIO/Source/Forms/FormSerialMonitor.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSerialMonitor.designer.cs
@@ -87,7 +87,8 @@
             "19200",
             "38400",
             "57600",
-            "115200"});
+            "115200",
+            "460800"});
             this.cboxBaud.Location = new System.Drawing.Point(236, 24);
             this.cboxBaud.Name = "cboxBaud";
             this.cboxBaud.Size = new System.Drawing.Size(127, 37);


### PR DESCRIPTION
If using an F9P Micro on the ardusimple-supplied Xbee USB-C adapter for a lightbar, the standard config sets baud rate to 460800. That's not an option in agio, so the user has to change the f9p config manually. Adding this option means they can use it immediately.