### PR TITLE
Enable code analysis for not real designer files

### DIFF
--- a/SourceCode/.editorconfig
+++ b/SourceCode/.editorconfig
@@ -5,3 +5,7 @@ dotnet_diagnostic.CS1690.severity = silent
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
+
+# Enable code analysis for *.Designer files that are not actually designer generated
+[{ConfigData,ConfigHelp,ConfigMenu,ConfigModule,ConfigTool,ConfigVehicle,Controls,GUI,NMEA,NTRIPComm,OpenGL,PGN,Position,SaveOpen,Sections,SerialComm,UDP,UDPComm}.Designer.cs]
+generated_code = false

--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -78,7 +78,7 @@ namespace AgIO
                     isRadio_RequiredOn = Properties.Settings.Default.setRadio_isOn;
                     lblWatch.Text = "Waiting";
                     lblNTRIP_IP.Text = "--";
-                    lblMount.Text= "--";
+                    lblMount.Text = "--";
                 }
             }
             else
@@ -313,11 +313,11 @@ namespace AgIO
                 if (form.DialogResult == DialogResult.Yes)
                 {
                     Log.EventWriter("Program Reset: Saving or Selecting Profile");
-                    
+
                     Program.Restart();
                 }
             }
-            this.Text = "AgIO  v" + Program.Version + "   Using Profile: " 
+            this.Text = "AgIO  v" + Program.Version + "   Using Profile: "
                 + RegistrySettings.profileName;
         }
 
@@ -459,9 +459,10 @@ namespace AgIO
 
             using (var form = new FormRadio(this))
             {
-                if (form.ShowDialog(this) == DialogResult.OK) {
+                if (form.ShowDialog(this) == DialogResult.OK)
+                {
                     Settings.Default.Save();
-               }
+                }
             }
         }
 

--- a/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
@@ -15,7 +15,7 @@ namespace AgIO
         private bool isSti035Available = false;
         private bool isSti036Available = false;
 
-        public string ggaSentence, vtgSentence, hdtSentence, avrSentence, paogiSentence, 
+        public string ggaSentence, vtgSentence, hdtSentence, avrSentence, paogiSentence,
             hpdSentence, rmcSentence, pandaSentence, ksxtSentence;
 
         public float hdopData, altitude = float.MaxValue, headingTrue = float.MaxValue,
@@ -24,12 +24,12 @@ namespace AgIO
 
         public double latitudeSend = double.MaxValue, longitudeSend = double.MaxValue, latitude, longitude;
 
-        public ushort satellitesData, satellitesTracked = ushort.MaxValue, hdopX100 = ushort.MaxValue, 
+        public ushort satellitesData, satellitesTracked = ushort.MaxValue, hdopX100 = ushort.MaxValue,
             ageX100 = ushort.MaxValue;
 
         //imu data
         public ushort imuHeadingData, imuHeading = ushort.MaxValue;
-        public short imuRollData, imuRoll = short.MaxValue, imuPitchData, imuPitch = short.MaxValue, 
+        public short imuRollData, imuRoll = short.MaxValue, imuPitchData, imuPitch = short.MaxValue,
             imuYawRateData, imuYawRate = short.MaxValue;
 
         public byte fixQualityData, fixQuality = byte.MaxValue;
@@ -131,7 +131,7 @@ namespace AgIO
             if (isLogMonitorOn)
             {
                 logMonitorSentence.Append(DateTime.UtcNow
-                    .ToString("mm:ss.fff ", CultureInfo.InvariantCulture)+rawBuffer);
+                    .ToString("mm:ss.fff ", CultureInfo.InvariantCulture) + rawBuffer);
             }
 
 
@@ -420,7 +420,7 @@ namespace AgIO
 
                 //age
                 float.TryParse(words[13], NumberStyles.Float, CultureInfo.InvariantCulture, out ageData);
-                ageX100 = (ushort)(ageData*100.0);
+                ageX100 = (ushort)(ageData * 100.0);
 
                 //LastUpdateUTC = UTC;
 
@@ -457,7 +457,7 @@ namespace AgIO
                 { if (words[5] == "W") longitude *= -1; }
                 longitudeSend = longitude;
 
-                isNMEAToSend = true;                
+                isNMEAToSend = true;
             }
         }
 
@@ -487,7 +487,7 @@ namespace AgIO
             }
 
             if (!string.IsNullOrEmpty(words[1]))
