### PR TITLE
Let new base class DisposableObject take care of Dispose pattern

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Base/DisposableObject.cs
+++ b/SourceCode/AgOpenGPS.Core/Base/DisposableObject.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace AgOpenGPS.Core.Base
+{
+    // Base class that makes implementing the Dispose pattern easy.
+    public abstract class DisposableObject : IDisposable
+    {
+        protected bool IsDisposed { get; private set; }
+
+        protected DisposableObject()
+        {
+        }
+
+        ~DisposableObject()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void OnDispose()
+        {
+            // Subclasses only need to override this method to implement the Dispose pattern
+            // DisposableObject takes care of the rest.
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (IsDisposed) return;
+
+            if (disposing)
+            {
+                OnDispose();
+            }
+
+            IsDisposed = true;
+        }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Drawing.Imaging;
+using AgOpenGPS.Core.Base;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 
 namespace AgOpenGPS.Core.DrawLib
 {
-    public class Texture2D : IDisposable
+    public class Texture2D : DisposableObject
     {
         private readonly Bitmap _bitmap;
         private int _textureId;
-        private bool isDisposed;
 
         public Texture2D(Bitmap bitmap)
         {
@@ -96,26 +95,10 @@ namespace AgOpenGPS.Core.DrawLib
             _textureId = 0;
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected override void OnDispose()
         {
-            if (!isDisposed)
-            {
-                DeleteTexture();
-                isDisposed = true;
-            }
+            DeleteTexture();
         }
 
-        ~Texture2D()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
-        }
-
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
     }
 }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
@@ -1,13 +1,12 @@
-﻿using AgOpenGPS.Core.Models;
+﻿using AgOpenGPS.Core.Base;
+using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
-using System;
 
 namespace AgOpenGPS.Core.DrawLib
 {
-    public abstract class VertexArrayBase : IDisposable
+    public abstract class VertexArrayBase : DisposableObject
     {
         private int _bufId;
-        private bool isDisposed;
 
         public VertexArrayBase(int nDimensions)
         {
@@ -33,25 +32,11 @@ namespace AgOpenGPS.Core.DrawLib
             _bufId = 0;
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected override void OnDispose()
         {
-            if (!isDisposed)
-            {
-                DeleteBuffer();
-                isDisposed = true;
-            }
+            DeleteBuffer();
         }
 
-        ~VertexArrayBase()
-        {
-            Dispose(disposing: false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
     }
 
 }

--- a/SourceCode/AgOpenGPS.Core/Models/Field/BingMap.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Field/BingMap.cs
@@ -1,8 +1,9 @@
-﻿using System.Drawing;
+﻿using AgOpenGPS.Core.Base;
+using System.Drawing;
 
 namespace AgOpenGPS.Core.Models
 {
-    public class BingMap
+    public class BingMap : DisposableObject
     {
         public BingMap(
             GeoBoundingBox geoBoundingBox,
@@ -15,5 +16,9 @@ namespace AgOpenGPS.Core.Models
         public GeoBoundingBox GeoBoundingBox { get; }
         public Bitmap Bitmap { get; }
 
+        protected override void OnDispose()
+        {
+            Bitmap.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Let new base class DisposableObject take care of Dispose pattern
Subclasses only need to override the method OnDispose to implement the Dispose pattern
and let the class DisposableObject takes care of the rest.