### PR TITLE
user-selectable precision, optional simulate data

### DIFF
--- a/SourceCode/GPS_Out/Source/App.config
+++ b/SourceCode/GPS_Out/Source/App.config
@@ -61,6 +61,18 @@
             <setting name="SentenceStart" serializeAs="String">
                 <value>$GP</value>
             </setting>
+            <setting name="SentencePrecisionFormat" serializeAs="String">
+                <value>00.0000000</value>
+            </setting>
+            <setting name="SentencePrecisionIndex" serializeAs="String">
+                <value>3</value>
+            </setting>
+            <setting name="Simulate" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="DisplayPrecisionFormat" serializeAs="String">
+                <value>0.0000000</value>
+            </setting>
         </GPS_Out.Properties.Settings>
     </userSettings>
 </configuration>

--- a/SourceCode/GPS_Out/Source/Classes/clsTools.cs
+++ b/SourceCode/GPS_Out/Source/Classes/clsTools.cs
@@ -39,7 +39,8 @@ namespace GPS_Out
         private static Hashtable HTapp;
         private static Hashtable HTfiles;
         private string cAppName = "GPS_Out";
-        private string cAppVersion = "1.2.1";
+        private string cAppVersion = "1.2.2";
+        private string cVersionDate = "09-Jul-2025";
         private string cPropertiesApp;
         private string cPropertiesFile;
         private string cSettingsDir;

--- a/SourceCode/GPS_Out/Source/Form1.Designer.cs
+++ b/SourceCode/GPS_Out/Source/Form1.Designer.cs
@@ -39,6 +39,10 @@
             this.tmrZDA = new System.Windows.Forms.Timer(this.components);
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.lbAge = new System.Windows.Forms.Label();
+            this.lbElev = new System.Windows.Forms.Label();
+            this.lbSats = new System.Windows.Forms.Label();
+            this.lbHDOP = new System.Windows.Forms.Label();
             this.lbSim = new System.Windows.Forms.Label();
             this.btnZDA = new System.Windows.Forms.Button();
             this.tbZDA = new System.Windows.Forms.TextBox();
@@ -56,10 +60,6 @@
             this.cboBaud1 = new System.Windows.Forms.ComboBox();
             this.cboPort1 = new System.Windows.Forms.ComboBox();
             this.lbBaud = new System.Windows.Forms.Label();
-            this.lbAge = new System.Windows.Forms.Label();
-            this.lbElev = new System.Windows.Forms.Label();
-            this.lbSats = new System.Windows.Forms.Label();
-            this.lbHDOP = new System.Windows.Forms.Label();
             this.lbQuality = new System.Windows.Forms.Label();
             this.lbSpeed = new System.Windows.Forms.Label();
             this.lbLat = new System.Windows.Forms.Label();
@@ -73,6 +73,9 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.cboPrecision = new System.Windows.Forms.ComboBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.ckSimulate = new System.Windows.Forms.CheckBox();
             this.rbGP = new System.Windows.Forms.RadioButton();
             this.rbGN = new System.Windows.Forms.RadioButton();
             this.ckGSA = new System.Windows.Forms.CheckBox();
@@ -185,24 +188,72 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Main";
             // 
+            // lbAge
+            // 
+            this.lbAge.AutoSize = true;
+            this.lbAge.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbAge.Location = new System.Drawing.Point(452, 218);
+            this.lbAge.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lbAge.Name = "lbAge";
+            this.lbAge.Size = new System.Drawing.Size(126, 24);
+            this.lbAge.TabIndex = 168;
+            this.lbAge.Text = "1234567890.";
+            this.lbAge.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lbElev
+            // 
+            this.lbElev.AutoSize = true;
+            this.lbElev.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbElev.Location = new System.Drawing.Point(452, 188);
+            this.lbElev.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lbElev.Name = "lbElev";
+            this.lbElev.Size = new System.Drawing.Size(126, 24);
+            this.lbElev.TabIndex = 167;
+            this.lbElev.Text = "1234567890.";
+            this.lbElev.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lbSats
+            // 
+            this.lbSats.AutoSize = true;
+            this.lbSats.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbSats.Location = new System.Drawing.Point(452, 158);
+            this.lbSats.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lbSats.Name = "lbSats";
+            this.lbSats.Size = new System.Drawing.Size(126, 24);
+            this.lbSats.TabIndex = 166;
+            this.lbSats.Text = "1234567890.";
+            this.lbSats.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lbHDOP
+            // 
+            this.lbHDOP.AutoSize = true;
+            this.lbHDOP.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbHDOP.Location = new System.Drawing.Point(452, 128);
+            this.lbHDOP.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lbHDOP.Name = "lbHDOP";
+            this.lbHDOP.Size = new System.Drawing.Size(126, 24);
+            this.lbHDOP.TabIndex = 165;
+            this.lbHDOP.Text = "1234567890.";
+            this.lbHDOP.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // lbSim
             // 
