### PR TITLE
Fix exception when opening Bing map

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
+  # Runtime to publish for (Windows 64-bit)
+  PUBLISH_RUNTIME: win-x64
+
   # Path to the output folder
   PUBLISH_DIR: ./AgOpenGPS
 
@@ -55,7 +58,7 @@ jobs:
       run: dotnet test --no-restore --no-build ${{env.SOLUTION_FILE_PATH}}
 
     - name: Publish
-      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} --runtime ${{env.PUBLISH_RUNTIME}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
+  # Runtime to publish for (Windows 64-bit)
+  PUBLISH_RUNTIME: win-x64
+
   # Path to the output folder
   PUBLISH_DIR: ./AgOpenGPS
 
@@ -52,7 +55,7 @@ jobs:
       run: dotnet test --no-restore --no-build ${{env.SOLUTION_FILE_PATH}}
 
     - name: Publish
-      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} --runtime ${{env.PUBLISH_RUNTIME}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Create AgOpenGPS.zip
       shell: powershell

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -41,6 +41,8 @@
     <PackageReference Include="GMap.NET.WinForms" Version="2.1.7" />
     <PackageReference Include="MechanikaDesign.WinForms.UI.ColorPicker" Version="2.0.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.3.3" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.50.3"/>
+    <PackageReference Include="System.Data.SQLite" Version="2.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />


### PR DESCRIPTION
The `System.Data.Interop.dll` was not copied properly to the output folder.
With version 2.0.1 of `System.Data.SQLite`, that is not an issue anymore, because it does not rely on that DLL anymore.