### PR TITLE
Replaces `WebEye.Controls.WinForms.WebCameraControl` with `Accord.Video.DirectShow`

### DIFF
--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -37,6 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Accord.Controls.Imaging" Version="3.8.0" />
+    <PackageReference Include="Accord.Video.DirectShow" Version="3.8.0" />
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
     <PackageReference Include="GMap.NET.WinForms" Version="2.1.7" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
@@ -44,7 +46,6 @@
     <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
-    <PackageReference Include="WebEye.Controls.WinForms.WebCameraControl" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS/Forms/FormWebCam.Designer.cs
+++ b/SourceCode/GPS/Forms/FormWebCam.Designer.cs
@@ -28,23 +28,23 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.deviceComboBox = new System.Windows.Forms.ComboBox();
             this.stopButton = new System.Windows.Forms.Button();
-            this.webCameraControl1 = new WebEye.Controls.WinForms.WebCameraControl.WebCameraControl();
             this.startButton = new System.Windows.Forms.Button();
+            this.videoSourcePlayer = new Accord.Controls.VideoSourcePlayer();
             this.SuspendLayout();
             // 
-            // comboBox1
+            // deviceComboBox
             // 
-            this.comboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(13, 234);
-            this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(196, 27);
-            this.comboBox1.TabIndex = 11;
-            this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged_1);
+            this.deviceComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.deviceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.deviceComboBox.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.deviceComboBox.FormattingEnabled = true;
+            this.deviceComboBox.Location = new System.Drawing.Point(13, 234);
+            this.deviceComboBox.Name = "deviceComboBox";
+            this.deviceComboBox.Size = new System.Drawing.Size(196, 27);
+            this.deviceComboBox.TabIndex = 11;
+            this.deviceComboBox.SelectedIndexChanged += new System.EventHandler(this.deviceComboBox_SelectedIndexChanged);
             // 
             // stopButton
             // 
@@ -61,18 +61,7 @@
             this.stopButton.Size = new System.Drawing.Size(75, 37);
             this.stopButton.TabIndex = 13;
             this.stopButton.UseVisualStyleBackColor = true;
-            this.stopButton.Click += new System.EventHandler(this.stopButton_Click_1);
-            // 
-            // webCameraControl1
-            // 
-            this.webCameraControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.webCameraControl1.BackColor = System.Drawing.SystemColors.AppWorkspace;
-            this.webCameraControl1.Location = new System.Drawing.Point(0, 0);
-            this.webCameraControl1.Name = "webCameraControl1";
-            this.webCameraControl1.Size = new System.Drawing.Size(398, 229);
-            this.webCameraControl1.TabIndex = 10;
+            this.stopButton.Click += new System.EventHandler(this.stopButton_Click);
             // 
             // startButton
             // 
@@ -89,17 +78,31 @@
             this.startButton.Size = new System.Drawing.Size(75, 37);
             this.startButton.TabIndex = 12;
             this.startButton.UseVisualStyleBackColor = true;
-            this.startButton.Click += new System.EventHandler(this.startButton_Click_1);
+            this.startButton.Click += new System.EventHandler(this.startButton_Click);
+            // 
+            // videoSourcePlayer
+            // 
+            this.videoSourcePlayer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.videoSourcePlayer.BackColor = System.Drawing.SystemColors.AppWorkspace;
+            this.videoSourcePlayer.BorderColor = System.Drawing.Color.Transparent;
+            this.videoSourcePlayer.KeepAspectRatio = true;
+            this.videoSourcePlayer.Location = new System.Drawing.Point(0, 0);
+            this.videoSourcePlayer.Name = "videoSourcePlayer";
+            this.videoSourcePlayer.Size = new System.Drawing.Size(398, 229);
+            this.videoSourcePlayer.TabIndex = 15;
+            this.videoSourcePlayer.VideoSource = null;
             // 
             // FormWebCam
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(398, 268);
-            this.Controls.Add(this.comboBox1);
+            this.Controls.Add(this.videoSourcePlayer);
+            this.Controls.Add(this.deviceComboBox);
             this.Controls.Add(this.stopButton);
             this.Controls.Add(this.startButton);