-            { 
+            {
                 //True heading
                 float.TryParse(words[1], NumberStyles.Float, CultureInfo.InvariantCulture, out headingTrue);
                 headingTrueData = headingTrue;
@@ -731,9 +731,9 @@ namespace AgIO
                 }
 
                 decim -= 2;
-                double.TryParse(words[2].Substring(0, decim), 
+                double.TryParse(words[2].Substring(0, decim),
                     NumberStyles.Float, CultureInfo.InvariantCulture, out latitude);
-                double.TryParse(words[2].Substring(decim), 
+                double.TryParse(words[2].Substring(decim),
                     NumberStyles.Float, CultureInfo.InvariantCulture, out double temp);
                 temp *= 0.01666666666666666666666666666667;
                 latitude += temp;
@@ -751,9 +751,9 @@ namespace AgIO
                 }
 
                 decim -= 2;
-                double.TryParse(words[4].Substring(0, decim), 
+                double.TryParse(words[4].Substring(0, decim),
                     NumberStyles.Float, CultureInfo.InvariantCulture, out longitude);
-                double.TryParse(words[4].Substring(decim), 
+                double.TryParse(words[4].Substring(decim),
                     NumberStyles.Float, CultureInfo.InvariantCulture, out temp);
                 longitude += temp * 0.01666666666666666666666666666667;
 
@@ -926,7 +926,7 @@ namespace AgIO
 
             if (!string.IsNullOrEmpty(words[6])) //Roll Dual GPS; 0 if no RTK or “heading offset” <= 45 or >= 135
             {
-                float.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);               
+                float.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);
 
                 if (words[7] == "R") //MovingBase Mode Indicator
                 {
@@ -1063,8 +1063,8 @@ namespace AgIO
                 else
                 {
                     //CRC code goes here - return true for now if $KS
-                    if(sentenceChars[0] == 36 && sentenceChars[1] == 75 && sentenceChars[2] == 83) return true;
-                    else return false;  
+                    if (sentenceChars[0] == 36 && sentenceChars[1] == 75 && sentenceChars[2] == 83) return true;
+                    else return false;
                 }
             }
             catch (Exception ex)

--- a/SourceCode/AgIO/Source/Forms/NTRIPComm.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/NTRIPComm.Designer.cs
@@ -359,7 +359,7 @@ namespace AgIO
             ntripCounter++;
 
             //Thinks is connected but not receiving anything
-            if (NTRIP_Watchdog++ > 30 && isNTRIP_Connected) 
+            if (NTRIP_Watchdog++ > 30 && isNTRIP_Connected)
                 ReconnectRequest();
 
             //Once all connected set the timer GGA to NTRIP Settings
@@ -423,8 +423,8 @@ namespace AgIO
         {
             //update gui with stats
             tripBytes += (uint)data.Length;
-            
-            if (isViewAdvanced && isNTRIP_RequiredOn )
+
+            if (isViewAdvanced && isNTRIP_RequiredOn)
             {
                 int mess = 0;
                 //lblPacketSize.Text = data.Length.ToString();
@@ -442,7 +442,7 @@ namespace AgIO
                             if (mess > 1000 && mess < 1231)
                             {
                                 rList.Add(mess);
-                                i += (data[i + 1] << 6) + (data[i + 2])+5;
+                                i += (data[i + 1] << 6) + (data[i + 2]) + 5;
                                 if (data[i + 1] != 211)
                                 {
                                     //rList.Clear();
@@ -628,7 +628,7 @@ namespace AgIO
             try
             {
                 SerialPort comport = (SerialPort)sender;
-                if (comport.BytesToRead < 32) 
+                if (comport.BytesToRead < 32)
                     return;
 
                 int nBytesRec = comport.BytesToRead;
@@ -675,7 +675,7 @@ namespace AgIO
                 //Also stop the requests now
                 isNTRIP_RequiredOn = false;
             }
-            else if(spRadio != null)
+            else if (spRadio != null)
             {
                 spRadio.Close();
                 spRadio.Dispose();

--- a/SourceCode/AgIO/Source/Forms/SerialComm.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/SerialComm.Designer.cs
@@ -15,22 +15,22 @@ namespace AgIO
         private int totalHeaderByteCount = 5;
 
         public static string portNameGPS = "***";
-        public  static int baudRateGPS = 4800;
+        public static int baudRateGPS = 4800;
 
-        public  static string portNameGPS2 = "***";
-        public  static int baudRateGPS2 = 4800;
+        public static string portNameGPS2 = "***";
+        public static int baudRateGPS2 = 4800;
 
-        public  static string portNameRtcm = "***";
-        public  static int baudRateRtcm = 4800;
+        public static string portNameRtcm = "***";
+        public static int baudRateRtcm = 4800;
 
-        public  static string portNameIMU = "***";
-        public  static int baudRateIMU = 38400;
+        public static string portNameIMU = "***";
+        public static int baudRateIMU = 38400;
 
-        public  static string portNameSteerModule = "***";
-        public  static int baudRateSteerModule = 38400;
+        public static string portNameSteerModule = "***";
+        public static int baudRateSteerModule = 38400;
 
-        public  static string portNameMachineModule = "***";
-        public  static int baudRateMachineModule = 38400;
+        public static string portNameMachineModule = "***";
+        public static int baudRateMachineModule = 38400;
 
         //public  static string portNameModule3 = "***";
         //public  static int baudRateModule3 = 38400;
@@ -76,7 +76,7 @@ namespace AgIO
 
         //serial port Ardiuno is connected to
         //public SerialPort spModule3 = new SerialPort(portNameModule3, baudRateModule3, Parity.None, 8, StopBits.One);
-        
+
         //lists for parsing incoming bytes
         private byte[] pgnSteerModule = new byte[22];
         private byte[] pgnMachineModule = new byte[22];

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -57,7 +57,7 @@ namespace AgOpenGPS
 
             PanelUpdateRightAndBottom();
         }
-        
+
         private void btnContourLock_Click(object sender, EventArgs e)
         {
             if (ct.isContourBtnOn)
@@ -140,7 +140,7 @@ namespace AgOpenGPS
                 }
 
                 //position of panel
-                flp1.Top = this.Height - 120 - (btnCount*75);
+                flp1.Top = this.Height - 120 - (btnCount * 75);
                 flp1.Left = this.Width - 120 - flp1.Width;
                 trackMethodPanelCounter = 4;
             }
@@ -596,7 +596,7 @@ namespace AgOpenGPS
 
                     Log.EventWriter("** Opened **  " + currentFieldDirectory + "   "
                         + (DateTime.Now.ToString("f", CultureInfo.InvariantCulture)));
-                    
+
                     Settings.Default.setF_CurrentDir = currentFieldDirectory;
                     Settings.Default.Save();
                 }
@@ -754,13 +754,13 @@ namespace AgOpenGPS
 
         public void GetHeadland()
         {
-            using (var form = new FormHeadLine (this))
+            using (var form = new FormHeadLine(this))
             {
                 form.ShowDialog(this);
             }
 
             bnd.isHeadlandOn = (bnd.bndList.Count > 0 && bnd.bndList[0].hdLine.Count > 0);
-            
+
             PanelsAndOGLSize();
             PanelUpdateRightAndBottom();
             SetZoom();
@@ -854,7 +854,7 @@ namespace AgOpenGPS
                 btnPathGoStop.Image = Properties.Resources.boundaryPlay;
                 btnPathRecordStop.Enabled = true;
                 btnPickPath.Enabled = true;
-                btnResumePath.Enabled = true;   
+                btnResumePath.Enabled = true;
                 return;
             }
 
@@ -891,7 +891,7 @@ namespace AgOpenGPS
                 using (var form = new FormRecordName(this))
                 {
                     form.ShowDialog(this);
-                    if(form.DialogResult == DialogResult.OK) 
+                    if (form.DialogResult == DialogResult.OK)
                     {
                         String filename = form.filename + ".rec";
                         FileSaveRecPath();
@@ -901,7 +901,7 @@ namespace AgOpenGPS
                     {
                         recPath.recList.Clear();
                     }
-                }                
+                }
             }
             else if (isJobStarted)
             {
@@ -925,7 +925,7 @@ namespace AgOpenGPS
             else if (recPath.resumeState == 1)
             {
                 recPath.resumeState++;
-                btnResumePath.Image = Properties.Resources.pathResumeClose; 
+                btnResumePath.Image = Properties.Resources.pathResumeClose;
                 TimedMessageBox(1500, "Resume Style", "Closest Point");
             }
             else
@@ -1024,7 +1024,7 @@ namespace AgOpenGPS
         private void toolStripDropDownButtonDistance_Click(object sender, EventArgs e)
         {
             fd.distanceUser = 0;
-        }          
+        }
         private void btnNavigationSettings_Click(object sender, EventArgs e)
         {
             //buttonPanelCounter = 0;
@@ -1158,7 +1158,7 @@ namespace AgOpenGPS
                 flagNumberPicked = 1;
                 Form form = new FormFlags(this);
                 form.Show(this);
-            }            
+            }
         }
         private void btnFlag_Click(object sender, EventArgs e)
         {
@@ -1166,7 +1166,7 @@ namespace AgOpenGPS
             CFlag flagPt = new CFlag(
                 AppModel.CurrentLatLon.Latitude,
                 AppModel.CurrentLatLon.Longitude,
-                pn.fix.easting, pn.fix.northing, 
+                pn.fix.easting, pn.fix.northing,
                 fixHeading, flagColor, nextflag, nextflag.ToString());
             flagPts.Add(flagPt);
             FileSaveFlags();
@@ -1194,12 +1194,12 @@ namespace AgOpenGPS
 
         private void btnAdjRight_Click(object sender, EventArgs e)
         {
-            trk.NudgeTrack(Properties.Settings.Default.setAS_snapDistance*0.01);
+            trk.NudgeTrack(Properties.Settings.Default.setAS_snapDistance * 0.01);
         }
 
         private void btnAdjLeft_Click(object sender, EventArgs e)
         {
-            trk.NudgeTrack(-Properties.Settings.Default.setAS_snapDistance*0.01);
+            trk.NudgeTrack(-Properties.Settings.Default.setAS_snapDistance * 0.01);
         }
 
         #endregion
@@ -1232,7 +1232,7 @@ namespace AgOpenGPS
 
             form.Top = this.Top + this.Height / 2 - GPSDataWindowTopOffset;
             if (isPanelBottomHidden)
-                form.Left = this.Left + 5 ;
+                form.Left = this.Left + 5;
             else
                 form.Left = this.Left + GPSDataWindowLeft + 5;
 
@@ -1244,7 +1244,7 @@ namespace AgOpenGPS
         }
 
         private void btnGPSData_Click(object sender, EventArgs e)
-        {            
+        {
             Form f = Application.OpenForms["FormGPSData"];
 
             if (f != null)
@@ -1270,7 +1270,7 @@ namespace AgOpenGPS
             if (isPanelBottomHidden)
                 form.Left = this.Left + 5;
             else
-                form.Left = this.Left + GPSDataWindowLeft + 5; 
+                form.Left = this.Left + GPSDataWindowLeft + 5;
 
             Form ff = Application.OpenForms["FormGPS"];
             ff.Focus();
@@ -1472,7 +1472,7 @@ namespace AgOpenGPS
 
         private void helpMenuItem_Click(object sender, EventArgs e)
         {
-             using (var form = new Form_Help(this))
+            using (var form = new Form_Help(this))
             {
                 form.ShowDialog(this);
             }
@@ -1606,7 +1606,7 @@ namespace AgOpenGPS
         private void menuLanguageTurkish_Click(object sender, EventArgs e)
         {
             SetLanguage("tr");
-        }          
+        }
         private void menuLanguageFinnish_Click(object sender, EventArgs e)
         {
             SetLanguage("fi");
@@ -1742,7 +1742,7 @@ namespace AgOpenGPS
 
                 case "sr":
                     menuLanguageSerbie.Checked = true;
-                    break;  
+                    break;
 
                 case "no":
                     menuLanguageNorsk.Checked = true;
@@ -1798,14 +1798,14 @@ namespace AgOpenGPS
         private void btnAutoTrack_Click(object sender, EventArgs e)
         {
             trk.isAutoTrack = !trk.isAutoTrack;
-            btnAutoTrack.Image = trk.isAutoTrack ? Resources.AutoTrack : Resources.AutoTrackOff;            
+            btnAutoTrack.Image = trk.isAutoTrack ? Resources.AutoTrack : Resources.AutoTrackOff;
         }
         private void btnResetToolHeading_Click(object sender, EventArgs e)
         {
             tankPos.heading = fixHeading;
             tankPos.easting = hitchPos.easting + (Math.Sin(tankPos.heading) * (tool.tankTrailingHitchLength));
             tankPos.northing = hitchPos.northing + (Math.Cos(tankPos.heading) * (tool.tankTrailingHitchLength));
-            
+
             toolPivotPos.heading = tankPos.heading;
             toolPivotPos.easting = tankPos.easting + (Math.Sin(toolPivotPos.heading) * (tool.trailingHitchLength));
             toolPivotPos.northing = tankPos.northing + (Math.Cos(toolPivotPos.heading) * (tool.trailingHitchLength));
@@ -1866,7 +1866,7 @@ namespace AgOpenGPS
         {
             yt.rowSkipsWidth = Properties.Settings.Default.set_youSkipWidth;
             switch (yt.skipMode)
-                            {
+            {
                 case SkipMode.Normal:
                     btnYouSkipEnable.Image = Resources.YouSkipOn;
                     yt.skipMode = SkipMode.Alternative;
@@ -2003,7 +2003,7 @@ namespace AgOpenGPS
                 else TimedMessageBox(2000, gStr.gsCurveNotOn, gStr.gsTurnABCurveOn);
             }
         }
-         private void deleteContourPathsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void deleteContourPathsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             //FileCreateContour();
             ct.stripList?.Clear();
@@ -2023,7 +2023,7 @@ namespace AgOpenGPS
                         MessageBoxButtons.YesNo
                     );
 
-                    if (result3 == DialogResult.OK) 
+                    if (result3 == DialogResult.OK)
                     {
                         //FileCreateElevation();
 
@@ -2084,7 +2084,7 @@ namespace AgOpenGPS
                 }
                 else
                 {
-                   TimedMessageBox(1500, "Sections are on", "Turn Auto or Manual Off First");
+                    TimedMessageBox(1500, "Sections are on", "Turn Auto or Manual Off First");
                 }
             }
         }
@@ -2117,7 +2117,7 @@ namespace AgOpenGPS
             //
             Form formG = new FormGraphSteer(this);
             formG.Show(this);
-        }               
+        }
         private void xTEChartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             //check if window already exists
@@ -2210,7 +2210,7 @@ namespace AgOpenGPS
         private void btnGrid_Click(object sender, EventArgs e)
         {
             var form = new FormGrid(this);
-                form.Show(this);
+            form.Show(this);
             navPanelCounter = 0;
         }
         private void btnBrightnessUp_Click(object sender, EventArgs e)
@@ -2277,9 +2277,8 @@ namespace AgOpenGPS
                 sim.stepDistance = 0;
                 return;
             }
-            if (sim.stepDistance < 0.2 ) sim.stepDistance += 0.02;
-            else 
-                sim.stepDistance *= 1.15;
+            if (sim.stepDistance < 0.2) sim.stepDistance += 0.02;
+            else sim.stepDistance *= 1.15;
 
             if (sim.stepDistance > 7.5) sim.stepDistance = 7.5;
         }