-            this.lbSim.AutoSize = true;
             this.lbSim.BackColor = System.Drawing.Color.Transparent;
             this.lbSim.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbSim.Location = new System.Drawing.Point(247, 218);
+            this.lbSim.Location = new System.Drawing.Point(244, 216);
             this.lbSim.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.lbSim.Name = "lbSim";
             this.lbSim.Size = new System.Drawing.Size(102, 24);
             this.lbSim.TabIndex = 317;
             this.lbSim.Text = "Simulated";
+            this.lbSim.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // btnZDA
             // 
             this.btnZDA.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnZDA.Location = new System.Drawing.Point(6, 438);
+            this.btnZDA.Location = new System.Drawing.Point(6, 431);
             this.btnZDA.Name = "btnZDA";
-            this.btnZDA.Size = new System.Drawing.Size(75, 33);
+            this.btnZDA.Size = new System.Drawing.Size(75, 47);
             this.btnZDA.TabIndex = 316;
             this.btnZDA.Text = "ZDA";
             this.btnZDA.UseVisualStyleBackColor = true;
@@ -221,9 +272,9 @@
             // btnRMC
             // 
             this.btnRMC.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnRMC.Location = new System.Drawing.Point(6, 380);
+            this.btnRMC.Location = new System.Drawing.Point(6, 373);
             this.btnRMC.Name = "btnRMC";
-            this.btnRMC.Size = new System.Drawing.Size(75, 33);
+            this.btnRMC.Size = new System.Drawing.Size(75, 47);
             this.btnRMC.TabIndex = 314;
             this.btnRMC.Text = "RMC";
             this.btnRMC.UseVisualStyleBackColor = true;
@@ -242,9 +293,9 @@
             // btnVTG
             // 
             this.btnVTG.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnVTG.Location = new System.Drawing.Point(6, 322);
+            this.btnVTG.Location = new System.Drawing.Point(6, 315);
             this.btnVTG.Name = "btnVTG";
-            this.btnVTG.Size = new System.Drawing.Size(75, 33);
+            this.btnVTG.Size = new System.Drawing.Size(75, 47);
             this.btnVTG.TabIndex = 312;
             this.btnVTG.Text = "VTG";
             this.btnVTG.UseVisualStyleBackColor = true;
@@ -253,9 +304,9 @@
             // btnGGA
             // 
             this.btnGGA.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnGGA.Location = new System.Drawing.Point(6, 264);
+            this.btnGGA.Location = new System.Drawing.Point(6, 257);
             this.btnGGA.Name = "btnGGA";
-            this.btnGGA.Size = new System.Drawing.Size(75, 33);
+            this.btnGGA.Size = new System.Drawing.Size(75, 47);
             this.btnGGA.TabIndex = 311;
             this.btnGGA.Text = "GGA";
             this.btnGGA.UseVisualStyleBackColor = true;
@@ -389,61 +440,17 @@
             this.lbBaud.Text = "Baud";
             this.lbBaud.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
-            // lbAge
-            // 
-            this.lbAge.AutoSize = true;
-            this.lbAge.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbAge.Location = new System.Drawing.Point(452, 218);
-            this.lbAge.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.lbAge.Name = "lbAge";
-            this.lbAge.Size = new System.Drawing.Size(126, 24);
-            this.lbAge.TabIndex = 168;
-            this.lbAge.Text = "1234567890.";
-            // 
-            // lbElev
-            // 
-            this.lbElev.AutoSize = true;
-            this.lbElev.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbElev.Location = new System.Drawing.Point(452, 188);
-            this.lbElev.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.lbElev.Name = "lbElev";
-            this.lbElev.Size = new System.Drawing.Size(126, 24);
-            this.lbElev.TabIndex = 167;
-            this.lbElev.Text = "1234567890.";
-            // 
-            // lbSats
-            // 
-            this.lbSats.AutoSize = true;
-            this.lbSats.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbSats.Location = new System.Drawing.Point(452, 158);
-            this.lbSats.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.lbSats.Name = "lbSats";
-            this.lbSats.Size = new System.Drawing.Size(126, 24);
-            this.lbSats.TabIndex = 166;
-            this.lbSats.Text = "1234567890.";
-            // 
-            // lbHDOP
-            // 
-            this.lbHDOP.AutoSize = true;
-            this.lbHDOP.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbHDOP.Location = new System.Drawing.Point(452, 128);
-            this.lbHDOP.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.lbHDOP.Name = "lbHDOP";
-            this.lbHDOP.Size = new System.Drawing.Size(126, 24);
-            this.lbHDOP.TabIndex = 165;
-            this.lbHDOP.Text = "1234567890.";
-            // 
             // lbQuality
             // 
