### PR TITLE
Replace `WinFormsMapControl` with `GMap.NET`

### DIFF
--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -38,13 +38,13 @@
 
   <ItemGroup>
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
+    <PackageReference Include="GMap.NET.WinForms" Version="2.1.7" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.3.3" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="WebEye.Controls.WinForms.WebCameraControl" Version="1.0.2" />
-    <PackageReference Include="WinFormsMapControl" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS/Forms/Field/FormMap.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormMap.Designer.cs
@@ -30,8 +30,6 @@
         {
             this.components = new System.ComponentModel.Container();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.cmbTileServers = new System.Windows.Forms.ComboBox();
-            this.mapControl = new System.Windows.Forms.MapControl();
             this.lblPoints = new System.Windows.Forms.Label();
             this.lblBnds = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -47,6 +45,7 @@
             this.btnDeletePoint = new System.Windows.Forms.Button();
             this.labelBoundary = new System.Windows.Forms.Label();
             this.cboxDrawMap = new System.Windows.Forms.CheckBox();
+            this.gMapControl = new GMap.NET.WindowsForms.GMapControl();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -55,46 +54,6 @@
             this.timer1.Enabled = true;
             this.timer1.Interval = 1000;
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
-            // 
-            // cmbTileServers
-            // 
-            this.cmbTileServers.AllowDrop = true;
-            this.cmbTileServers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cmbTileServers.DisplayMember = "Name";
-            this.cmbTileServers.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbTileServers.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cmbTileServers.FormattingEnabled = true;
-            this.cmbTileServers.Location = new System.Drawing.Point(12, 617);
-            this.cmbTileServers.Name = "cmbTileServers";
-            this.cmbTileServers.Size = new System.Drawing.Size(273, 31);
-            this.cmbTileServers.TabIndex = 462;
-            this.cmbTileServers.Tag = "";
-            this.cmbTileServers.Visible = false;
-            this.cmbTileServers.SelectedIndexChanged += new System.EventHandler(this.cmbTileServers_SelectedIndexChanged);
-            // 
-            // mapControl
-            // 
-            this.mapControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.mapControl.BackColor = System.Drawing.Color.White;
-            this.mapControl.Cursor = System.Windows.Forms.Cursors.Cross;
-            this.mapControl.ErrorColor = System.Drawing.Color.Red;
-            this.mapControl.FitToBounds = true;
-            this.mapControl.ForeColor = System.Drawing.Color.Black;
-            this.mapControl.Location = new System.Drawing.Point(3, 3);
-            this.mapControl.Name = "mapControl";
-            this.mapControl.ShowThumbnails = true;
-            this.mapControl.Size = new System.Drawing.Size(880, 776);
-            this.mapControl.TabIndex = 464;
-            this.mapControl.ThumbnailBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.mapControl.ThumbnailForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(176)))), ((int)(((byte)(176)))), ((int)(((byte)(176)))));
-            this.mapControl.ThumbnailText = "Downloading...";
-            this.mapControl.TileImageAttributes = null;
-            this.mapControl.ZoomLevel = 2;
-            this.mapControl.Click += new System.EventHandler(this.mapControl_Click);
-            this.mapControl.MouseMove += new System.Windows.Forms.MouseEventHandler(this.mapControl_MouseMove);
-            this.mapControl.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.mapControl_MouseWheel);
             // 
             // lblPoints
             // 
@@ -347,6 +306,41 @@
             this.cboxDrawMap.UseVisualStyleBackColor = false;
             this.cboxDrawMap.Click += new System.EventHandler(this.cboxDrawMap_Click);
             // 
