### PR TITLE
Replaces `WebEye.Controls.WinForms.WebCameraControl` with `OpenCvSharp4.VideoCapture`

### DIFF
--- a/SourceCode/AgDiag/AgDiag.csproj
+++ b/SourceCode/AgDiag/AgDiag.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 

--- a/SourceCode/AgIO/Source/AgIO.csproj
+++ b/SourceCode/AgIO/Source/AgIO.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 

--- a/SourceCode/AgLibrary.Tests/AgLibrary.Tests.csproj
+++ b/SourceCode/AgLibrary.Tests/AgLibrary.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/AgLibrary/AgLibrary.csproj
+++ b/SourceCode/AgLibrary/AgLibrary.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/AgOpenGPS.Core.Tests/AgOpenGPS.Core.Tests.csproj
+++ b/SourceCode/AgOpenGPS.Core.Tests/AgOpenGPS.Core.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="3.3.3" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
   </ItemGroup>
 

--- a/SourceCode/AgOpenGPS.WpfApp/AgOpenGPS.WpfApp.csproj
+++ b/SourceCode/AgOpenGPS.WpfApp/AgOpenGPS.WpfApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/AgOpenGPS.WpfViews/AgOpenGPS.WpfViews.csproj
+++ b/SourceCode/AgOpenGPS.WpfViews/AgOpenGPS.WpfViews.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -39,11 +39,12 @@
   <ItemGroup>
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
+    <PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.Windows" Version="4.11.0.20250507" />
     <PackageReference Include="OpenTK.GLControl" Version="3.3.3" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
-    <PackageReference Include="WebEye.Controls.WinForms.WebCameraControl" Version="1.0.2" />
     <PackageReference Include="WinFormsMapControl" Version="1.1.0" />
   </ItemGroup>
 

--- a/SourceCode/GPS/Forms/FormWebCam.Designer.cs
+++ b/SourceCode/GPS/Forms/FormWebCam.Designer.cs
@@ -28,93 +28,49 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.comboBox1 = new System.Windows.Forms.ComboBox();
-            this.stopButton = new System.Windows.Forms.Button();
-            this.webCameraControl1 = new WebEye.Controls.WinForms.WebCameraControl.WebCameraControl();
-            this.startButton = new System.Windows.Forms.Button();
+            this.webCamPictureBox = new System.Windows.Forms.PictureBox();
+            this.webCamBackgroundWorker = new System.ComponentModel.BackgroundWorker();
+            ((System.ComponentModel.ISupportInitialize)(this.webCamPictureBox)).BeginInit();
             this.SuspendLayout();
             // 
-            // comboBox1
+            // webCamPictureBox
             // 
-            this.comboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(13, 234);
-            this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(196, 27);
-            this.comboBox1.TabIndex = 11;
-            this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged_1);
+            this.webCamPictureBox.BackColor = System.Drawing.Color.Black;
+            this.webCamPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.webCamPictureBox.Location = new System.Drawing.Point(0, 0);
+            this.webCamPictureBox.Name = "webCamPictureBox";
+            this.webCamPictureBox.Size = new System.Drawing.Size(398, 268);
+            this.webCamPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.webCamPictureBox.TabIndex = 14;
+            this.webCamPictureBox.TabStop = false;
             // 
-            // stopButton
+            // webCamBackgroundWorker
             // 
-            this.stopButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.stopButton.BackgroundImage = global::AgOpenGPS.Properties.Resources.Stop;
-            this.stopButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.stopButton.Enabled = false;
-            this.stopButton.FlatAppearance.BorderSize = 0;
-            this.stopButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.stopButton.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.stopButton.Location = new System.Drawing.Point(319, 229);
-            this.stopButton.Margin = new System.Windows.Forms.Padding(2);
-            this.stopButton.Name = "stopButton";
-            this.stopButton.Size = new System.Drawing.Size(75, 37);
-            this.stopButton.TabIndex = 13;
-            this.stopButton.UseVisualStyleBackColor = true;
-            this.stopButton.Click += new System.EventHandler(this.stopButton_Click_1);
-            // 
-            // webCameraControl1
-            // 
-            this.webCameraControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.webCameraControl1.BackColor = System.Drawing.SystemColors.AppWorkspace;
-            this.webCameraControl1.Location = new System.Drawing.Point(0, 0);
-            this.webCameraControl1.Name = "webCameraControl1";
-            this.webCameraControl1.Size = new System.Drawing.Size(398, 229);
-            this.webCameraControl1.TabIndex = 10;
-            // 
-            // startButton
-            // 
-            this.startButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.startButton.BackgroundImage = global::AgOpenGPS.Properties.Resources.Play;
-            this.startButton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.startButton.Enabled = false;
-            this.startButton.FlatAppearance.BorderSize = 0;
-            this.startButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.startButton.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.startButton.Location = new System.Drawing.Point(226, 229);
-            this.startButton.Margin = new System.Windows.Forms.Padding(2);
-            this.startButton.Name = "startButton";
-            this.startButton.Size = new System.Drawing.Size(75, 37);
-            this.startButton.TabIndex = 12;
-            this.startButton.UseVisualStyleBackColor = true;
-            this.startButton.Click += new System.EventHandler(this.startButton_Click_1);
+            this.webCamBackgroundWorker.WorkerReportsProgress = true;
+            this.webCamBackgroundWorker.WorkerSupportsCancellation = true;
+            this.webCamBackgroundWorker.DoWork += new System.ComponentModel.DoWorkEventHandler(this.webCamBackgroundWorker_DoWork);
+            this.webCamBackgroundWorker.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.webCamBackgroundWorker_ProgressChanged);
             // 
             // FormWebCam
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(398, 268);
-            this.Controls.Add(this.comboBox1);
-            this.Controls.Add(this.stopButton);
-            this.Controls.Add(this.startButton);
-            this.Controls.Add(this.webCameraControl1);
+            this.Controls.Add(this.webCamPictureBox);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "FormWebCam";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "WebCam";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormWebCam_FormClosing);
             this.Load += new System.EventHandler(this.FormWebCam_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.webCamPictureBox)).EndInit();
             this.ResumeLayout(false);
 
         }
 
         #endregion