--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -204,7 +204,7 @@ namespace AgOpenGPS
                             break;
                     }
 
-                    if (tram.displayMode == 0) 
+                    if (tram.displayMode == 0)
                         tram.isRightManualOn = tram.isLeftManualOn = false;
                 }
                 else
@@ -292,7 +292,7 @@ namespace AgOpenGPS
                         break;
                     case 2:
                         btnGPSData.BackColor = Color.Yellow;
-                        break;                               
+                        break;
                     default:
                         btnGPSData.BackColor = Color.Red;
                         break;
@@ -332,7 +332,7 @@ namespace AgOpenGPS
                 //the main formgps windows
 
                 //Make sure it is off when it should
-                if (!ct.isContourBtnOn && trk.idx == -1 && isBtnAutoSteerOn) 
+                if (!ct.isContourBtnOn && trk.idx == -1 && isBtnAutoSteerOn)
                 {
                     btnAutoSteer.PerformClick();
                     TimedMessageBox(2000, gStr.gsGuidanceStopped, gStr.gsNoGuidanceLines);
@@ -827,7 +827,7 @@ namespace AgOpenGPS
                 if (trk.idx > -1 && trk.gArr.Count > 0 && !ct.isContourBtnOn)
                 {
                     lblNumCu.Visible = true;
-                    lblNumCu.Text = (trk.idx+1).ToString() + "/" + trk.gArr.Count.ToString();
+                    lblNumCu.Text = (trk.idx + 1).ToString() + "/" + trk.gArr.Count.ToString();
                 }
                 else
                 {
@@ -1133,35 +1133,35 @@ namespace AgOpenGPS
 
             if (heading > 337.5 || heading < 22.5)
             {
-                return (" " +  gStr.gsNorth + " ");
+                return (" " + gStr.gsNorth + " ");
             }
             if (heading > 22.5 && heading < 67.5)
             {
-                return (" " +  gStr.gsN_East + " ");
+                return (" " + gStr.gsN_East + " ");
             }
             if (heading > 67.5 && heading < 111.5)
             {
-                return (" " +  gStr.gsEast + " ");
+                return (" " + gStr.gsEast + " ");
             }
             if (heading > 111.5 && heading < 157.5)
             {
-                return (" " +  gStr.gsS_East + " ");
+                return (" " + gStr.gsS_East + " ");
             }
             if (heading > 157.5 && heading < 202.5)
             {
-                return (" " +  gStr.gsSouth + " ");
+                return (" " + gStr.gsSouth + " ");
             }
             if (heading > 202.5 && heading < 247.5)
             {
-                return (" " +  gStr.gsS_West + " ");
+                return (" " + gStr.gsS_West + " ");
             }
             if (heading > 247.5 && heading < 292.5)
             {
-                return (" " +  gStr.gsWest + " ");
+                return (" " + gStr.gsWest + " ");
             }
             if (heading > 292.5 && heading < 337.5)
             {
-                return (" " +  gStr.gsN_West + " ");
+                return (" " + gStr.gsN_West + " ");
             }
             return (" ?? ");
         }
@@ -1311,8 +1311,8 @@ namespace AgOpenGPS
                             Form form = new FormPan(this);
                             form.Show(this);
 
-                            form.Top = this.Height/3 + this.Top;
-                            form.Left = this.Width -400 + this.Left;
+                            form.Top = this.Height / 3 + this.Top;
+                            form.Left = this.Width - 400 + this.Left;
                         }
 
                         if (isJobStarted)
@@ -1329,7 +1329,7 @@ namespace AgOpenGPS
                     //tram override
                     int bottomSide = oglMain.Height / 5 + 25;
 
-                    if (tool.isDisplayTramControl && (point.Y > (bottomSide-50) && point.Y < bottomSide))
+                    if (tool.isDisplayTramControl && (point.Y > (bottomSide - 50) && point.Y < bottomSide))
                     {
                         if (point.X > centerX - 100 && point.X < centerX - 20)
                         {
@@ -1501,7 +1501,7 @@ namespace AgOpenGPS
             }
         }
         public string SetSteerAngle { get { return ((double)(guidanceLineSteerAngle) * 0.01).ToString("N1"); } }
-        public string ActualSteerAngle { get { return ((mc.actualSteerAngleDegrees) ).ToString("N1") ; } }
+        public string ActualSteerAngle { get { return (mc.actualSteerAngleDegrees).ToString("N1"); } }
 
         //Metric and Imperial Properties
         public string SpeedMPH
@@ -1511,7 +1511,7 @@ namespace AgOpenGPS
                 if (avgSpeed > 2)
                     return (avgSpeed * 0.62137).ToString("N1");
                 else
-                    return(avgSpeed * 0.62137).ToString("N2");
+                    return (avgSpeed * 0.62137).ToString("N2");
             }
         }
         public string SpeedKPH
@@ -1525,13 +1525,13 @@ namespace AgOpenGPS
             }
         }
 
