### PR TITLE
Restore code that was accidently deleted in #666: Set correct color for BingMap texture

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/WorldGrid.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/WorldGrid.cs
@@ -113,6 +113,7 @@ namespace AgOpenGPS.Core
 
             if (isGeoMap)
             {
+                GL.Color4(0.6f, 0.6f, 0.6f, 0.5f);
                 GeoCoord u0v0Map = new GeoCoord(eastingMinGeo, northingMaxGeo);
                 GeoCoord u1v1Map = new GeoCoord(eastingMaxGeo, northingMinGeo);
                 BingTexture.DrawZ(u0v0Map, u1v1Map, -0.05);


### PR DESCRIPTION
Restore code that was accidently deleted in #666: Set correct color (middle gray half transparent) for BingMap texture.
Otherwise the color of the background was used.