+            // gMapControl
+            // 
+            this.gMapControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.gMapControl.BackColor = System.Drawing.Color.White;
+            this.gMapControl.Bearing = 0F;
+            this.gMapControl.CanDragMap = true;
+            this.gMapControl.Cursor = System.Windows.Forms.Cursors.Cross;
+            this.gMapControl.EmptyTileColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
+            this.gMapControl.ForeColor = System.Drawing.Color.Black;
+            this.gMapControl.GrayScaleMode = false;
+            this.gMapControl.HelperLineOption = GMap.NET.WindowsForms.HelperLineOptions.DontShow;
+            this.gMapControl.LevelsKeepInMemory = 5;
+            this.gMapControl.Location = new System.Drawing.Point(3, 3);
+            this.gMapControl.MarkersEnabled = true;
+            this.gMapControl.MaxZoom = 19;
+            this.gMapControl.MinZoom = 1;
+            this.gMapControl.MouseWheelZoomEnabled = true;
+            this.gMapControl.MouseWheelZoomType = GMap.NET.MouseWheelZoomType.MousePositionAndCenter;
+            this.gMapControl.Name = "gMapControl";
+            this.gMapControl.NegativeMode = false;
+            this.gMapControl.PolygonsEnabled = true;
+            this.gMapControl.RetryLoadTile = 0;
+            this.gMapControl.RoutesEnabled = true;
+            this.gMapControl.ScaleMode = GMap.NET.WindowsForms.ScaleModes.Integer;
+            this.gMapControl.SelectedAreaFillColor = System.Drawing.Color.FromArgb(((int)(((byte)(33)))), ((int)(((byte)(65)))), ((int)(((byte)(105)))), ((int)(((byte)(225)))));
+            this.gMapControl.ShowTileGridLines = false;
+            this.gMapControl.Size = new System.Drawing.Size(880, 776);
+            this.gMapControl.TabIndex = 492;
+            this.gMapControl.Zoom = 2D;
+            this.gMapControl.MouseClick += new System.Windows.Forms.MouseEventHandler(this.gMapControl_MouseClick);
+            this.gMapControl.MouseMove += new System.Windows.Forms.MouseEventHandler(this.gMapControl_MouseMove);
+            this.gMapControl.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.gMapControl_MouseWheel);
+            // 
             // FormMap
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -355,9 +349,8 @@
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1130, 780);
             this.ControlBox = false;
+            this.Controls.Add(this.gMapControl);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.mapControl);
-            this.Controls.Add(this.cmbTileServers);
             this.HelpButton = true;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -375,8 +368,6 @@
         #endregion
         private System.Windows.Forms.Timer timer1;
         private System.Windows.Forms.Button btnExit;
-        private System.Windows.Forms.ComboBox cmbTileServers;
-        private System.Windows.Forms.MapControl mapControl;
         private System.Windows.Forms.Button btnGo;
         private System.Windows.Forms.Button btnDeletePoint;
         private System.Windows.Forms.Button btnAddFence;
@@ -391,5 +382,6 @@
         private System.Windows.Forms.Label labelBackground;
         private System.Windows.Forms.Label labelNewBoundary;
         private System.Windows.Forms.Label labelBoundary;
+        private GMap.NET.WindowsForms.GMapControl gMapControl;
     }
 }

--- a/SourceCode/GPS/Forms/Field/FormMap.cs
+++ b/SourceCode/GPS/Forms/Field/FormMap.cs
@@ -3,12 +3,17 @@ using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Translations;
 using AgOpenGPS.Forms;
 using AgOpenGPS.Helpers;
-using OpenTK.Graphics.OpenGL;
+using GMap.NET;
+using GMap.NET.MapProviders;
+using GMap.NET.WindowsForms;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -19,7 +24,9 @@ namespace AgOpenGPS
         private readonly FormGPS mf = null;
 
         private bool isClosing;
-        private Track bingLine = new Track(new TrackStyle(new Pen(Color.White, 4)));
+        private GMapPolygon polygon;
+        private GMapOverlay overlay = new GMapOverlay();
+        private Point lastMouseLocation;
         private bool isColorMap = true;
 
         public FormMap(Form callingForm)
@@ -35,32 +42,25 @@ namespace AgOpenGPS
             lblPoints.Text = gStr.gsPoints + ":";
             labelBackground.Text = gStr.gsBackground;
 
-            mapControl.CacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "MapControl");
+            gMapControl.MapProvider = GMapProviders.BingHybridMap;
 
-            ITileServer[] tileServers = new ITileServer[]
+            polygon = new GMapPolygon(new List<PointLatLng>(), "bingLine")
             {
-                new BingMapsHybridTileServer(),
-                new BingMapsRoadsTileServer(),
-                new OpenStreetMapTileServer(userAgent: "Map Control AgOpenGPS"),
-                new OfflineTileServer(),
-                new BingMapsAerialTileServer(),
+                Fill = Brushes.Transparent,
+                Stroke = new Pen(Color.White, 4f) { LineJoin = LineJoin.Round }
             };