-        public string Altitude { get { return Convert.ToString(Math.Round(pn.altitude,2)); } }
-        public string AltitudeFeet { get { return Convert.ToString((Math.Round((pn.altitude * 3.28084),1))); } }
+        public string Altitude { get { return Convert.ToString(Math.Round(pn.altitude, 2)); } }
+        public string AltitudeFeet { get { return Convert.ToString((Math.Round((pn.altitude * 3.28084), 1))); } }
         public string DistPivotM
         {
             get
             {
-                if (distancePivotToTurnLine > 0 )
+                if (distancePivotToTurnLine > 0)
                     return ((int)(distancePivotToTurnLine)) + " m";
                 else return "--";
             }
@@ -1540,7 +1540,7 @@ namespace AgOpenGPS
         {
             get
             {
-                if (distancePivotToTurnLine > 0 ) return (((int)(glm.m2ft * (distancePivotToTurnLine))) + " ft");
+                if (distancePivotToTurnLine > 0) return (((int)(glm.m2ft * (distancePivotToTurnLine))) + " ft");
                 else return "--";
             }
         }

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -287,7 +287,7 @@ namespace AgOpenGPS
                                     if (isDay) GL.Color4(tool.secColors[j].R, tool.secColors[j].G, tool.secColors[j].B, (byte)152);
                                     else GL.Color4(tool.secColors[j].R, tool.secColors[j].G, tool.secColors[j].B, (byte)(76));
                                 }
-                                patchCount = triStrip[j].patchList.Count-1;
+                                patchCount = triStrip[j].patchList.Count - 1;
 
                                 if (patchCount > -1)
                                 {
@@ -441,7 +441,7 @@ namespace AgOpenGPS
                         {
                             PointStyle backgroundPointStyle = new PointStyle(12.0f, Colors.Black);
                             PointStyle foregroundPointStyle = new PointStyle(6.0f, Colors.GoalPointColor);
-                            PointStyle[] pointStyles = { backgroundPointStyle, foregroundPointStyle};
+                            PointStyle[] pointStyles = { backgroundPointStyle, foregroundPointStyle };
                             vec2 goalPoint = trk.gArr[trk.idx].mode == TrackMode.AB ? ABLine.goalPointAB : curve.goalPointCu;
                             GLW.DrawPointLayered(pointStyles, goalPoint.easting, goalPoint.northing, 0.0);
                         }
@@ -634,7 +634,7 @@ namespace AgOpenGPS
                 deadCam += 5;
 
                 GL.Color4(1.25f, 1.25f, 1.275f, 0.75);
-                ScreenTextures.NoGps.DrawCenteredAroundOrigin(new XyDelta(2.5, - 2.5));
+                ScreenTextures.NoGps.DrawCenteredAroundOrigin(new XyDelta(2.5, -2.5));
 
                 // 2D Ortho ---------------------------------------////////-------------------------------------------------
 
@@ -2308,7 +2308,7 @@ namespace AgOpenGPS
 
                 //hide show bottom menu
                 int hite = oglMain.Height - 30;
-                XyCoord menuShowHideCoord = new XyCoord(center, hite -32);
+                XyCoord menuShowHideCoord = new XyCoord(center, hite - 32);
                 ScreenTextures.MenuShowHide.Draw(menuShowHideCoord, menuShowHideCoord + sizeDelta);
 
                 center += 50;
@@ -2453,7 +2453,7 @@ namespace AgOpenGPS
             else GL.Color3(0.952f, 0.0f, 0.0f);
 
             GL.Rotate(angle, 0, 0, 1);
-            ScreenTextures.SpeedoNeedle.DrawCenteredAroundOrigin(new XyDelta(48 ,48));
+            ScreenTextures.SpeedoNeedle.DrawCenteredAroundOrigin(new XyDelta(48, 48));
 
             GL.PopMatrix();
         }

--- a/SourceCode/GPS/Forms/PGN.Designer.cs
+++ b/SourceCode/GPS/Forms/PGN.Designer.cs
@@ -17,7 +17,6 @@ namespace AgOpenGPS
 
             public void LoadLatitudeLongitude(double lat, double lon)
             {
-                
                 int encodedAngle = (int)(lat * (0x7FFFFFFF / 90.0));
                 //double angle = (encodedAngle / (0x7FFFFFFF / 90.0));
 
@@ -44,7 +43,7 @@ namespace AgOpenGPS
             public int status = 7;
             public int steerAngleLo = 8;
             public int steerAngleHi = 9;
-            public int lineDistance  = 10;
+            public int lineDistance = 10;
             public int sc1to8 = 11;
             public int sc9to16 = 12;
 
@@ -98,7 +97,7 @@ namespace AgOpenGPS
                 pgn[lowPWM] = Properties.Settings.Default.setAS_lowSteerPWM;
                 pgn[minPWM] = Properties.Settings.Default.setAS_minSteerPWM;
                 pgn[countsPerDegree] = Properties.Settings.Default.setAS_countsPerDegree;
-                pgn[wasOffsetHi] = unchecked((byte)(Properties.Settings.Default.setAS_wasOffset >> 8));;
+                pgn[wasOffsetHi] = unchecked((byte)(Properties.Settings.Default.setAS_wasOffset >> 8));
                 pgn[wasOffsetLo] = unchecked((byte)(Properties.Settings.Default.setAS_wasOffset));
                 pgn[ackerman] = Properties.Settings.Default.setAS_ackerman;
             }
@@ -121,7 +120,7 @@ namespace AgOpenGPS
             public int maxPulse = 6;
             public int minSpeed = 7;
             public int set1 = 8;
-            public int angVel  = 9;
+            public int angVel = 9;
             //public int  = 10;
             //public int  = 11;
             //public int  = 12;
@@ -175,7 +174,7 @@ namespace AgOpenGPS
             public int sc9to16 = 6;
             public int sc17to24 = 7;
             public int sc25to32 = 8;
-            public int sc33to40 = 9; 
+            public int sc33to40 = 9;
             public int sc41to48 = 10;
             public int sc49to56 = 11;
             public int sc57to64 = 12;
@@ -206,7 +205,7 @@ namespace AgOpenGPS
             public int user1 = 9;
             public int user2 = 10;
             public int user3 = 11;
-            public int user4  = 12;
+            public int user4 = 12;
 
             // PGN  - 127.239 0x7FEF
             int crc = 0;
@@ -346,16 +345,16 @@ namespace AgOpenGPS
                                         0, 0xCC };
 
             //where in the pgn is which pin
-            public int sec0Lo  = 5;
-            public int sec1Lo  = 7;
-            public int sec2Lo  = 9;
-            public int sec3Lo  = 11;
-            public int sec4Lo  = 13;
-            public int sec5Lo  = 15;
-            public int sec6Lo  = 17;
-            public int sec7Lo  = 19;
-            public int sec8Lo  = 21;
-            public int sec9Lo  = 23;
+            public int sec0Lo = 5;
+            public int sec1Lo = 7;
+            public int sec2Lo = 9;
+            public int sec3Lo = 11;
+            public int sec4Lo = 13;
+            public int sec5Lo = 15;
+            public int sec6Lo = 17;
+            public int sec7Lo = 19;
+            public int sec8Lo = 21;
+            public int sec9Lo = 23;
             public int sec10Lo = 25;
             public int sec11Lo = 27;
             public int sec12Lo = 29;
@@ -363,16 +362,16 @@ namespace AgOpenGPS
             public int sec14Lo = 33;
             public int sec15Lo = 35;
 
-            public int sec0Hi  = 6;
-            public int sec1Hi  = 8;
-            public int sec2Hi  = 10;
-            public int sec3Hi  = 12;
-            public int sec4Hi  = 14;
-            public int sec5Hi  = 16;
-            public int sec6Hi  = 18;
-            public int sec7Hi  = 20;
-            public int sec8Hi  = 22;
-            public int sec9Hi  = 24;
+            public int sec0Hi = 6;
+            public int sec1Hi = 8;
+            public int sec2Hi = 10;
+            public int sec3Hi = 12;
+            public int sec4Hi = 14;
+            public int sec5Hi = 16;
+            public int sec6Hi = 18;
+            public int sec7Hi = 20;
+            public int sec8Hi = 22;
+            public int sec9Hi = 24;
             public int sec10Hi = 26;
             public int sec11Hi = 28;
             public int sec12Hi = 30;
@@ -406,7 +405,7 @@ namespace AgOpenGPS
                 pgn[sec2Hi] = 0;
                 pgn[sec3Hi] = 0;
                 pgn[sec4Hi] = 0;
-                pgn[sec5Hi] = 0; 
+                pgn[sec5Hi] = 0;
                 pgn[sec6Hi] = 0;
                 pgn[sec7Hi] = 0;
                 pgn[sec8Hi] = 0;
@@ -418,7 +417,7 @@ namespace AgOpenGPS
                 pgn[sec14Hi] = 0;
                 pgn[sec15Hi] = 0;
 
-                pgn[numSections] = 0;   
+                pgn[numSections] = 0;
             }
 
             public void Reset()
@@ -498,4 +497,3 @@ namespace AgOpenGPS
 
     }
 }
