### PR TITLE
Update NMEA parsing heading and roll for SkyTraq receivers

### DIFF
--- a/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
@@ -853,26 +853,16 @@ namespace AgIO
                 headingTrueDualData = headingTrueDual;
             }
 
-            if (!string.IsNullOrEmpty(words[5])) //Pitch Dual GPS; 0 if no RTK or "heading offset" > 45 && < 135
+            /*if (!string.IsNullOrEmpty(words[5])) //Pitch Dual GPS; 0 if no RTK or "heading offset" > 45 && < 135
             {
-                //float.TryParse(words[5], NumberStyles.Float, CultureInfo.InvariantCulture, out _PITCH_);
-                //NOT USED atm                
-            }
+                //float.TryParse(words[5], NumberStyles.Float, CultureInfo.InvariantCulture, out XXX_PITCH_XXX);
+                //NOT USED atm
+                //and not needed/possible to use when using heading
+            }*/
 
             if (!string.IsNullOrEmpty(words[6])) //Roll Dual GPS; 0 if no RTK or “heading offset” <= 45 or >= 135
             {
-                float.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);
-
-                //Kalman filter
-                /*Pc = P + varProcess;
-                G = Pc / (Pc + varRoll);
-                P = (1 - G) * Pc;
-                Xp = XeRoll;
-                Zp = Xp;
-                XeRoll = (G * (rollK - Zp)) + Xp;
-                rollData = XeRoll;
-
-                roll = (float)(XeRoll);*/
+                float.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);               
 
                 if (words[7] == "R") //MovingBase Mode Indicator
                 {


### PR DESCRIPTION
The "PSTI, 032 and 035" messages are completely outdated! I'm using this code with "PSTI, 036" messages for 3 years now inside old version 5.5., working good. Would like to see getting it in the latest program to make cheap SkyTraq PX1172RH receivers usable for the community.

I was kind of responsable for the old code about 5 years ago. See also these posts:
https://discourse.agopengps.com/t/skytraq-dual-gnss-board/19614
https://discourse.agopengps.com/t/dual-gps-using-skytraq-receivers/1577