-
-            cmbTileServers.Items.AddRange(tileServers);
-            cmbTileServers.SelectedIndex = 0;
-            mapControl.Tracks.Add(bingLine);
+            overlay.Polygons.Add(polygon);
+            gMapControl.Overlays.Add(overlay);
         }
 
         private void FormMap_Load(object sender, EventArgs e)
         {
             Size = Properties.Settings.Default.setWindow_BingMapSize;
 
-            mapControl.ZoomLevel = Properties.Settings.Default.setWindow_BingZoom;//mapControl
-            mapControl.Center = new GeoPoint(
-                (float)mf.AppModel.CurrentLatLon.Longitude,
-                (float)mf.AppModel.CurrentLatLon.Latitude);
-
-            mapControl.Invalidate();
+            gMapControl.Zoom = Properties.Settings.Default.setWindow_BingZoom;
+            gMapControl.Position = new PointLatLng(
+                mf.AppModel.CurrentLatLon.Latitude,
+                mf.AppModel.CurrentLatLon.Longitude);
 
             cboxDrawMap.Checked = mf.worldGrid.isGeoMap;
 
@@ -84,7 +84,7 @@ namespace AgOpenGPS
                 return;
             }
             Properties.Settings.Default.setWindow_BingMapSize = Size;
-            Properties.Settings.Default.setWindow_BingZoom = mapControl.ZoomLevel;
+            Properties.Settings.Default.setWindow_BingZoom = (int)gMapControl.Zoom;
             Properties.Settings.Default.Save();
         }
 
@@ -96,117 +96,94 @@ namespace AgOpenGPS
 
         private void UpdateWindowTitle()
         {
-            GeoPoint g = mapControl.Mouse;
-            this.Text = $"Mouse = {g} / Zoom = {mapControl.ZoomLevel} ";
+            PointLatLng pos = gMapControl.FromLocalToLatLng(lastMouseLocation.X, lastMouseLocation.Y);
+            Text = $"Mouse = {PointLatLngToString(pos)} / Zoom = {gMapControl.Zoom} ";
         }
 
-        private void mapControl_MouseMove(object sender, MouseEventArgs e)
+        private void gMapControl_MouseMove(object sender, MouseEventArgs e)
         {
+            lastMouseLocation = e.Location;
             UpdateWindowTitle();
         }
 
-        private void mapControl_MouseWheel(object sender, MouseEventArgs e)
+        private void gMapControl_MouseWheel(object sender, MouseEventArgs e)
         {
             UpdateWindowTitle();
         }
-
-        private void cmbTileServers_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mapControl.TileServer = cmbTileServers.SelectedItem as ITileServer;
-            ActiveControl = mapControl;
-        }
-
-        //private void mapControl_DrawMarker(object sender, DrawMarkerEventArgs e)
-        //{
-        //    e.Handled = true;
-        //    e.Graphics.DrawImage(imageMarker, new Rectangle((int)e.Point.X - 12, (int)e.Point.Y - 24, 24, 24));
-        //    if (mapControl.ZoomLevel >= 5)
-        //    {
-        //        e.Graphics.DrawString(e.Marker.Label, SystemFonts.DefaultFont, Brushes.Red, new PointF(e.Point.X, e.Point.Y + 5), new StringFormat() { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Near });
-        //    }
-        //}
 
         private void btnGo_Click(object sender, EventArgs e)
         {
-            mapControl.Center = new GeoPoint(
-                (float)mf.AppModel.CurrentLatLon.Longitude,
-                (float)mf.AppModel.CurrentLatLon.Latitude);
-            if (bingLine.Count == 0)
+            gMapControl.Position = new PointLatLng(
+                mf.AppModel.CurrentLatLon.Latitude,
+                mf.AppModel.CurrentLatLon.Longitude);
+            if (polygon.Points.Count == 0)
             {
-                mapControl.Markers.Clear();
-                if (mapControl.Markers.Count == 0)
-                {
-                    // Create marker's location point
-                    var point = new GeoPoint(
-                        (float)mf.AppModel.CurrentLatLon.Longitude,
-                        (float)mf.AppModel.CurrentLatLon.Latitude);
+                overlay.Markers.Clear();
 
-                    var style = new MarkerStyle(10);
+                // Create marker's location point
+                var point = new PointLatLng(
+                    mf.AppModel.CurrentLatLon.Latitude,
+                    mf.AppModel.CurrentLatLon.Longitude);
 
-                    // Create marker instance: specify location on the map, drawing style, and label
-                    var marker = new Marker(point, style, "");
+                // Create marker instance: specify location on the map and radius
+                var marker = new GMapMarkerCircle(point, 5f);
 
-                    // Add marker to the map
-                    mapControl.Markers.Add(marker);
-                }
+                // Add marker to the map
+                overlay.Markers.Add(marker);
             }
             UpdateWindowTitle();
-            mapControl.Invalidate();
         }
 