-    

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -110,7 +110,7 @@ namespace AgOpenGPS
 
                             //write out the mode
                             writer.WriteLine(hdl.tracksArr[i].mode.ToString(CultureInfo.InvariantCulture));
-                            
+
                             //write out the A_Point index
                             writer.WriteLine(hdl.tracksArr[i].a_point.ToString(CultureInfo.InvariantCulture));
 
@@ -560,7 +560,7 @@ namespace AgOpenGPS
                             line = reader.ReadLine();
                             int numPoints = int.Parse(line);
 
-                            if (numPoints > 1) 
+                            if (numPoints > 1)
                             {
                                 trk.gArr[trk.gArr.Count - 1].curvePts?.Clear();
 
@@ -576,7 +576,7 @@ namespace AgOpenGPS
 
                                 trk.gArr[trk.gArr.Count - 1].ptB.easting = trk.gArr[trk.gArr.Count - 1].curvePts[0].easting;
                                 trk.gArr[trk.gArr.Count - 1].ptB.northing = trk.gArr[trk.gArr.Count - 1].curvePts[0].northing;
-                                
+
                                 trk.gArr[trk.gArr.Count - 1].ptB.easting = trk.gArr[trk.gArr.Count - 1].curvePts[trk.gArr[trk.gArr.Count - 1].curvePts.Count - 1].easting;
                                 trk.gArr[trk.gArr.Count - 1].ptB.northing = trk.gArr[trk.gArr.Count - 1].curvePts[trk.gArr[trk.gArr.Count - 1].curvePts.Count - 1].northing;
                             }
@@ -592,7 +592,7 @@ namespace AgOpenGPS
                     catch (Exception er)
                     {
                         TimedMessageBox(2000, gStr.gsCurveLineFileIsCorrupt, gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("Load Curve Line" + er.ToString());
                     }
                 }
@@ -692,7 +692,7 @@ namespace AgOpenGPS
                     catch (Exception er)
                     {
                         TimedMessageBox(2000, "AB Line Corrupt", "Please delete it!!!");
-                        
+
                         Log.EventWriter("FieldOpen, Loading ABLine, Corrupt ABLine File" + er);
                     }
                 }
@@ -810,13 +810,12 @@ namespace AgOpenGPS
 
             FileLoadTracks();
 
-            
             //section patches
             fileAndDirectory = Path.Combine(RegistrySettings.fieldsDirectory, currentFieldDirectory, "Sections.txt");
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingSectionFile, gStr.gsButFieldIsLoaded);
-                
+
                 //return;
             }
             else
@@ -878,7 +877,6 @@ namespace AgOpenGPS
                         Log.EventWriter("Section file" + e.ToString());
 
                         TimedMessageBox(2000, "Section File is Corrupt", gStr.gsButFieldIsLoaded);
-                        
                     }
 
                 }
@@ -899,10 +897,9 @@ namespace AgOpenGPS
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingContourFile, gStr.gsButFieldIsLoaded);
-                
+
                 //return;
             }
-            
             //Points in Patch followed by easting, heading, northing, altitude
             else
             {
@@ -941,7 +938,6 @@ namespace AgOpenGPS
                         Log.EventWriter("Loading Contour file" + e.ToString());
 
                         TimedMessageBox(2000, gStr.gsContourFileIsCorrupt, gStr.gsButFieldIsLoaded);
-                        
                     }
                 }
             }
@@ -954,7 +950,6 @@ namespace AgOpenGPS
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingFlagsFile, gStr.gsButFieldIsLoaded);
-                
             }
 
             else
@@ -1018,7 +1013,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, gStr.gsFlagFileIsCorrupt, gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("FieldOpen, Loading Flags, Corrupt Flag File" + e.ToString());
                     }
                 }
@@ -1030,7 +1025,6 @@ namespace AgOpenGPS
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingBoundaryFile, gStr.gsButFieldIsLoaded);
-                
             }
             else
             {
@@ -1113,7 +1107,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, gStr.gsBoundaryLineFilesAreCorrupt, gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("Load Boundary Line" + e.ToString());
                     }
                 }
@@ -1165,7 +1159,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, "Headland File is Corrupt", "But Field is Loaded");
-                        
+
                         Log.EventWriter("Load Headland Loop" + e.ToString());
                     }
                 }
@@ -1186,7 +1180,7 @@ namespace AgOpenGPS
             }
 
             int sett = Properties.Settings.Default.setArdMac_setting0;
-            btnHydLift.Visible = (((sett & 2) == 2) && bnd.isHeadlandOn); 
+            btnHydLift.Visible = (((sett & 2) == 2) && bnd.isHeadlandOn);
 
             //trams ---------------------------------------------------------------------------------
             fileAndDirectory = Path.Combine(RegistrySettings.fieldsDirectory, currentFieldDirectory, "Tram.txt");
@@ -1280,7 +1274,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, "Tram is corrupt", gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("Load Boundary Line" + e.ToString());
                     }
                 }
@@ -1333,7 +1327,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, gStr.gsRecordedPathFileIsCorrupt, gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("Load Recorded Path" + e.ToString());
                     }
                 }
@@ -1504,8 +1498,8 @@ namespace AgOpenGPS
                         writer.WriteLine(count2.ToString(CultureInfo.InvariantCulture));
 
                         for (int i = 0; i < count2; i++)
-                            writer.WriteLine((Math.Round(triList[i].easting,3)).ToString(CultureInfo.InvariantCulture) +
-                                "," + (Math.Round(triList[i].northing,3)).ToString(CultureInfo.InvariantCulture) +
+                            writer.WriteLine((Math.Round(triList[i].easting, 3)).ToString(CultureInfo.InvariantCulture) +
+                                "," + (Math.Round(triList[i].northing, 3)).ToString(CultureInfo.InvariantCulture) +
                                  "," + (Math.Round(triList[i].heading, 3)).ToString(CultureInfo.InvariantCulture));
                     }
                 }
@@ -1627,7 +1621,7 @@ namespace AgOpenGPS
                         for (int i = 0; i < count2; i++)
                         {
                             writer.WriteLine(Math.Round((triList[i].easting), 3).ToString(CultureInfo.InvariantCulture) + "," +
-                                Math.Round(triList[i].northing, 3).ToString(CultureInfo.InvariantCulture)+ "," +
+                                Math.Round(triList[i].northing, 3).ToString(CultureInfo.InvariantCulture) + "," +
                                 Math.Round(triList[i].heading, 3).ToString(CultureInfo.InvariantCulture));
                         }
                     }