-
-        private System.Windows.Forms.ComboBox comboBox1;
-        private System.Windows.Forms.Button stopButton;
-        private System.Windows.Forms.Button startButton;
-        private WebEye.Controls.WinForms.WebCameraControl.WebCameraControl webCameraControl1;
+        private System.Windows.Forms.PictureBox webCamPictureBox;
+        private System.ComponentModel.BackgroundWorker webCamBackgroundWorker;
     }
 }

--- a/SourceCode/GPS/Forms/FormWebCam.cs
+++ b/SourceCode/GPS/Forms/FormWebCam.cs
@@ -1,78 +1,59 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Threading;
 using System.Windows.Forms;
-using WebEye.Controls.WinForms.WebCameraControl;
+using OpenCvSharp;
+using OpenCvSharp.Extensions;
 
 namespace AgOpenGPS
 {
     public partial class FormWebCam : Form
     {
+        private readonly VideoCapture _capture = new VideoCapture();
+
         public FormWebCam()
         {
             InitializeComponent();
         }
 
-        private class ComboBoxItem
-        {
-            public ComboBoxItem(WebCameraId id)
-            {
-                _id = id;
-            }
-
-            private readonly WebCameraId _id;
-
-            public WebCameraId Id => _id;
-
-            public override string ToString()
-            {
-                // Generates the text shown in the combo box.
-                return _id.Name;
-            }
-        }
-
         private void FormWebCam_Load(object sender, EventArgs e)
         {
-            foreach (WebCameraId camera in webCameraControl1.GetVideoCaptureDevices())
-            {
-                comboBox1.Items.Add(new ComboBoxItem(camera));
-            }
-
-            if (comboBox1.Items.Count > 0)
-            {
-                comboBox1.SelectedItem = comboBox1.Items[0];
-            }
+            webCamBackgroundWorker.RunWorkerAsync();
         }
 
-        private void UpdateButtons()
+        private void FormWebCam_FormClosing(object sender, FormClosingEventArgs e)
         {
-            startButton.Enabled = comboBox1.SelectedItem != null;
-            stopButton.Enabled = webCameraControl1.IsCapturing;
-            //imageButton.Enabled = webCameraControl1.IsCapturing;
+            webCamBackgroundWorker.CancelAsync();
+            _capture.Dispose();
         }
 
-        private void comboBox1_SelectedIndexChanged_1(object sender, EventArgs e)
+        private void webCamBackgroundWorker_DoWork(object sender, DoWorkEventArgs e)
         {
-            UpdateButtons();
-        }
+            _capture.Open(0);
 
-        private void startButton_Click_1(object sender, EventArgs e)
-        {
-            ComboBoxItem i = (ComboBoxItem)comboBox1.SelectedItem;
-
-            try
+            if (!_capture.IsOpened())
             {
-                webCameraControl1.StartCapture(i.Id);
+                Close();
+                return;
             }
-            finally
+
+            while (!webCamBackgroundWorker.CancellationPending)
             {
-                UpdateButtons();
+                using (var frameMat = _capture.RetrieveMat())
+                {
+                    var bitmap = BitmapConverter.ToBitmap(frameMat);
+                    webCamBackgroundWorker.ReportProgress(0, bitmap);
+                }
+                Thread.Sleep(100);
             }
         }
 
-        private void stopButton_Click_1(object sender, EventArgs e)
+        private void webCamBackgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
-            webCameraControl1.StopCapture();
-
-            UpdateButtons();
+            var bitmap = (Bitmap)e.UserState;
+            webCamPictureBox.Image?.Dispose();
+            webCamPictureBox.Image = bitmap;
         }
     }
 }

--- a/SourceCode/GPS/Forms/FormWebCam.resx
+++ b/SourceCode/GPS/Forms/FormWebCam.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="webCamBackgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SourceCode/GPS_Out/Source/GPS_Out.csproj
+++ b/SourceCode/GPS_Out/Source/GPS_Out.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 

--- a/SourceCode/Keypad/Keypad.csproj
+++ b/SourceCode/Keypad/Keypad.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 

--- a/SourceCode/ModSim/Source/ModSim.csproj
+++ b/SourceCode/ModSim/Source/ModSim.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Uses the `VideoCapture` from `OpenCvSharp4` to render the web cam.

Unfortunately, there is no easy way to get a list of all available cameras. This was needed to populate the combo box and allow users to choose which camera to display.
Is this functionality actually needed? If so, there is quite some more work that needs to be done.