-        private void mapControl_Click(object sender, EventArgs e)
+        private void gMapControl_MouseClick(object sender, MouseEventArgs e)
         {
-            if (cboxEnableLineDraw.Checked)
-            {
-                if (bingLine.Count == 0) mapControl.Markers.Clear();
-                var coord = mapControl.Mouse;
-                bingLine.Add(coord);
-                mapControl.Invalidate();
-                {
-                    // Create marker's location point
-                    var point = coord;
+            if (e.Button != MouseButtons.Left)
+                return;
 
-                    var style = new MarkerStyle(8);
+            if (!cboxEnableLineDraw.Checked)
+                return;
 
-                    // Create marker instance: specify location on the map, drawing style, and label
-                    var marker = new Marker(point, style, bingLine.Count.ToString());
+            if (polygon.Points.Count == 0)
+                overlay.Markers.Clear();
 
-                    // Add marker to the map
-                    mapControl.Markers.Add(marker);
-                    mapControl.Invalidate();
-                }
-            }
+            var coord = gMapControl.FromLocalToLatLng(e.Location.X, e.Location.Y);
+            polygon.Points.Add(coord);
+            gMapControl.UpdatePolygonLocalPosition(polygon);
+
+            // Create marker instance: specify location on the map, radius and label
+            var marker = new GMapMarkerCircle(coord, 4f, polygon.Points.Count.ToString());
+
+            // Add marker to the map
+            overlay.Markers.Add(marker);
         }
 
         private void btnDeletePoint_Click(object sender, EventArgs e)
         {
-            if (bingLine != null && bingLine.Count > 0)
+            if (polygon.Points.Count == 0)
+                return;
+
+            string sNum = polygon.Points.Count.ToString();
+
+            polygon.Points.RemoveAt(polygon.Points.Count - 1);
+            gMapControl.UpdatePolygonLocalPosition(polygon);
+
+            foreach (var marker in overlay.Markers.OfType<GMapMarkerCircle>())
             {
-                string sNum = bingLine.Count.ToString();
-
-                if (bingLine.Count > 0) bingLine.RemoveAt(bingLine.Count - 1);
-                foreach (var mark in mapControl.Markers)
+                if (marker.Label == sNum)
                 {
-                    if (mark.Label == sNum)
-                    {
-                        mapControl.Markers.Remove(mark);
-                        break;
-                    }
+                    overlay.Markers.Remove(marker);
+                    break;
                 }
-                // mapControl.Markers.Clear();
-
-                mapControl.Invalidate();
             }
         }
 
         private void btnAddFence_Click(object sender, EventArgs e)
         {
-            if (bingLine.Count > 2)
+            if (polygon.Points.Count > 2)
             {
                 CBoundaryList New = new CBoundaryList();
-                for (int i = 0; i < bingLine.Count; i++)
+                foreach (var point in polygon.Points)
                 {
-                    GeoCoord geoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(bingLine[i].Latitude, bingLine[i].Longitude));
+                    GeoCoord geoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(point.Lat, point.Lng));
                     New.fenceLine.Add(new vec3(geoCoord));
                 }
 
@@ -226,9 +203,7 @@ namespace AgOpenGPS
             cboxEnableLineDraw.Checked = false;
 
             //clean up line