@@ -1660,9 +1654,9 @@ namespace AgOpenGPS
                     if (bnd.bndList[i].fenceLine.Count > 0)
                     {
                         for (int j = 0; j < bnd.bndList[i].fenceLine.Count; j++)
-                            writer.WriteLine(Math.Round(bnd.bndList[i].fenceLine[j].easting,3).ToString(CultureInfo.InvariantCulture) + "," +
+                            writer.WriteLine(Math.Round(bnd.bndList[i].fenceLine[j].easting, 3).ToString(CultureInfo.InvariantCulture) + "," +
                                                 Math.Round(bnd.bndList[i].fenceLine[j].northing, 3).ToString(CultureInfo.InvariantCulture) + "," +
-                                                    Math.Round(bnd.bndList[i].fenceLine[j].heading,5).ToString(CultureInfo.InvariantCulture));
+                                                    Math.Round(bnd.bndList[i].fenceLine[j].heading, 5).ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -1850,7 +1844,7 @@ namespace AgOpenGPS
                     catch (Exception e)
                     {
                         TimedMessageBox(2000, gStr.gsRecordedPathFileIsCorrupt, gStr.gsButFieldIsLoaded);
-                        
+
                         Log.EventWriter("Load Recorded Path" + e.ToString());
                     }
                 }
@@ -1992,20 +1986,20 @@ namespace AgOpenGPS
 
                 writer.WriteLine(@"<Document>");
 
-                    writer.WriteLine(@"  <Placemark>                                  ");
-                    writer.WriteLine(@"<Style> <IconStyle>");
-                    if (flagPts[flagNumber - 1].color == 0)  //red - xbgr
-                        writer.WriteLine(@"<color>ff4400ff</color>");
-                    if (flagPts[flagNumber - 1].color == 1)  //grn - xbgr
-                        writer.WriteLine(@"<color>ff44ff00</color>");
-                    if (flagPts[flagNumber - 1].color == 2)  //yel - xbgr
-                        writer.WriteLine(@"<color>ff44ffff</color>");
-                    writer.WriteLine(@"</IconStyle> </Style>");
-                    writer.WriteLine(@" <name> " + flagNumber.ToString(CultureInfo.InvariantCulture) + @"</name>");
-                    writer.WriteLine(@"<Point><coordinates> " +
-                                    flagPts[flagNumber-1].longitude.ToString(CultureInfo.InvariantCulture) + "," + flagPts[flagNumber-1].latitude.ToString(CultureInfo.InvariantCulture) + ",0" +
-                                    @"</coordinates> </Point> ");
-                    writer.WriteLine(@"  </Placemark>                                 ");
+                writer.WriteLine(@"  <Placemark>                                  ");
+                writer.WriteLine(@"<Style> <IconStyle>");
+                if (flagPts[flagNumber - 1].color == 0)  //red - xbgr
+                    writer.WriteLine(@"<color>ff4400ff</color>");
+                if (flagPts[flagNumber - 1].color == 1)  //grn - xbgr
+                    writer.WriteLine(@"<color>ff44ff00</color>");
+                if (flagPts[flagNumber - 1].color == 2)  //yel - xbgr
+                    writer.WriteLine(@"<color>ff44ffff</color>");
+                writer.WriteLine(@"</IconStyle> </Style>");
+                writer.WriteLine(@" <name> " + flagNumber.ToString(CultureInfo.InvariantCulture) + @"</name>");
+                writer.WriteLine(@"<Point><coordinates> " +
+                                flagPts[flagNumber - 1].longitude.ToString(CultureInfo.InvariantCulture) + "," + flagPts[flagNumber - 1].latitude.ToString(CultureInfo.InvariantCulture) + ",0" +
+                                @"</coordinates> </Point> ");
+                writer.WriteLine(@"  </Placemark>                                 ");
                 writer.WriteLine(@"</Document>");
                 writer.WriteLine(@"</kml>                                         ");
 
@@ -2038,7 +2032,7 @@ namespace AgOpenGPS
                 writer.WriteLine(@"</IconStyle> </Style>");
                 writer.WriteLine(@" <name> Your Current Position </name>");
                 writer.WriteLine(@"<Point><coordinates> "
-                    + currentLatLon.Longitude.ToString(CultureInfo.InvariantCulture)+ ","
+                    + currentLatLon.Longitude.ToString(CultureInfo.InvariantCulture) + ","
                     + currentLatLon.Latitude.ToString(CultureInfo.InvariantCulture) + ",0"
                     + @"</coordinates> </Point> ");
                 writer.WriteLine(@"  </Placemark>                                 ");
@@ -2236,7 +2230,7 @@ namespace AgOpenGPS
             for (int i = 0; i < flagPts.Count; i++)
             {
                 kml.WriteStartElement("Placemark");
-                kml.WriteElementString("name", "Flag_"+ i.ToString());
+                kml.WriteElementString("name", "Flag_" + i.ToString());
 
                 kml.WriteStartElement("Style");
                 kml.WriteStartElement("IconStyle");
@@ -2294,7 +2288,7 @@ namespace AgOpenGPS
                             kml.WriteElementString("color", collor);
                             //kml.WriteElementString("width", "6");
                             kml.WriteEndElement(); // <LineStyle>
-                            
+
                             kml.WriteStartElement("PolyStyle");
                             kml.WriteElementString("color", collor);
                             kml.WriteEndElement(); // <PloyStyle>
@@ -2304,7 +2298,7 @@ namespace AgOpenGPS
                             kml.WriteElementString("tessellate", "1");
                             kml.WriteStartElement("outerBoundaryIs");
                             kml.WriteStartElement("LinearRing");
-                            
+
                             //coords
                             kml.WriteStartElement("coordinates");
                             secPts = "";
@@ -2350,7 +2344,7 @@ namespace AgOpenGPS
         {
             StringBuilder sb = new StringBuilder();
 
-            foreach(vec3 v3 in bnd.bndList[bndNum].fenceLine)
+            foreach (vec3 v3 in bnd.bndList[bndNum].fenceLine)
             {
                 sb.Append(GetGeoCoordToWgs84_KML(v3.ToGeoCoord()));
             }
@@ -2380,7 +2374,7 @@ namespace AgOpenGPS
             kml.WriteStartElement("kml", "http://www.opengis.net/kml/2.2");
             kml.WriteStartElement("Document");
 
-            foreach(String dir in Directory.EnumerateDirectories(directoryName).OrderBy(d => new DirectoryInfo(d).Name).ToArray())
+            foreach (String dir in Directory.EnumerateDirectories(directoryName).OrderBy(d => new DirectoryInfo(d).Name).ToArray())
             //loop
             {
                 if (!File.Exists(Path.Combine(dir, "Field.kml"))) continue;
@@ -2391,10 +2385,10 @@ namespace AgOpenGPS
 
                 var lines = File.ReadAllLines(Path.Combine(dir, "Field.kml"));
                 LinkedList<string> linebuffer = new LinkedList<string>();
-                for( var i = 3; i < lines.Length-2; i++)  //We want to skip the first 3 and last 2 lines
+                for (var i = 3; i < lines.Length - 2; i++)  //We want to skip the first 3 and last 2 lines
                 {
                     linebuffer.AddLast(lines[i]);
-                    if(linebuffer.Count > 2)
+                    if (linebuffer.Count > 2)
                     {
                         kml.WriteRaw("   ");
                         kml.WriteRaw(Environment.NewLine);
@@ -2412,7 +2406,7 @@ namespace AgOpenGPS
                 kml.WriteRaw(Environment.NewLine);
 
                 kml.WriteEndElement(); // <Folder>
-                kml.WriteComment("End of " +directoryName);
+                kml.WriteComment("End of " + directoryName);
             }
 
             //end of document

--- a/SourceCode/GPS/Forms/Sections.Designer.cs
+++ b/SourceCode/GPS/Forms/Sections.Designer.cs
@@ -311,7 +311,7 @@ namespace AgOpenGPS
 
             //if (tool.zones == 0) return;
             int oglButtonWidth = oglMain.Width * 3 / 4;
-            int buttonWidth = Math.Min(oglButtonWidth / tool.zones,buttonMaxWidth);
+            int buttonWidth = Math.Min(oglButtonWidth / tool.zones, buttonMaxWidth);
             Size size = new System.Drawing.Size(buttonWidth, buttonHeight);
 
             for (int i = 1; i <= 8; i++)
@@ -323,7 +323,8 @@ namespace AgOpenGPS
                 if (isJobStarted)
                 {
                     btn.BackColor = Color.Red;
-                } else
+                }
+                else
                 {
                     btn.BackColor = Color.Silver;
                 }

--- a/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigData.Designer.cs
@@ -15,7 +15,7 @@ namespace AgOpenGPS
             if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Fix") rbtnHeadingFix.Checked = true;
             //else if (Properties.Settings.Default.setGPS_headingFromWhichSource == "VTG") rbtnHeadingGPS.Checked = true;
             else if (Properties.Settings.Default.setGPS_headingFromWhichSource == "Dual") rbtnHeadingHDT.Checked = true;
-            
+
             if (rbtnHeadingHDT.Checked)
             {
                 if (Properties.Settings.Default.setAutoSwitchDualFixOn)
@@ -23,7 +23,8 @@ namespace AgOpenGPS
                     rbtnHeadingFix.Enabled = false;
                     labelGboxSingle.Enabled = true;
                     labelGboxDual.Enabled = true;
-                } else
+                }
+                else
                 {
                     labelGboxSingle.Enabled = false;
                     labelGboxDual.Enabled = true;
@@ -80,7 +81,8 @@ namespace AgOpenGPS
                 hsbarFusion.Enabled = false;
             }
 
-            if (cboxIsAutoSwitchDualFixOn.Checked) { 
+            if (cboxIsAutoSwitchDualFixOn.Checked)
+            {
                 hsbarFusion.Enabled = true;
             }
 
@@ -130,7 +132,7 @@ namespace AgOpenGPS
             {
                 rbtnHeadingFix.Enabled = true;
                 labelGboxSingle.Enabled = true;
-                labelGboxDual.Enabled= false;
+                labelGboxDual.Enabled = false;
             }
         }
 
@@ -152,7 +154,7 @@ namespace AgOpenGPS
             }
         }
 
-         private void nudDualReverseDistance_Click(object sender, EventArgs e)
+        private void nudDualReverseDistance_Click(object sender, EventArgs e)
         {
             if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
@@ -191,8 +193,8 @@ namespace AgOpenGPS
 
         private void hsbarFusion_ValueChanged(object sender, EventArgs e)
         {
-            lblFusion.Text = (hsbarFusion.Value).ToString()+"%";
-            lblFusionIMU.Text = (100 - hsbarFusion.Value).ToString()+"%";
+            lblFusion.Text = (hsbarFusion.Value).ToString() + "%";
+            lblFusionIMU.Text = (100 - hsbarFusion.Value).ToString() + "%";
 
             mf.ahrs.fusionWeight = (double)hsbarFusion.Value * 0.002;
         }

--- a/SourceCode/GPS/Forms/Settings/ConfigMenu.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigMenu.Designer.cs
@@ -72,7 +72,7 @@ namespace AgOpenGPS
             lblNudgeDistance.Text = snapDist + mf.unitsInCm.ToString();
             lblUnits.Text = mf.isMetric ? "Metric" : "Imperial";
 
-            labelCurrentVehicle.Text = gStr.gsCurrent + ": "+ RegistrySettings.vehicleFileName;
+            labelCurrentVehicle.Text = gStr.gsCurrent + ": " + RegistrySettings.vehicleFileName;
             lblSummaryVehicleName.Text = labelCurrentVehicle.Text;
 
             lblTramWidth.Text = mf.isMetric ?
@@ -221,7 +221,7 @@ namespace AgOpenGPS
         private void btnTool_Click(object sender, EventArgs e)
         {
             ShowSubMenu(panelToolSubMenu, btnTool);
-            btnSubToolType.BackColor=SystemColors.GradientActiveCaption;
+            btnSubToolType.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void ClearToolSubBackgrounds()
@@ -246,7 +246,7 @@ namespace AgOpenGPS
         {
             ClearToolSubBackgrounds();
             tab1.SelectedTab = tabTHitch;
-            btnSubHitch.BackColor= SystemColors.GradientActiveCaption;
+            btnSubHitch.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void btnSubToolOffset_Click
@@ -268,14 +268,14 @@ namespace AgOpenGPS
         {
             ClearToolSubBackgrounds();
             tab1.SelectedTab = tabTSections;
-            btnSubSections.BackColor= SystemColors.GradientActiveCaption;
+            btnSubSections.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void btnSubSwitches_Click(object sender, EventArgs e)
         {
             ClearToolSubBackgrounds();
             tab1.SelectedTab = tabTSwitches;
-            btnSubSwitches .BackColor = SystemColors.GradientActiveCaption;
+            btnSubSwitches.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void btnSubToolSettings_Click(object sender, EventArgs e)
@@ -296,21 +296,21 @@ namespace AgOpenGPS
         private void btnDataSources_Click(object sender, EventArgs e)
         {
             ShowSubMenu(panelDataSourcesSubMenu, btnDataSources);
-            btnSubHeading.BackColor=SystemColors.GradientActiveCaption;
+            btnSubHeading.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void btnSubHeading_Click(object sender, EventArgs e)
         {
             ClearDataSubBackgrounds();
             tab1.SelectedTab = tabDHeading;
-            btnSubHeading.BackColor=SystemColors.GradientActiveCaption;
+            btnSubHeading.BackColor = SystemColors.GradientActiveCaption;
         }
 
         private void btnSubRoll_Click(object sender, EventArgs e)
         {
             ClearDataSubBackgrounds();
             tab1.SelectedTab = tabDRoll;
-            btnSubRoll.BackColor=SystemColors.GradientActiveCaption;
+            btnSubRoll.BackColor = SystemColors.GradientActiveCaption;
         }
 
         #endregion
@@ -339,7 +339,7 @@ namespace AgOpenGPS
         {
             ClearMachineSubBackgrounds();
             tab1.SelectedTab = tabRelay;
-            btnMachineRelay.BackColor= SystemColors.GradientActiveCaption;
+            btnMachineRelay.BackColor = SystemColors.GradientActiveCaption;
         }
         #endregion
     }

--- a/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
@@ -582,7 +582,7 @@ namespace AgOpenGPS
             }
 
             nudNumberOfSections.Maximum = FormGPS.MAXSECTIONS;
-            
+
             //fix ManualOffOnAuto buttons
             mf.manualBtnState = btnStates.Off;
             mf.btnSectionMasterManual.Image = Properties.Resources.ManualOff;
@@ -646,7 +646,7 @@ namespace AgOpenGPS
                 nudNumberOfSections.Value = numberOfSections;
 
                 defaultSectionWidth = Properties.Settings.Default.setTool_sectionWidthMulti;
-                nudDefaultSectionWidth.Value = (decimal)(Math.Round((defaultSectionWidth * mf.m2InchOrCm),1));
+                nudDefaultSectionWidth.Value = (decimal)(Math.Round((defaultSectionWidth * mf.m2InchOrCm), 1));
 
                 SetNudZoneMinMax();
 
@@ -701,7 +701,7 @@ namespace AgOpenGPS
                 Properties.Settings.Default.setSection_position15 = sectionPositionArr[14];
                 Properties.Settings.Default.setSection_position16 = sectionPositionArr[15];
                 Properties.Settings.Default.setSection_position17 = sectionPositionArr[16];
-                                                                    
+
                 mf.tool.numOfSections = numberOfSections;
 
                 Properties.Settings.Default.setVehicle_numSections = mf.tool.numOfSections;
@@ -800,7 +800,7 @@ namespace AgOpenGPS
                 }
 
                 String str = "";
-                str = String.Join(",",mf.tool.zoneRanges);
+                str = String.Join(",", mf.tool.zoneRanges);
                 Properties.Settings.Default.setTool_zones = str;
 
                 mf.LineUpAllZoneButtons();
@@ -818,7 +818,7 @@ namespace AgOpenGPS
             if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
                 mf.tool.zoneRanges[1] = (int)nudZone1To.Value;
-                SetNudZoneVisibility(); 
+                SetNudZoneVisibility();
             }
         }
 
@@ -887,7 +887,7 @@ namespace AgOpenGPS
 
         private void cboxNumberOfZones_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if ((cboxNumberOfZones.SelectedIndex+2) > (int)nudNumberOfSections.Value)
+            if ((cboxNumberOfZones.SelectedIndex + 2) > (int)nudNumberOfSections.Value)
             {
                 mf.YesMessageBox("You can't have more zones then sections");
                 cboxNumberOfZones.SelectedIndex = mf.tool.zones - 2;
@@ -1110,7 +1110,7 @@ namespace AgOpenGPS
                     mf.YesMessageBox("You can't have more zones then sections");
                     nudNumberOfSections.Value = numberOfSections;
                     return;
-                }    
+                }
                 numberOfSections = (int)nudNumberOfSections.Value;
                 SetNudZoneMinMax();
 
@@ -1120,7 +1120,7 @@ namespace AgOpenGPS
                 lblVehicleToolWidth.Text = Convert.ToString((int)(numberOfSections * defaultSectionWidth * 100 * mf.cm2CmOrIn));
                 SectionFeetInchesTotalWidthLabelUpdate();
                 FillZoneNudsWithDefaultValues();
-                SetNudZoneVisibility(); 
+                SetNudZoneVisibility();
             }
         }
 