-            this.lbQuality.AutoSize = true;
             this.lbQuality.BackColor = System.Drawing.Color.Transparent;
             this.lbQuality.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbQuality.Location = new System.Drawing.Point(119, 218);
+            this.lbQuality.Location = new System.Drawing.Point(120, 216);
             this.lbQuality.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.lbQuality.Name = "lbQuality";
             this.lbQuality.Size = new System.Drawing.Size(126, 24);
             this.lbQuality.TabIndex = 164;
-            this.lbQuality.Text = "1234567890.";
+            this.lbQuality.Text = "RTK Fix";
+            this.lbQuality.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lbSpeed
             // 
@@ -455,6 +462,7 @@
             this.lbSpeed.Size = new System.Drawing.Size(126, 24);
             this.lbSpeed.TabIndex = 163;
             this.lbSpeed.Text = "1234567890.";
+            this.lbSpeed.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lbLat
             // 
@@ -466,6 +474,7 @@
             this.lbLat.Size = new System.Drawing.Size(126, 24);
             this.lbLat.TabIndex = 162;
             this.lbLat.Text = "1234567890.";
+            this.lbLat.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lbLon
             // 
@@ -477,6 +486,7 @@
             this.lbLon.Size = new System.Drawing.Size(126, 24);
             this.lbLon.TabIndex = 161;
             this.lbLon.Text = "1234567890.";
+            this.lbLon.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // label8
             // 
@@ -570,6 +580,9 @@
             // tabPage2
             // 
             this.tabPage2.BackColor = System.Drawing.Color.Gainsboro;
+            this.tabPage2.Controls.Add(this.cboPrecision);
+            this.tabPage2.Controls.Add(this.label12);
+            this.tabPage2.Controls.Add(this.ckSimulate);
             this.tabPage2.Controls.Add(this.rbGP);
             this.tabPage2.Controls.Add(this.rbGN);
             this.tabPage2.Controls.Add(this.ckGSA);