-            bingLine.Clear();
-            mapControl.Markers.Clear();
-            mapControl.Invalidate();
+            ResetPolygonAndMarkers();
 
             btnAddFence.Enabled = false;
             btnDeletePoint.Enabled = false;
@@ -236,11 +211,9 @@ namespace AgOpenGPS
 
         private void btnDeleteAll_Click(object sender, EventArgs e)
         {
-            if (bingLine.Count > 0)
+            if (polygon.Points.Count > 0)
             {
-                bingLine.Clear();
-                mapControl.Markers.Clear();
-                mapControl.Invalidate();
+                ResetPolygonAndMarkers();
                 return;
             }
 
@@ -266,10 +239,6 @@ namespace AgOpenGPS
                 mf.bnd.BuildTurnLines();
                 mf.fd.UpdateFieldBoundaryGUIAreas();
                 mf.btnABDraw.Visible = false;
-                //clean up line
-                mapControl.Markers.Clear();
-                bingLine.Clear();
-                mapControl.Invalidate();
             }
             else
             {
@@ -278,9 +247,7 @@ namespace AgOpenGPS
             cboxEnableLineDraw.Checked = false;
 
             //clean up line
-            bingLine.Clear();
-            mapControl.Markers.Clear();
-            mapControl.Invalidate();
+            ResetPolygonAndMarkers();
 
             btnAddFence.Enabled = false;
             btnDeletePoint.Enabled = false;
@@ -293,37 +260,32 @@ namespace AgOpenGPS
                 mf.TimedMessageBox(3000, "Boundary Create Mode", "Touch Map to Create The Boundary");
                 btnAddFence.Enabled = true;
                 btnDeletePoint.Enabled = true;
-                bingLine.Clear();
-                mapControl.Markers.Clear();
-                mapControl.Invalidate();
                 Log.EventWriter("Bing Touch Boundary started");
             }
             else
             {
-                bingLine.Clear();
-                mapControl.Markers.Clear();
-                mapControl.Invalidate();
-
                 btnAddFence.Enabled = false;
                 btnDeletePoint.Enabled = false;
             }
+
+            ResetPolygonAndMarkers();
         }
 
         private void SaveBackgroundImage()
         {
-            if (bingLine.Count > 0)
+            if (polygon.Points.Count > 0)
             {
                 mf.TimedMessageBox(3000, gStr.gsBoundary, "Finish Making Boundary or Delete");
                 return;
             }
 
-            GeoPoint geoRef = mapControl.TopLeft;
-            GeoCoord topLeftGeoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(geoRef.Latitude, geoRef.Longitude));
+            PointLatLng geoRef = gMapControl.ViewArea.LocationTopLeft;
+            GeoCoord topLeftGeoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(geoRef.Lat, geoRef.Lng));
             mf.worldGrid.northingMaxGeo = topLeftGeoCoord.Northing;
             mf.worldGrid.eastingMinGeo = topLeftGeoCoord.Easting;
 
-            geoRef = mapControl.BottomRight;
-            GeoCoord bottomRightGeoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(geoRef.Latitude, geoRef.Longitude));
+            geoRef = gMapControl.ViewArea.LocationRightBottom;
+            GeoCoord bottomRightGeoCoord = mf.AppModel.LocalPlane.ConvertWgs84ToGeoCoord(new Wgs84(geoRef.Lat, geoRef.Lng));
             mf.worldGrid.northingMinGeo = bottomRightGeoCoord.Northing;
             mf.worldGrid.eastingMaxGeo = bottomRightGeoCoord.Easting;
 
@@ -341,8 +303,8 @@ namespace AgOpenGPS
                 return;
             }
 