@@ -1255,22 +1255,22 @@ namespace AgOpenGPS
                                     mf.TimedMessageBox(3000, "Too Wide", "Set to 99, Max 50 Meters");
                                     Log.EventWriter("Sections, Tool Set Too Wide");
                                     toolWidth = 0;
-                                    nudSection01.Value =  99;
-                                    nudSection02.Value =  99;
-                                    nudSection03.Value =  99;
-                                    nudSection04.Value =  99;
-                                    nudSection05.Value =  99;
-                                    nudSection06.Value =  99;
-                                    nudSection07.Value =  99;
-                                    nudSection08.Value =  99;
-                                    nudSection09.Value =  99;
-                                    nudSection10.Value =  99;
-                                    nudSection11.Value =  99;
-                                    nudSection12.Value =  99;
-                                    nudSection13.Value =  99;
-                                    nudSection14.Value =  99;
-                                    nudSection15.Value =  99;
-                                    nudSection16.Value =  99;
+                                    nudSection01.Value = 99;
+                                    nudSection02.Value = 99;
+                                    nudSection03.Value = 99;
+                                    nudSection04.Value = 99;
+                                    nudSection05.Value = 99;
+                                    nudSection06.Value = 99;
+                                    nudSection07.Value = 99;
+                                    nudSection08.Value = 99;
+                                    nudSection09.Value = 99;
+                                    nudSection10.Value = 99;
+                                    nudSection11.Value = 99;
+                                    nudSection12.Value = 99;
+                                    nudSection13.Value = 99;
+                                    nudSection14.Value = 99;
+                                    nudSection15.Value = 99;
+                                    nudSection16.Value = 99;
                                 }
                             }
                             else
