### PR TITLE
Remove unused `NetTopologySuite` package

### DIFF
--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -7,19 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
-    <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
-    <PackageReference Include="NetTopologySuite.IO" Version="1.14.0.1" />
-    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="OpenTK" Version="3.3.3" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="PresentationCore" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>
 
@@ -39,13 +40,8 @@
     <PackageReference Include="Control.Draggable" Version="1.0.5049.269" />
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
-    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
-    <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
-    <PackageReference Include="NetTopologySuite.IO" Version="1.14.0.1" />
-    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.3.3" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="WebEye.Controls.WinForms.WebCameraControl" Version="1.0.2" />


### PR DESCRIPTION
The `NetTopologySuite` package (and the other related packages) are not actually used by AgOpenGPS.
They are only used in the server implementation of AgShare.

This checks another thing off of #811.