### PR TITLE
Ensure that builds are always x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,6 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
-  # Runtime to publish for (Windows 64-bit)
-  PUBLISH_RUNTIME: win-x64
-
   # Path to the output folder
   PUBLISH_DIR: ./AgOpenGPS
 
@@ -58,7 +55,7 @@ jobs:
       run: dotnet test --no-restore --no-build ${{env.SOLUTION_FILE_PATH}}
 
     - name: Publish
-      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} --runtime ${{env.PUBLISH_RUNTIME}} ${{env.SOLUTION_FILE_PATH}}
+      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Release
 
-  # Runtime to publish for (Windows 64-bit)
-  PUBLISH_RUNTIME: win-x64
-
   # Path to the output folder
   PUBLISH_DIR: ./AgOpenGPS
 
@@ -55,7 +52,7 @@ jobs:
       run: dotnet test --no-restore --no-build ${{env.SOLUTION_FILE_PATH}}
 
     - name: Publish
-      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} --runtime ${{env.PUBLISH_RUNTIME}} ${{env.SOLUTION_FILE_PATH}}
+      run: dotnet publish --no-restore --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Create AgOpenGPS.zip
       shell: powershell

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>..\..\AgOpenGPS\</PublishDir>
     <ApplicationIcon>AOG.ico</ApplicationIcon>
     <UseWindowsForms>true</UseWindowsForms>


### PR DESCRIPTION
Local builds still crashed when opening the Bing map.

This change ensures that local builds also run in x64 mode.