### PR TITLE
Implement IDisposable for Texture2D and VertextArrayBase .

### DIFF
--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.cs
@@ -86,7 +86,7 @@ namespace AgOpenGPS.Core.DrawLib
         {
             Vertex2Array vertex2Array = new Vertex2Array(vertices);
             GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
-            vertex2Array.DeleteBuffer();
+            vertex2Array.Dispose();
         }
 
         private static void DrawPrimitiveLayered(
@@ -100,7 +100,7 @@ namespace AgOpenGPS.Core.DrawLib
                 SetLineStyle(lineStyle);
                 GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
             }
-            vertex2Array.DeleteBuffer();
+            vertex2Array.Dispose();
         }
 
         public static void Translate(double x, double y, double z)

--- a/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
@@ -1,14 +1,17 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using System.Drawing.Imaging;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 
 namespace AgOpenGPS.Core.DrawLib
 {
-    public class Texture2D
+    public class Texture2D : IDisposable
     {
         private readonly Bitmap _bitmap;
         private int _textureId;
+        private bool isDisposed;
+
         public Texture2D(Bitmap bitmap)
         {
             _bitmap = bitmap;
@@ -24,7 +27,7 @@ namespace AgOpenGPS.Core.DrawLib
 
         public void Draw(
             XyCoord u0v0, // The corner (u==0.0 && v==0.0) of the texture will be mapped to this coord
-            XyCoord u1v1  // The corner (u==1.0 && v==1.0) of the texture will be apped to this coord
+            XyCoord u1v1  // The corner (u==1.0 && v==1.0) of the texture will be mapped to this coord
         )
         {
             GL.Enable(EnableCap.Texture2D);
@@ -84,5 +87,35 @@ namespace AgOpenGPS.Core.DrawLib
             if (_bitmap != null) SetBitmap(_bitmap);
         }
 
+        private void DeleteTexture()
+        {
+            if (0 != _textureId)
+            {
+                GL.DeleteTexture(_textureId);
+            }
+            _textureId = 0;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                DeleteTexture();
+                isDisposed = true;
+            }
+        }
+
+        ~Texture2D()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
@@ -4,9 +4,10 @@ using System;
 
 namespace AgOpenGPS.Core.DrawLib
 {
-    public abstract class VertexArrayBase
+    public abstract class VertexArrayBase : IDisposable
     {
-        private readonly int _bufId;
+        private int _bufId;
+        private bool isDisposed;
 
         public VertexArrayBase(int nDimensions)
         {
@@ -23,9 +24,33 @@ namespace AgOpenGPS.Core.DrawLib
             GL.BindBuffer(BufferTarget.ArrayBuffer, _bufId);
         }
 
-        public void DeleteBuffer()
+        private void DeleteBuffer()
         {
-            GL.DeleteBuffer(_bufId);
+            if (0 != _bufId)
+            {
+                GL.DeleteBuffer(_bufId);
+            }
+            _bufId = 0;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                DeleteBuffer();
+                isDisposed = true;
+            }
+        }
+
+        ~VertexArrayBase()
+        {
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 


### PR DESCRIPTION
Texture2D and VertextArrayBase  must implement IDisposable for proper release of unmanaged OpenGL resources.