@@ -1306,7 +1306,7 @@ namespace AgOpenGPS
                             item2.Visible = false;
                         }
                     }
-                }                
+                }
             }
 
             lblVehicleToolWidth.Text = Convert.ToString((int)toolWidth);
@@ -1387,8 +1387,8 @@ namespace AgOpenGPS
 
             for (int j = 1; j < 17; j++)
             {
-                if (j <= i) sectionPositionArr[j] = sectionPositionArr[j - 1] + sectionWidthArr[j-1];
-                else sectionPositionArr[j] = 0;                
+                if (j <= i) sectionPositionArr[j] = sectionPositionArr[j - 1] + sectionWidthArr[j - 1];
+                else sectionPositionArr[j] = 0;
             }
         }
 
@@ -1460,7 +1460,7 @@ namespace AgOpenGPS
 
         private void chkSelectWorkSwitch_Click(object sender, EventArgs e)
         {
-            chkSetManualSections.Enabled = chkSetAutoSections.Enabled= chkWorkSwActiveLow.Enabled = chkSelectWorkSwitch.Checked;
+            chkSetManualSections.Enabled = chkSetAutoSections.Enabled = chkWorkSwActiveLow.Enabled = chkSelectWorkSwitch.Checked;
         }
 
         private void chkSelectSteerSwitch_Click(object sender, EventArgs e)

--- a/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
@@ -195,7 +195,7 @@ namespace AgOpenGPS
             nudTractorHitchLength.Visible = rbtnTBT.Checked || rbtnTrailing.Checked;
             label94.Visible = rbtnTBT.Checked || rbtnTrailing.Checked;
             labelHitchLength.Visible = rbtnTBT.Checked || rbtnTrailing.Checked;
-            HitchLengthBlindBox.Visible = rbtnFixedRear.Checked || rbtnFront.Checked; 
+            HitchLengthBlindBox.Visible = rbtnFixedRear.Checked || rbtnFront.Checked;
 
             label94.Text = mf.unitsInCm;
             label95.Text = mf.unitsInCm;
@@ -273,7 +273,7 @@ namespace AgOpenGPS
                 mf.vehicle.VehicleConfig.Type = VehicleType.Harvester;
                 Properties.Settings.Default.setVehicle_vehicleType = 1;
 
-                if ( mf.tool.hitchLength < 0) mf.tool.hitchLength *= -1;
+                if (mf.tool.hitchLength < 0) mf.tool.hitchLength *= -1;
 
                 Properties.Settings.Default.setTool_isToolFront = true;
                 Properties.Settings.Default.setTool_isToolTBT = false;

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -106,7 +106,7 @@ namespace AgOpenGPS
                                     ahrs.imuRoll = temp - ahrs.rollZero;
                                 }
                                 if (temp == float.MinValue)
-                                    ahrs.imuRoll = 0;                               
+                                    ahrs.imuRoll = 0;
 
                                 //altitude in meters
                                 temp = BitConverter.ToSingle(data, 37);
@@ -173,13 +173,13 @@ namespace AgOpenGPS
                             //Heading
                             ahrs.imuHeading = (Int16)((data[6] << 8) + data[5]);
                             ahrs.imuHeading *= 0.1;
-                            
+
                             //Roll
                             double rollK = (Int16)((data[8] << 8) + data[7]);
 
                             if (ahrs.isRollInvert) rollK *= -0.1;
                             else rollK *= 0.1;
-                            rollK -= ahrs.rollZero;                           
+                            rollK -= ahrs.rollZero;
                             ahrs.imuRoll = ahrs.imuRoll * ahrs.rollFilter + rollK * (1 - ahrs.rollFilter);
 
                             //Angular velocity
@@ -248,7 +248,7 @@ namespace AgOpenGPS
                         }
 
                     case 221: // DD
-                        {                    
+                        {
                             //{ 0x80, 0x81, 0x7f, 221, number bytes, seconds to display, mystery byte, 98,99,100,101, CRC };
                             if (data.Length < 9) break;
 
@@ -283,10 +283,10 @@ namespace AgOpenGPS
                             }
                             if (((data[5] & 2) == 2)) //mask bit #1 set and command bit #0 cycle line to the 0 = left 1 = right
                             {
-                                if ((data[6] & 1) != 1) {  btnCycleLines.PerformClick(); }
+                                if ((data[6] & 1) != 1) { btnCycleLines.PerformClick(); }
                                 if ((data[6] & 1) == 1) { btnCycleLinesBk.PerformClick(); }
                             }
-                           
+
                             break;
                         }
 
@@ -304,7 +304,7 @@ namespace AgOpenGPS
 
                             break;
                         }
-                     #endregion
+                        #endregion
                 }
             }
         }
@@ -659,8 +659,7 @@ namespace AgOpenGPS
             if (keyData == Keys.Up)
             {
                 if (sim.stepDistance < 0.4 && sim.stepDistance > -0.36) sim.stepDistance += 0.01;
-                else 
-                    sim.stepDistance += 0.04;
+                else sim.stepDistance += 0.04;
                 if (sim.stepDistance > 4) sim.stepDistance = 4;
                 return true;
             }

--- a/SourceCode/ModSim/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/ModSim/Source/Forms/Controls.Designer.cs
@@ -31,8 +31,8 @@ namespace ModSim
         private void lblKmh_Click(object sender, EventArgs e)
         {
             tbarSpeed.Value = 0;
-            lblKmh.Text = "Kmh: 0.0" ;
-            mSec.Text = "M/Sec: 0.0" ;
+            lblKmh.Text = "Kmh: 0.0";
+            mSec.Text = "M/Sec: 0.0";
         }
 
         private void tbarSteerAngleWAS_Scroll(object sender, EventArgs e)
@@ -53,17 +53,19 @@ namespace ModSim
         private void tbarRoll_Scroll(object sender, EventArgs e)
         {
             roll = (double)tbarRoll.Value * 0.1;
-            rollIMU = (int)(roll*10);
+            rollIMU = (int)(roll * 10);
             lblRoll.Text = "Roll: " + (roll).ToString("N2") + "°";
         }
-         private void lblRoll_Click(object sender, EventArgs e)
+
+        private void lblRoll_Click(object sender, EventArgs e)
         {
             roll = 0;
             rollIMU = 0;
             lblRoll.Text = "Roll: 0°";
             tbarRoll.Value = 0;
         }
-       private void btnSteerButtonRemote_Click(object sender, EventArgs e)
+
+        private void btnSteerButtonRemote_Click(object sender, EventArgs e)
         {
             if (steerSwitch > 0) steerSwitch = 0;
             else steerSwitch = 1;
@@ -74,8 +76,7 @@ namespace ModSim
         {
             if (cboxSteerSwitchRemote.Checked) steerSwitch = 0;
             else steerSwitch = 1;
-        }        
-        
+        }
 
         private void cboxWorkSwitch_Click(object sender, EventArgs e)
         {
@@ -94,7 +95,7 @@ namespace ModSim
             var form = new FormYes(s1);
             form.ShowDialog(this);
         }
-        
+
         #region GPS Simulator
 
         private string TimeNow = "";
@@ -157,7 +158,7 @@ namespace ModSim
 
             degrees = ToDegrees * headingTrue;
 
-            headingIMU = (int)(degrees*10);
+            headingIMU = (int)(degrees * 10);
 
             lblHeading.Text = (headingTrue * 57.29577951308).ToString("N2") + '°';
 
@@ -490,8 +491,7 @@ namespace ModSim
             sbRMC.Append("\r\n");
         }
 
-#endregion
-
+        #endregion
     }
 }
 

--- a/SourceCode/ModSim/Source/ModSim.csproj
+++ b/SourceCode/ModSim/Source/ModSim.csproj
@@ -23,6 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Forms\Controls.Designer.cs">
+      <DependentUpon>FormSim.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Forms\UDP.Designer.cs">
+      <DependentUpon>FormSim.cs</DependentUpon>
+    </Compile>
     <Compile Update="gStr.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Code analysis is disabled by default for all `*.Designer.cs` files.

Unfortunately, we are also using this naming convention for splitting up big forms (like `FormGPS` has 9 `*.Designer.cs` files, but only `FormGPS.Designer.cs` is actually generated by the designer).

I added an exception for all the non designer generated `*.Designer.cs` files to the `.editorconfig` and fixed all formatting issues.