-            this.Controls.Add(this.webCameraControl1);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "FormWebCam";
             this.ShowInTaskbar = false;
@@ -112,9 +115,9 @@
 
         #endregion
 
-        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.ComboBox deviceComboBox;
         private System.Windows.Forms.Button stopButton;
         private System.Windows.Forms.Button startButton;
-        private WebEye.Controls.WinForms.WebCameraControl.WebCameraControl webCameraControl1;
+        private Accord.Controls.VideoSourcePlayer videoSourcePlayer;
     }
 }

--- a/SourceCode/GPS/Forms/FormWebCam.cs
+++ b/SourceCode/GPS/Forms/FormWebCam.cs
@@ -1,76 +1,58 @@
 ﻿using System;
 using System.Windows.Forms;
-using WebEye.Controls.WinForms.WebCameraControl;
+using Accord.Video.DirectShow;
 
 namespace AgOpenGPS
 {
     public partial class FormWebCam : Form
     {
+        private FilterInfoCollection _videoDevices;
+
         public FormWebCam()
         {
             InitializeComponent();
         }
 
-        private class ComboBoxItem
-        {
-            public ComboBoxItem(WebCameraId id)
-            {
-                _id = id;
-            }
-
-            private readonly WebCameraId _id;
-
-            public WebCameraId Id => _id;
-
-            public override string ToString()
-            {
-                // Generates the text shown in the combo box.
-                return _id.Name;
-            }
-        }
-
         private void FormWebCam_Load(object sender, EventArgs e)
         {
-            foreach (WebCameraId camera in webCameraControl1.GetVideoCaptureDevices())
+            _videoDevices = new FilterInfoCollection(FilterCategory.VideoInputDevice);
+
+            foreach (var videoDevice in _videoDevices)
             {
-                comboBox1.Items.Add(new ComboBoxItem(camera));
+                deviceComboBox.Items.Add(videoDevice.Name);
             }
 
-            if (comboBox1.Items.Count > 0)
+            if (deviceComboBox.Items.Count > 0)
             {
-                comboBox1.SelectedItem = comboBox1.Items[0];
+                deviceComboBox.SelectedItem = deviceComboBox.Items[0];
             }
         }
 
         private void UpdateButtons()
         {
-            startButton.Enabled = comboBox1.SelectedItem != null;
-            stopButton.Enabled = webCameraControl1.IsCapturing;
-            //imageButton.Enabled = webCameraControl1.IsCapturing;
+            startButton.Enabled = deviceComboBox.SelectedItem != null;
+            stopButton.Enabled = videoSourcePlayer.IsRunning;
         }
 
-        private void comboBox1_SelectedIndexChanged_1(object sender, EventArgs e)
+        private void deviceComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             UpdateButtons();
         }
 
-        private void startButton_Click_1(object sender, EventArgs e)
+        private void startButton_Click(object sender, EventArgs e)
         {
-            ComboBoxItem i = (ComboBoxItem)comboBox1.SelectedItem;
+            var videoSource = new VideoCaptureDevice(_videoDevices[deviceComboBox.SelectedIndex].MonikerString);
 
-            try
-            {
-                webCameraControl1.StartCapture(i.Id);
-            }
-            finally
-            {
-                UpdateButtons();
-            }
+            videoSourcePlayer.VideoSource = videoSource;
+            videoSourcePlayer.Start();
+
+            UpdateButtons();
         }
 
-        private void stopButton_Click_1(object sender, EventArgs e)
+        private void stopButton_Click(object sender, EventArgs e)
         {
-            webCameraControl1.StopCapture();
+            videoSourcePlayer.SignalToStop();
+            videoSourcePlayer.WaitForStop();
 
             UpdateButtons();
         }


### PR DESCRIPTION
Uses the capabilities from `Accord.Video.DirectShow` and `Accord.Controls.Imaging` to render the web cam.

This checks one more thing from #811.