### PR TITLE
LocalPlane must calculate MetersPerDegreeLon for each point separately

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/LocalPlane.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/LocalPlane.cs
@@ -8,13 +8,12 @@ namespace AgOpenGPS.Core.Models
     {
         private SharedFieldProperties _sharedFieldProperties;
         private double _metersPerDegreeLat;
-        private double _metersPerDegreeLon;
 
         public LocalPlane(Wgs84 origin, SharedFieldProperties sharedFieldProperties)
         {
             Origin = origin;
             _sharedFieldProperties = sharedFieldProperties;
-            SetLocalMetersPerDegree();
+            SetMetersPerDegreeLat();
         }
 
         public Wgs84 Origin { get; }
@@ -23,30 +22,37 @@ namespace AgOpenGPS.Core.Models
         {
             return new GeoCoord(
                 (latLon.Latitude - Origin.Latitude) * _metersPerDegreeLat,
-                (latLon.Longitude - Origin.Longitude) * _metersPerDegreeLon);
+                (latLon.Longitude - Origin.Longitude) * MetersPerDegreeLon(latLon.Latitude)
+            );
         }
 
         public Wgs84 ConvertGeoCoordToWgs84(GeoCoord geoCoord)
         {
             geoCoord += _sharedFieldProperties.DriftCompensation;
-            double lat = (geoCoord.Northing / _metersPerDegreeLat) + Origin.Latitude;
-            double lon = (geoCoord.Easting / _metersPerDegreeLon) + Origin.Longitude;
+            double lat = Origin.Latitude + (geoCoord.Northing / _metersPerDegreeLat);
+            double lon = Origin.Longitude + (geoCoord.Easting / MetersPerDegreeLon(lat));
             return new Wgs84(lat, lon);
         }
 
         // see https://en.wikipedia.org/wiki/Geographic_coordinate_system#Latitude_and_longitude
-        private void SetLocalMetersPerDegree()
+        private void SetMetersPerDegreeLat()
         {
             double originLatInRad = Units.DegreesToRadians(Origin.Latitude);
             _metersPerDegreeLat = 111132.92
                 - 559.82 * Math.Cos(2.0 * originLatInRad)
                 + 1.175 * Math.Cos(4.0 * originLatInRad)
                 - 0.0023 * Math.Cos(6.0 * originLatInRad);
+            // meters per degree longitude depends on latitude
+            // so we must calculate it for each point separately in ConvertWgs84ToGeoCoord and ConvertGeoCoordToWgs84
+        }
 
-            _metersPerDegreeLon =
-                111412.84 * Math.Cos(originLatInRad)
-                - 93.5 * Math.Cos(3.0 * originLatInRad)
-                + 0.118 * Math.Cos(5.0 * originLatInRad);
+        private double MetersPerDegreeLon(double lat)
+        {
+            double latRad = Units.DegreesToRadians(lat);
+            return
+                111412.84 * Math.Cos(latRad)
+                - 93.5 * Math.Cos(3.0 * latRad)
+                + 0.118 * Math.Cos(5.0 * latRad);
         }
 
     }


### PR DESCRIPTION
Thanks to Richard, for spotting this bug!
The old code in CNMEA correctly calculated 'metersPerDegreeLon' for each point separately. LocalPlane must do that to.
Otherwise, importing and exporting fields results in small deviations.