### PR TITLE
Replace `Control.Draggable` NuGet package with source code

### DIFF
--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -36,7 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Control.Draggable" Version="1.0.5049.269" />
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />

--- a/SourceCode/GPS/Controls/DraggableControlExtension.cs
+++ b/SourceCode/GPS/Controls/DraggableControlExtension.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace AgOpenGPS.Controls
+{
+    // Source: https://github.com/intrueder/Control.Draggable
+    public static class DraggableControlExtension
+    {
+        // TKey is control to drag, TValue is a flag used while dragging
+        private static readonly Dictionary<Control, bool> _draggables = new Dictionary<Control, bool>();
+        private static Size _mouseOffset;
+
+        /// <summary>
+        /// Enabling/disabling dragging for control
+        /// </summary>
+        public static void Draggable(this Control control, bool enable)
+        {
+            if (enable)
+            {
+                // enable drag feature
+                if (_draggables.ContainsKey(control))
+                {
+                    // return if control is already draggable
+                    return;
+                }
+                // 'false' - initial state is 'not dragging'
+                _draggables.Add(control, false);
+
+                // assign required event handlersnnn
+                control.MouseDown += new MouseEventHandler(control_MouseDown);
+                control.MouseUp += new MouseEventHandler(control_MouseUp);
+                control.MouseMove += new MouseEventHandler(control_MouseMove);
+            }
+            else
+            {
+                // disable drag feature
+                if (!_draggables.ContainsKey(control))
+                {
+                    // return if control is not draggable
+                    return;
+                }
+                // remove event handlers
+                control.MouseDown -= control_MouseDown;
+                control.MouseUp -= control_MouseUp;
+                control.MouseMove -= control_MouseMove;
+                _draggables.Remove(control);
+            }
+        }
+
+        private static void control_MouseDown(object sender, MouseEventArgs e)
+        {
+            _mouseOffset = new Size(e.Location);
+            // turning on dragging
+            _draggables[(Control)sender] = true;
+        }
+
+        private static void control_MouseUp(object sender, MouseEventArgs e)
+        {
+            // turning off dragging
+            _draggables[(Control)sender] = false;
+        }
+
+        private static void control_MouseMove(object sender, MouseEventArgs e)
+        {
+            // only if dragging is turned on
+            if (_draggables[(Control)sender] == true)
+            {
+                // calculations of control's new position
+                Point newLocationOffset = e.Location - _mouseOffset;
+                ((Control)sender).Left += newLocationOffset.X;
+                ((Control)sender).Top += newLocationOffset.Y;
+            }
+        }
+    }
+}

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -1,34 +1,26 @@
 ﻿//Please, if you use this, share the improvements
 
-using AgLibrary.Logging;
-using AgOpenGPS;
-using AgOpenGPS.Classes;
-using AgOpenGPS.Core;
-using AgOpenGPS.Core.Models;
-using AgOpenGPS.Core.ViewModels;
-using AgOpenGPS.Core.Translations;
-using AgOpenGPS.Forms.Profiles;
-using AgOpenGPS.Properties;
-using AgOpenGPS.Classes.AgShare.Helpers;
-using Microsoft.Win32;
-using OpenTK;
-using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Media;
 using System.Net.Sockets;
-using System.Reflection;
-using System.Resources;
-using System.Text;
-using System.Threading;
-using System.Windows.Forms;
 using System.Threading.Tasks;
+using System.Windows.Forms;
+using AgLibrary.Logging;
+using AgOpenGPS.Classes;
+using AgOpenGPS.Controls;
+using AgOpenGPS.Core;
+using AgOpenGPS.Core.Models;
+using AgOpenGPS.Core.Translations;
+using AgOpenGPS.Core.ViewModels;
+using AgOpenGPS.Forms.Profiles;
+using AgOpenGPS.Properties;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
 
 namespace AgOpenGPS
 {
@@ -518,7 +510,7 @@ namespace AgOpenGPS
             //nmea limiter
             udpWatch.Start();
 
-            ControlExtension.Draggable(panelDrag, true);
+            panelDrag.Draggable(true);
 
             hotkeys = new char[19];
 


### PR DESCRIPTION
Includes the source code for the `Draggable()` extension method from: https://github.com/intrueder/Control.Draggable

This checks one more thing from #811.