-            Bitmap bitmap = new Bitmap(mapControl.Width, mapControl.Height);
-            mapControl.DrawToBitmap(bitmap, new Rectangle(0, 0, bitmap.Width, bitmap.Height));
+            Bitmap bitmap = new Bitmap(gMapControl.Width, gMapControl.Height);
+            gMapControl.DrawToBitmap(bitmap, new Rectangle(0, 0, bitmap.Width, bitmap.Height));
 
             if (!isColorMap)
             {
@@ -400,7 +362,7 @@ namespace AgOpenGPS
 
         private void cboxDrawMap_Click(object sender, EventArgs e)
         {
-            if (bingLine.Count > 0)
+            if (polygon.Points.Count > 0)
             {
                 mf.TimedMessageBox(2000, gStr.gsBoundary, "Finish Making Boundary");
                 cboxDrawMap.Checked = !cboxDrawMap.Checked;
@@ -434,36 +396,39 @@ namespace AgOpenGPS
             catch { }
 
             mf.worldGrid.isGeoMap = false;
-            bingLine.Clear();
-            mapControl.Markers.Clear();
-            mapControl.Invalidate();
+            ResetPolygonAndMarkers();
+        }
+
+        private void ResetPolygonAndMarkers()
+        {
+            polygon.Points.Clear();
+            gMapControl.UpdatePolygonLocalPosition(polygon);
+            overlay.Markers.Clear();
         }
 
         private void btnZoomOut_Click(object sender, EventArgs e)
         {
-            int zoom = mapControl.ZoomLevel;
+            int zoom = (int)gMapControl.Zoom;
             zoom--;
             if (zoom < 12) zoom = 12;
-            mapControl.ZoomLevel = zoom;//mapControl
-            mapControl.Invalidate();
+            gMapControl.Zoom = zoom;//mapControl
             UpdateWindowTitle();
         }
 
         private void btnZoomIn_Click(object sender, EventArgs e)
         {
-            int zoom = mapControl.ZoomLevel;
+            int zoom = (int)gMapControl.Zoom;
             zoom++;
             if (zoom > 19) zoom = 19;
-            mapControl.ZoomLevel = zoom;//mapControl
-            mapControl.Invalidate();
+            gMapControl.Zoom = zoom;//mapControl
             UpdateWindowTitle();
         }
 
         private void timer1_Tick(object sender, EventArgs e)
         {
             lblBnds.Text = mf.bnd.bndList.Count.ToString();
-            if (bingLine.Count > 0)
-                lblPoints.Text = "Pts: " + bingLine.Count.ToString();
+            if (polygon.Points.Count > 0)
+                lblPoints.Text = "Pts: " + polygon.Points.Count.ToString();
             else
                 lblPoints.Text = "";
 
@@ -481,5 +446,53 @@ namespace AgOpenGPS
             }
         }
 
+        private static string PointLatLngToString(PointLatLng point)
+        {
+            return $"{DegreeToString(point.Lng, "W", "E")}, {DegreeToString(point.Lat, "S", "N")}";
+        }
+
+        private static string DegreeToString(double coordinate, string negativeSym, string positiveSym)
+        {
+            string sym = (coordinate < 0.0) ? negativeSym : positiveSym;
+            coordinate = Math.Abs(coordinate);
+            double d = Math.Floor(coordinate);
+            coordinate -= d;
+            coordinate *= 60;
+            double m = Math.Floor(coordinate);
+            coordinate -= m;
+            coordinate *= 60;
+            double s = coordinate;
+            string dd = d.ToString();
+            string mm = m.ToString().PadLeft(2, '0');
+            string ss = s.ToString("00.00", CultureInfo.InvariantCulture);
+            return $"{dd}° {mm}' {ss}\" {sym}";
+        }
+
+        private class GMapMarkerCircle : GMapMarker
+        {
+            private readonly float _radius;
+            private readonly Brush _brush = Brushes.Red;
+            private readonly Font _font = SystemFonts.DefaultFont;
+            private readonly Brush _labelBrush = Brushes.Black;
+
+            public GMapMarkerCircle(PointLatLng pos, float radius, string label = null)
+                : base(pos)
+            {
+                _radius = radius;
+                Label = label;
+            }
+
+            public string Label { get; }
+
+            public override void OnRender(Graphics g)
+            {
+                g.FillEllipse(_brush, LocalPosition.X - _radius, LocalPosition.Y - _radius, 2 * _radius, 2 * _radius);
+
+                if (Label != null)
+                {
+                    g.DrawString(Label, _font, _labelBrush, LocalPosition.X + _radius * 0.7f, LocalPosition.Y + _radius * 0.7f);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Replaces the use of [WinFormsMapControl](https://www.nuget.org/packages/WinFormsMapControl/) with [GMap.NET.WinForms](https://www.nuget.org/packages/GMap.NET.WinForms/).

This checks one more thing from #811.