### PR TITLE
Replace `Accord.Controls.VideoSourcePlayer` with source code

### DIFF
--- a/SourceCode/AgLibrary/AgLibrary.csproj
+++ b/SourceCode/AgLibrary/AgLibrary.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Accord.Imaging" Version="3.8.0" />
+    <PackageReference Include="Accord.Video.DirectShow" Version="3.8.0" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
 

--- a/SourceCode/AgLibrary/Controls/VideoSourcePlayer.Designer.cs
+++ b/SourceCode/AgLibrary/Controls/VideoSourcePlayer.Designer.cs
@@ -1,0 +1,42 @@
+﻿namespace AgLibrary.Controls
+{
+    partial class VideoSourcePlayer
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // VideoSourcePlayer
+            // 
+            this.Paint += new System.Windows.Forms.PaintEventHandler(this.VideoSourcePlayer_Paint);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+    }
+}

--- a/SourceCode/AgLibrary/Controls/VideoSourcePlayer.cs
+++ b/SourceCode/AgLibrary/Controls/VideoSourcePlayer.cs
@@ -1,0 +1,417 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Windows.Forms;
+using Accord.Video;
+
+namespace AgLibrary.Controls
+{
+    public partial class VideoSourcePlayer : Control
+    {
+        // video source to play
+        private IVideoSource videoSource = null;
+        // last received frame from the video source
+        private Bitmap currentFrame = null;
+        // converted version of the current frame (in the case if current frame is a 16 bpp 
+        // per color plane image, then the converted image is its 8 bpp version for rendering)
+        private Bitmap convertedFrame = null;
+        // last error message provided by video source
+        private string lastMessage = null;
+        // controls border color
+        private Color borderColor = Color.Black;
+
+        private bool keepRatio = false;
+        private bool needSizeUpdate = false;
+        private bool firstFrameNotProcessed = true;
+        private volatile bool requestedToStop = false;
+
+        // dummy object to lock for synchronization
+        private readonly object sync = new object();
+
+        /// <summary>
+        /// Gets or sets whether the player should keep the aspect ratio of the images being shown.
+        /// </summary>
+        /// 
+        [DefaultValue(false)]
+        public bool KeepAspectRatio
+        {
+            get { return keepRatio; }
+            set
+            {
+                keepRatio = value;
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// Control's border color.
+        /// </summary>
+        /// 
+        /// <remarks><para>Specifies color of the border drawn around video frame.</para></remarks>
+        /// 
+        [DefaultValue(typeof(Color), "Black")]
+        public Color BorderColor
+        {
+            get { return borderColor; }
+            set
+            {
+                borderColor = value;
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// Video source to play.
+        /// </summary>
+        /// 
+        /// <remarks><para>The property sets the video source to play. After setting the property the
+        /// <see cref="Start"/> method should be used to start playing the video source.</para>
+        /// 
+        /// <para><note>Trying to change video source while currently set video source is still playing
+        /// will generate an exception. Use <see cref="IsRunning"/> property to check if current video
+        /// source is still playing or <see cref="Stop"/> or <see cref="SignalToStop"/> and <see cref="WaitForStop"/>
+        /// methods to stop current video source.</note></para>
+        /// </remarks>
+        /// 
+        /// <exception cref="Exception">Video source can not be changed while current video source is still running.</exception>
+        /// 
+        [Browsable(false)]
+        public IVideoSource VideoSource
+        {
+            get { return videoSource; }
+            set
+            {
+                CheckForCrossThreadAccess();
+
+                // detach events
+                if (videoSource != null)
+                {
+                    videoSource.NewFrame -= new NewFrameEventHandler(videoSource_NewFrame);
+                    videoSource.VideoSourceError -= new VideoSourceErrorEventHandler(videoSource_VideoSourceError);
+                    videoSource.PlayingFinished -= new PlayingFinishedEventHandler(videoSource_PlayingFinished);
+                }
+
+                lock (sync)
+                {
+                    if (currentFrame != null)
+                    {
+                        currentFrame.Dispose();
+                        currentFrame = null;
+                    }
+                }
+
+                videoSource = value;
+
+                // atach events
+                if (videoSource != null)
+                {
+                    videoSource.NewFrame += new NewFrameEventHandler(videoSource_NewFrame);
+                    videoSource.VideoSourceError += new VideoSourceErrorEventHandler(videoSource_VideoSourceError);
+                    videoSource.PlayingFinished += new PlayingFinishedEventHandler(videoSource_PlayingFinished);
+                }
+
+                lastMessage = null;
+                needSizeUpdate = true;
+                firstFrameNotProcessed = true;
+                // update the control
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// State of the current video source.
+        /// </summary>
+        /// 
+        /// <remarks><para>Current state of the current video source object - running or not.</para></remarks>
+        /// 
+        [Browsable(false)]
+        public bool IsRunning
+        {
+            get
+            {
+                CheckForCrossThreadAccess();
+
+                return videoSource != null && videoSource.IsRunning;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VideoSourcePlayer"/> class.
+        /// </summary>
+        public VideoSourcePlayer()
+        {
+            InitializeComponent();
+
+            // update control style
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.ResizeRedraw |
+                ControlStyles.DoubleBuffer | ControlStyles.UserPaint, true);
+        }
+
+        // Check if the control is accessed from a none UI thread
+        private void CheckForCrossThreadAccess()
+        {
+            // force handle creation, so InvokeRequired() will use it instead of searching through parent's chain
+            if (!IsHandleCreated)
+            {
+                CreateControl();
+
+                // if the control is not Visible, then CreateControl() will not be enough
+                if (!IsHandleCreated)
+                {
+                    CreateHandle();
+                }
+            }
+
+            if (InvokeRequired)
+            {
+                throw new InvalidOperationException("Cross thread access to the control is not allowed.");
+            }
+        }
+
+        /// <summary>
+        /// Start video source and displaying its frames.
+        /// </summary>
+        public void Start()
+        {
+            CheckForCrossThreadAccess();
+
+            requestedToStop = false;
+
+            if (videoSource != null)
+            {
+                firstFrameNotProcessed = true;
+
+                videoSource.Start();
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// Stop video source.
+        /// </summary>
+        /// 
+        /// <remarks><para>The method stops video source by calling its <see cref="Accord.Video.IVideoSource.Stop"/>
+        /// method, which abourts internal video source's thread. Use <see cref="SignalToStop"/> and
+        /// <see cref="WaitForStop"/> for more polite video source stopping, which gives a chance for
+        /// video source to perform proper shut down and clean up.
+        /// </para></remarks>
+        /// 
+        public void Stop()
+        {
+            CheckForCrossThreadAccess();
+
+            requestedToStop = true;
+
+            if (videoSource != null)
+            {
+                videoSource.Stop();
+
+                if (currentFrame != null)
+                {
+                    currentFrame.Dispose();
+                    currentFrame = null;
+                }
+
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// Signal video source to stop. 
+        /// </summary>
+        /// 
+        /// <remarks><para>Use <see cref="WaitForStop"/> method to wait until video source
+        /// stops.</para></remarks>
+        /// 
+        public void SignalToStop()
+        {
+            CheckForCrossThreadAccess();
+
+            requestedToStop = true;
+
+            videoSource?.SignalToStop();
+        }
+
+        /// <summary>
+        /// Wait for video source has stopped. 
+        /// </summary>
+        /// 
+        /// <remarks><para>Waits for video source stopping after it was signaled to stop using
+        /// <see cref="SignalToStop"/> method. If <see cref="SignalToStop"/> was not called, then
+        /// it will be called automatically.</para></remarks>
+        /// 
+        public void WaitForStop()
+        {
+            CheckForCrossThreadAccess();
+
+            if (!requestedToStop)
+            {
+                SignalToStop();
+            }
+
+            if (videoSource != null)
+            {
+                videoSource.WaitForStop();
+
+                if (currentFrame != null)
+                {
+                    currentFrame.Dispose();
+                    currentFrame = null;
+                }
+
+                Invalidate();
+            }
+        }
+
+        // Paint control
+        private void VideoSourcePlayer_Paint(object sender, PaintEventArgs e)
+        {
+            if (!Visible)
+            {
+                return;
+            }
+
+            // is it required to update control's size/position
+            if (needSizeUpdate || firstFrameNotProcessed)
+            {
+                needSizeUpdate = false;
+            }
+
+            lock (sync)
+            {
+                Graphics g = e.Graphics;
+                Rectangle rect = ClientRectangle;
+                Pen borderPen = new Pen(borderColor, 1);
+
+                // draw rectangle
+                g.DrawRectangle(borderPen, rect.X, rect.Y, rect.Width - 1, rect.Height - 1);
+
+                if (videoSource != null)
+                {
+                    if ((currentFrame != null) && (lastMessage == null))
+                    {
+                        Bitmap frame = convertedFrame ?? currentFrame;
+
+                        if (keepRatio)
+                        {
+                            double ratio = (double)frame.Width / frame.Height;
+                            Rectangle newRect = rect;
+
+                            if (rect.Width < rect.Height * ratio)
+                            {
+                                newRect.Height = (int)(rect.Width / ratio);
+                            }
+                            else
+                            {
+                                newRect.Width = (int)(rect.Height * ratio);
+                            }
+
+                            newRect.X = (rect.Width - newRect.Width) / 2;
+                            newRect.Y = (rect.Height - newRect.Height) / 2;
+
+                            g.DrawImage(frame, newRect.X + 1, newRect.Y + 1, newRect.Width - 2, newRect.Height - 2);
+                        }
+                        else
+                        {
+                            // draw current frame
+                            g.DrawImage(frame, rect.X + 1, rect.Y + 1, rect.Width - 2, rect.Height - 2);
+                        }
+
+                        firstFrameNotProcessed = false;
+                    }
+                    else
+                    {
+                        // create font and brush
+                        SolidBrush drawBrush = new SolidBrush(ForeColor);
+
+                        g.DrawString(lastMessage ?? "Connecting ...", Font, drawBrush, new PointF(5, 5));
+
+                        drawBrush.Dispose();
+                    }
+                }
+
+                borderPen.Dispose();
+            }
+        }
+
+        // On new frame ready
+        private void videoSource_NewFrame(object sender, NewFrameEventArgs eventArgs)
+        {
+            if (!requestedToStop)
+            {
+                Bitmap newFrame = (Bitmap)eventArgs.Frame.Clone();
+
+                // now update current frame of the control
+                lock (sync)
+                {
+                    // dispose previous frame
+                    if (currentFrame != null)
+                    {
+                        if (currentFrame.Size != eventArgs.Frame.Size)
+                        {
+                            needSizeUpdate = true;
+                        }
+
+                        currentFrame.Dispose();
+                        currentFrame = null;
+                    }
+                    if (convertedFrame != null)
+                    {
+                        convertedFrame.Dispose();
+                        convertedFrame = null;
+                    }
+
+                    currentFrame = newFrame;
+                    lastMessage = null;
+
+                    // check if conversion is required to lower bpp rate
+                    if ((currentFrame.PixelFormat == PixelFormat.Format16bppGrayScale) ||
+                         (currentFrame.PixelFormat == PixelFormat.Format48bppRgb) ||
+                         (currentFrame.PixelFormat == PixelFormat.Format64bppArgb))
+                    {
+                        convertedFrame = Accord.Imaging.Image.Convert16bppTo8bpp(currentFrame);
+                    }
+                }
+
+                // update control
+                Invalidate();
+            }
+        }
+
+        // Error occured in video source
+        private void videoSource_VideoSourceError(object sender, VideoSourceErrorEventArgs eventArgs)
+        {
+            lastMessage = eventArgs.Description;
+            Invalidate();
+        }
+
+        // Video source has finished playing video
+        private void videoSource_PlayingFinished(object sender, ReasonToFinishPlaying reason)
+        {
+            switch (reason)
+            {
+                case ReasonToFinishPlaying.EndOfStreamReached:
+                    lastMessage = "Video has finished";
+                    break;
+
+                case ReasonToFinishPlaying.StoppedByUser:
+                    lastMessage = "Video was stopped";
+                    break;
+
+                case ReasonToFinishPlaying.DeviceLost:
+                    lastMessage = "Video device was unplugged";
+                    break;
+
+                case ReasonToFinishPlaying.VideoSourceError:
+                    lastMessage = "Video has finished because of error in video source";
+                    break;
+
+                default:
+                    lastMessage = "Video has finished for unknown reason";
+                    break;
+            }
+            Invalidate();
+        }
+    }
+}

--- a/SourceCode/AgLibrary/Controls/VideoSourcePlayer.resx
+++ b/SourceCode/AgLibrary/Controls/VideoSourcePlayer.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="$this.TrayLargeIcon" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+</root>

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -35,8 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Accord.Controls.Imaging" Version="3.8.0" />
-    <PackageReference Include="Accord.Video.DirectShow" Version="3.8.0" />
     <PackageReference Include="Dev4Agriculture.ISO11783.ISOXML" Version="0.23.1.1" />
     <PackageReference Include="GMap.NET.WinForms" Version="2.1.7" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />

--- a/SourceCode/GPS/Forms/FormWebCam.Designer.cs
+++ b/SourceCode/GPS/Forms/FormWebCam.Designer.cs
@@ -31,7 +31,7 @@
             this.deviceComboBox = new System.Windows.Forms.ComboBox();
             this.stopButton = new System.Windows.Forms.Button();
             this.startButton = new System.Windows.Forms.Button();
-            this.videoSourcePlayer = new Accord.Controls.VideoSourcePlayer();
+            this.videoSourcePlayer = new AgLibrary.Controls.VideoSourcePlayer();
             this.SuspendLayout();
             // 
             // deviceComboBox
@@ -118,6 +118,6 @@
         private System.Windows.Forms.ComboBox deviceComboBox;
         private System.Windows.Forms.Button stopButton;
         private System.Windows.Forms.Button startButton;
-        private Accord.Controls.VideoSourcePlayer videoSourcePlayer;
+        private AgLibrary.Controls.VideoSourcePlayer videoSourcePlayer;
     }
 }


### PR DESCRIPTION
The `Accord.Controls.Imaging` NuGet package introduced in #827 is only compatible with .NET Framework.

This was an oversight, since the idea was to be ready for a newer .NET version (#811).

This change replaces the `Accord.Controls.VideoSourcePlayer` from the `Accord.Controls.Imaging` package with its source code, which should be compatible with newer .NET versions.