@@ -580,9 +593,50 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 44);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(629, 488);
+            this.tabPage2.Size = new System.Drawing.Size(618, 488);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Options";
+            // 
+            // cboPrecision
+            // 
+            this.cboPrecision.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboPrecision.Font = new System.Drawing.Font("Tahoma", 24F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cboPrecision.FormattingEnabled = true;
+            this.cboPrecision.Items.AddRange(new object[] {
+            "4",
+            "5",
+            "6",
+            "7"});
+            this.cboPrecision.Location = new System.Drawing.Point(481, 425);
+            this.cboPrecision.Name = "cboPrecision";
+            this.cboPrecision.Size = new System.Drawing.Size(71, 47);
+            this.cboPrecision.TabIndex = 317;
+            this.cboPrecision.SelectedIndexChanged += new System.EventHandler(this.cbPrecision_SelectedIndexChanged);
+            // 
+            // label12
+            // 
+            this.label12.Location = new System.Drawing.Point(367, 418);
+            this.label12.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(105, 61);
+            this.label12.TabIndex = 316;
+            this.label12.Text = "Decimal Precision";
+            this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // ckSimulate
+            // 
+            this.ckSimulate.Appearance = System.Windows.Forms.Appearance.Button;
+            this.ckSimulate.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
+            this.ckSimulate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ckSimulate.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ckSimulate.Location = new System.Drawing.Point(97, 418);
+            this.ckSimulate.Name = "ckSimulate";
+            this.ckSimulate.Size = new System.Drawing.Size(182, 61);
+            this.ckSimulate.TabIndex = 315;
+            this.ckSimulate.Text = "Simulate Data";
+            this.ckSimulate.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.ckSimulate.UseVisualStyleBackColor = true;
+            this.ckSimulate.CheckedChanged += new System.EventHandler(this.ckSimulate_CheckedChanged);
             // 
             // rbGP
             // 
@@ -591,7 +645,7 @@
             this.rbGP.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.rbGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.rbGP.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rbGP.Location = new System.Drawing.Point(97, 300);
+            this.rbGP.Location = new System.Drawing.Point(97, 264);
             this.rbGP.Name = "rbGP";
             this.rbGP.Size = new System.Drawing.Size(182, 61);
             this.rbGP.TabIndex = 314;
@@ -606,7 +660,7 @@
             this.rbGN.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.rbGN.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.rbGN.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rbGN.Location = new System.Drawing.Point(370, 300);
+            this.rbGN.Location = new System.Drawing.Point(370, 264);
             this.rbGN.Name = "rbGN";
             this.rbGN.Size = new System.Drawing.Size(182, 61);
             this.rbGN.TabIndex = 313;
@@ -619,7 +673,7 @@
             this.ckGSA.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.ckGSA.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ckGSA.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ckGSA.Location = new System.Drawing.Point(370, 384);
+            this.ckGSA.Location = new System.Drawing.Point(370, 341);
             this.ckGSA.Name = "ckGSA";
             this.ckGSA.Size = new System.Drawing.Size(182, 61);
             this.ckGSA.TabIndex = 312;
@@ -634,7 +688,7 @@
             this.ckRoll.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.ckRoll.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ckRoll.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ckRoll.Location = new System.Drawing.Point(97, 384);
+            this.ckRoll.Location = new System.Drawing.Point(97, 341);
             this.ckRoll.Name = "ckRoll";
             this.ckRoll.Size = new System.Drawing.Size(182, 61);
             this.ckRoll.TabIndex = 311;
@@ -651,7 +705,7 @@
             this.ckAutoConnect.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.ckAutoConnect.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ckAutoConnect.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ckAutoConnect.Location = new System.Drawing.Point(97, 216);
+            this.ckAutoConnect.Location = new System.Drawing.Point(97, 187);
             this.ckAutoConnect.Name = "ckAutoConnect";
             this.ckAutoConnect.Size = new System.Drawing.Size(182, 61);
             this.ckAutoConnect.TabIndex = 306;
@@ -668,7 +722,7 @@
             this.ckAutoHide.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.ckAutoHide.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ckAutoHide.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ckAutoHide.Location = new System.Drawing.Point(370, 216);
+            this.ckAutoHide.Location = new System.Drawing.Point(370, 187);
             this.ckAutoHide.Name = "ckAutoHide";
             this.ckAutoHide.Size = new System.Drawing.Size(182, 61);
             this.ckAutoHide.TabIndex = 305;
@@ -692,7 +746,7 @@
             this.groupBox2.Controls.Add(this.label10);
             this.groupBox2.Controls.Add(this.label9);
             this.groupBox2.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.groupBox2.Location = new System.Drawing.Point(97, 20);
+            this.groupBox2.Location = new System.Drawing.Point(97, 6);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(455, 175);
             this.groupBox2.TabIndex = 155;
@@ -941,6 +995,9 @@
         private System.Windows.Forms.RadioButton rbGP;
         private System.Windows.Forms.Timer tmrGSA;
         private System.Windows.Forms.Label lbSim;
+        private System.Windows.Forms.CheckBox ckSimulate;
+        private System.Windows.Forms.ComboBox cboPrecision;
+        private System.Windows.Forms.Label label12;
     }
 }
 

--- a/SourceCode/GPS_Out/Source/Form1.cs
+++ b/SourceCode/GPS_Out/Source/Form1.cs
@@ -245,7 +245,14 @@ namespace GPS_Out
 
         private void btnGGA_Click(object sender, EventArgs e)
         {
-            tbGGA.Text = GGA.Sentence;
+            if (AGIOdata.Connected() || Properties.Settings.Default.Simulate)
+            {
+                tbGGA.Text = GGA.Sentence;
+            }
+            else
+            {
+                tbGGA.Text = "";
+            }
             if (tbGGA.Text != "") Clipboard.SetText(tbGGA.Text);
         }
 
