### PR TITLE
AgIO auto-saves changes to XML file

### DIFF
--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -266,6 +266,7 @@ namespace AgIO
                     ////Clicked Save
                     //Application.Restart();
                     //Environment.Exit(0);
+                    Settings.Default.Save();
                 }
             }
         }
@@ -400,6 +401,7 @@ namespace AgIO
                     {
                         SettingsShutDownNTRIP();
                     }
+                    Settings.Default.Save();
                 }
             }
         }
@@ -428,7 +430,9 @@ namespace AgIO
 
             using (var form = new FormRadio(this))
             {
-                form.ShowDialog(this);
+                if (form.ShowDialog(this) == DialogResult.OK) {
+                    Settings.Default.Save();
+               }
             }
         }
 


### PR DESCRIPTION
Amended AgIO so whenever you accept the RTCM dialog boxes, changes are saved back. This is more inline with AOG Configuration.

Otherwise, if you want to change an NTRIP station in an existing profile, you're forced to give it a new name.