@@ -256,19 +263,40 @@ namespace GPS_Out
 
         private void btnRMC_Click(object sender, EventArgs e)
         {
-            tbRMC.Text = RMC.Sentence;
+            if (AGIOdata.Connected() || Properties.Settings.Default.Simulate)
+            {
+                tbRMC.Text = RMC.Sentence;
+            }
+            else
+            {
+                tbRMC.Text = "";
+            }
             if (tbRMC.Text != "") Clipboard.SetText(tbRMC.Text);
         }
 
         private void btnVTG_Click(object sender, EventArgs e)
         {
-            tbVTG.Text = VTG.Sentence;
+            if (AGIOdata.Connected() || Properties.Settings.Default.Simulate)
+            {
+                tbVTG.Text = VTG.Sentence;
+            }
+            else
+            {
+                tbVTG.Text = "";
+            }
             if (tbVTG.Text != "") Clipboard.SetText(tbVTG.Text);
         }
 
         private void btnZDA_Click(object sender, EventArgs e)
         {
-            tbZDA.Text = ZDA.Sentence;
+            if (AGIOdata.Connected() || Properties.Settings.Default.Simulate)
+            {
+                tbZDA.Text = ZDA.Sentence;
+            }
+            else
+            {
+                tbZDA.Text = "";
+            }
             if (tbZDA.Text != "") Clipboard.SetText(tbZDA.Text);
         }
 
@@ -338,6 +366,26 @@ namespace GPS_Out
             Properties.Settings.Default.ZDA = cboZDA.SelectedIndex;
         }
 
+        private void cbPrecision_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.SentencePrecisionIndex = cboPrecision.SelectedIndex;
+
+            int precision = Convert.ToInt32(cboPrecision.SelectedItem);
+            string NewFormat = ".";
+            for (int i = 0; i < precision; i++)
+            {
+                NewFormat += "0";
+            }
+
+            Properties.Settings.Default.SentencePrecisionFormat = "00" + NewFormat;
+            Properties.Settings.Default.DisplayPrecisionFormat = "0" + NewFormat;
+
+            tbGGA.Text = "";
+            tbVTG.Text = "";
+            tbRMC.Text = "";
+            tbZDA.Text = "";
+        }
+
         private void ckAutoConnect_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.AutoConnect = ckAutoConnect.Checked;
@@ -359,6 +407,18 @@ namespace GPS_Out
         private void ckRoll_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.UseRollCorrected = ckRoll.Checked;
+        }
+
+        private void ckSimulate_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.Simulate = ckSimulate.Checked;
+            if (!ckSimulate.Checked)
+            {
+                tbGGA.Text = "";
+                tbVTG.Text = "";
+                tbRMC.Text = "";
+                tbZDA.Text = "";
+            }
         }
 
         private void frmStart_FormClosed(object sender, FormClosedEventArgs e)
@@ -390,6 +450,9 @@ namespace GPS_Out
             cboVTG.SelectedIndex = Properties.Settings.Default.VTG;
             cboRMC.SelectedIndex = Properties.Settings.Default.RMC;
             cboZDA.SelectedIndex = Properties.Settings.Default.ZDA;
+
+            cboPrecision.SelectedIndex = Properties.Settings.Default.SentencePrecisionIndex;
+            ckSimulate.Checked = Properties.Settings.Default.Simulate;
 
             if (ckAutoHide.Checked) this.WindowState = FormWindowState.Minimized;
         }
@@ -453,8 +516,11 @@ namespace GPS_Out
             if (GGAsentence == "")
             {
                 Watchdog = 0;
-                GGAsentence = GGA.Build();
-                Send();
+                if (AGIOdata.Connected() || Properties.Settings.Default.Simulate)
+                {
+                    GGAsentence = GGA.Build();
+                    Send();
+                }
             }
             else
             {
@@ -472,7 +538,7 @@ namespace GPS_Out
             if (GSAsentence == "")
             {
                 Watchdog = 0;
-                GSAsentence = GSA.Build();
+                if (AGIOdata.Connected() || Properties.Settings.Default.Simulate) GSAsentence = GSA.Build();
             }
             else
             {
@@ -495,7 +561,7 @@ namespace GPS_Out
             if (RMCsentence == "")
             {
                 Watchdog = 0;
-                RMCsentence = RMC.Build();
+                if (AGIOdata.Connected() || Properties.Settings.Default.Simulate) RMCsentence = RMC.Build();
             }
             else
             {
@@ -513,7 +579,7 @@ namespace GPS_Out
             if (VTGsentence == "")
             {
                 Watchdog = 0;
-                VTGsentence = VTG.Build();
+                if (AGIOdata.Connected() || Properties.Settings.Default.Simulate) VTGsentence = VTG.Build();
             }
             else
             {
@@ -531,7 +597,7 @@ namespace GPS_Out
             if (ZDAsentence == "")
             {
                 Watchdog = 0;
-                ZDAsentence = ZDA.Build();
+                if (AGIOdata.Connected() || Properties.Settings.Default.Simulate) ZDAsentence = ZDA.Build();
             }
             else
             {
@@ -548,15 +614,15 @@ namespace GPS_Out
         {
             if (this.WindowState != FormWindowState.Minimized)
             {
-                if (AOGdata.Connected())
+                if (AOGdata.Connected() && (AGIOdata.Connected() || Properties.Settings.Default.Simulate))
                 {
-                    lbLon.Text = AOGdata.Longitude.ToString("N7");
-                    lbLat.Text = AOGdata.Latitude.ToString("N7");
+                    lbLon.Text = AOGdata.Longitude.ToString(Properties.Settings.Default.DisplayPrecisionFormat);
+                    lbLat.Text = AOGdata.Latitude.ToString(Properties.Settings.Default.DisplayPrecisionFormat);
                 }
                 else
                 {
-                    lbLon.Text = AGIOdata.Longitude.ToString("N7");
-                    lbLat.Text = AGIOdata.Latitude.ToString("N7");
+                    lbLon.Text = AGIOdata.Longitude.ToString(Properties.Settings.Default.DisplayPrecisionFormat);
+                    lbLat.Text = AGIOdata.Latitude.ToString(Properties.Settings.Default.DisplayPrecisionFormat);
                 }
 
                 lbAge.Text = AGIOdata.Age.ToString("N2");
@@ -576,13 +642,20 @@ namespace GPS_Out
                     lbSim.Visible = false;
                     this.Text = "GPS_Out [" + Tls.AppVersion() + "]   " + HeadingType;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     lbQuality.BackColor = SimColor;
                     label4.BackColor = SimColor;
                     lbSim.Visible = true;
                     lbSim.BackColor = SimColor;
                     this.Text = "GPS_Out [" + Tls.AppVersion() + "]  Simulated Data   " + HeadingType;
+                }
+                else
+                {
+                    lbQuality.BackColor = Color.Transparent;
+                    label4.BackColor = Color.Transparent;
+                    lbSim.Visible = false;
+                    this.Text = "GPS_Out [" + Tls.AppVersion() + "]   NO DATA";
                 }
             }
         }

--- a/SourceCode/GPS_Out/Source/PGNs/PGN54908.cs
+++ b/SourceCode/GPS_Out/Source/PGNs/PGN54908.cs
@@ -59,9 +59,13 @@ namespace GPS_Out
                 {
                     return (float)(cAgeX100 / 100.0);
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 1.8F;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -74,9 +78,13 @@ namespace GPS_Out
                 {
                     return cAltitude;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 732.0F;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -89,9 +97,13 @@ namespace GPS_Out
                 {
                     return cFixQuality;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 4;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -104,9 +116,13 @@ namespace GPS_Out
                 {
                     return (float)(cHdopX100 / 100.0);
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 7;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -119,9 +135,13 @@ namespace GPS_Out
                 {
                     return cHeadingDual;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 1000;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -134,9 +154,13 @@ namespace GPS_Out
                 {
                     return cImuHeading;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 1000;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -228,9 +252,13 @@ namespace GPS_Out
                 {
                     return cSatellites;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 12;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -250,9 +278,13 @@ namespace GPS_Out
                         return 0;
                     }
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 4.8F;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -265,9 +297,13 @@ namespace GPS_Out
                 {
                     return cTrueHeading;
                 }
-                else
+                else if (Properties.Settings.Default.Simulate)
                 {
                     return 1000;
+                }
+                else
+                {
+                    return 0;
                 }
             }
         }
@@ -300,8 +336,6 @@ namespace GPS_Out
 
                 ReceiveTime = DateTime.Now;
                 Result = true;
-
-                //mf.Tls.WriteByteFile(Data, "AGIOdata.txt");
             }
             return Result;
         }

--- a/SourceCode/GPS_Out/Source/PGNs/PGN_GGA.cs
+++ b/SourceCode/GPS_Out/Source/PGNs/PGN_GGA.cs
@@ -65,7 +65,7 @@ namespace GPS_Out
             lat = Math.Abs(lat);
             cSentence += "," + ((int)lat).ToString("D2");
             double Mins = (double)(lat - (int)lat) * 60.0;
-            cSentence += Mins.ToString("00.0000000", CultureInfo.InvariantCulture);
+            cSentence += Mins.ToString(Properties.Settings.Default.SentencePrecisionFormat, CultureInfo.InvariantCulture);
             cSentence += NS;
 
             string EW = ",E";
@@ -73,7 +73,7 @@ namespace GPS_Out
             lon = Math.Abs(lon);
             cSentence += "," + ((int)lon).ToString("D3");
             Mins = (double)(lon - (int)lon) * 60.0;
-            cSentence += Mins.ToString("00.0000000", CultureInfo.InvariantCulture);
+            cSentence += Mins.ToString(Properties.Settings.Default.SentencePrecisionFormat, CultureInfo.InvariantCulture);
             cSentence += EW;
 
             cSentence += "," + mf.AGIOdata.FixQuality.ToString();

--- a/SourceCode/GPS_Out/Source/PGNs/PGN_RMC.cs
+++ b/SourceCode/GPS_Out/Source/PGNs/PGN_RMC.cs
@@ -58,7 +58,7 @@ namespace GPS_Out
             lat = Math.Abs(lat);
             cSentence += "," + ((int)lat).ToString("D2");
             double Mins = (double)(lat - (int)lat) * 60.0;
-            cSentence += Mins.ToString("00.0000000", CultureInfo.InvariantCulture);
+            cSentence += Mins.ToString(Properties.Settings.Default.SentencePrecisionFormat, CultureInfo.InvariantCulture);
             cSentence += NS;
 
             string EW = ",E";
@@ -66,7 +66,7 @@ namespace GPS_Out
             lon = Math.Abs(lon);
             cSentence += "," + ((int)lon).ToString("D3");
             Mins = (double)(lon - (int)lon) * 60.0;
-            cSentence += Mins.ToString("00.0000000", CultureInfo.InvariantCulture);
+            cSentence += Mins.ToString(Properties.Settings.Default.SentencePrecisionFormat, CultureInfo.InvariantCulture);
             cSentence += EW;
 
             double knots = mf.AGIOdata.Speed * 0.5399568;

--- a/SourceCode/GPS_Out/Source/Properties/Settings.Designer.cs
+++ b/SourceCode/GPS_Out/Source/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace GPS_Out.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -224,6 +224,54 @@ namespace GPS_Out.Properties {
             }
             set {
                 this["SentenceStart"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("00.0000000")]
+        public string SentencePrecisionFormat {
+            get {
+                return ((string)(this["SentencePrecisionFormat"]));
+            }
+            set {
+                this["SentencePrecisionFormat"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
+        public int SentencePrecisionIndex {
+            get {
+                return ((int)(this["SentencePrecisionIndex"]));
+            }
+            set {
+                this["SentencePrecisionIndex"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Simulate {
+            get {
+                return ((bool)(this["Simulate"]));
+            }
+            set {
+                this["Simulate"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.0000000")]
+        public string DisplayPrecisionFormat {
+            get {
+                return ((string)(this["DisplayPrecisionFormat"]));
+            }
+            set {
+                this["DisplayPrecisionFormat"] = value;
             }
         }
     }

--- a/SourceCode/GPS_Out/Source/Properties/Settings.settings
+++ b/SourceCode/GPS_Out/Source/Properties/Settings.settings
@@ -53,5 +53,17 @@
     <Setting Name="SentenceStart" Type="System.String" Scope="User">
       <Value Profile="(Default)">$GP</Value>
     </Setting>
+    <Setting Name="SentencePrecisionFormat" Type="System.String" Scope="User">
+      <Value Profile="(Default)">00.0000000</Value>
+    </Setting>
+    <Setting Name="SentencePrecisionIndex" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">3</Value>
+    </Setting>
+    <Setting Name="Simulate" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="DisplayPrecisionFormat" Type="System.String" Scope="User">
+      <Value Profile="(Default)">0.0000000</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Users can select less than 7 digits of precision for location for devices that require it. Simulate data is optional. If no AGIO data is available and 'Simulate' is checked, the simulated data will be sent. If 'Simulate' is not checked and AGIO data is unavailable,  GPS_Out won't send any data.