### PR TITLE
Bugfix/imperial tramwidth

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/Units.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/Units.cs
@@ -24,6 +24,8 @@ namespace AgOpenGPS.Core.Models
         private const double milesToKilometers = 1.609344;
         private const double kilometersToMiles = 1 / milesToKilometers;
         private const double metersToFeet = 3.28;
+        private const double metersToInches = 39.3701;
+        private const double metersToCm = 100;
         private const double metersToMiles = metersToKilometers * kilometersToMiles;
 
         private double _distanceInMeters;
@@ -36,6 +38,53 @@ namespace AgOpenGPS.Core.Models
         public double InKilometers => _distanceInMeters * metersToKilometers;
         public double InMiles => _distanceInMeters * metersToMiles;
         public double InFeet => _distanceInMeters * metersToFeet;
+
+
+        // Return the distance (value and unit) in a string expressed in cm or inches, (depending on argument isMetric)
+        // Use 0 decimals for cm and 1 decimal for inches.
+
+        public static string VerySmallDistanceString(bool isMetric, double distanceInMeters)
+        {
+            if (isMetric)
+            {
+                return (distanceInMeters * metersToCm).ToString("N0") + " cm";
+            }
+            else
+            {
+                return (distanceInMeters * metersToInches).ToString("N1") + " in";
+            }
+        }
+
+        // Return the distance (value and unit) in a string expressed in cm or inches, (depending on argument isMetric)
+        // Use 0 decimals for both cm and inches.
+        public static string SmallDistanceString(bool isMetric, double distanceInMeters)
+        {
+            if (isMetric)
+            {
+                return (distanceInMeters * metersToCm).ToString("N0") + " cm";
+            }
+            else
+            {
+                return (distanceInMeters * metersToInches).ToString("N0") + " in";
+            }
+        }
+
+        // Return the distance (value and unit) in a string expressed in meters or feet and inches, (depending on argument isMetric)
+        public static string MediumDistanceString(bool isMetric, double distanceInMeters)
+        {
+            if (isMetric)
+            {
+                return distanceInMeters.ToString() + " m";
+            }
+            else
+            {
+                int totalInches = Convert.ToInt32(distanceInMeters * metersToInches);
+                int feet = totalInches / 12;
+                int inches = totalInches - 12 * feet;
+                return feet.ToString() + "' " + inches.ToString() + '"';
+            }
+        }
+
     }
 
     public class Area

--- a/SourceCode/AgOpenGPS.Core/Models/Base/Units.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/Units.cs
@@ -74,7 +74,7 @@ namespace AgOpenGPS.Core.Models
         {
             if (isMetric)
             {
-                return distanceInMeters.ToString() + " m";
+                return distanceInMeters.ToString("N2") + " m";
             }
             else
             {

--- a/SourceCode/GPS/Forms/Config/ConfigSummaryControl.cs
+++ b/SourceCode/GPS/Forms/Config/ConfigSummaryControl.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using AgOpenGPS.Core.Models;
 using AgOpenGPS.Core.Translations;
 
 namespace AgOpenGPS.Forms.Config
@@ -30,35 +31,19 @@ namespace AgOpenGPS.Forms.Config
 
         public void UpdateSummary(FormGPS mf)
         {
-            lblSumWheelbase.Text = (mf.isMetric ?
-                (Properties.Settings.Default.setVehicle_wheelbase * mf.m2InchOrCm).ToString("N0") :
-                (Properties.Settings.Default.setVehicle_wheelbase * mf.m2InchOrCm).ToString("N0"))
-                + mf.unitsInCm;
+            lblSumWheelbase.Text = Distance.SmallDistanceString(mf.isMetric, Properties.Settings.Default.setVehicle_wheelbase);
 
             lblSumNumSections.Text = mf.tool.numOfSections.ToString();
 
-            string snapDist = mf.isMetric ?
-                Properties.Settings.Default.setAS_snapDistance.ToString() :
-                (Properties.Settings.Default.setAS_snapDistance * mf.cm2CmOrIn).ToString("N1");
-
-            lblNudgeDistance.Text = snapDist + mf.unitsInCm.ToString();
+            lblNudgeDistance.Text = Distance.VerySmallDistanceString(mf.isMetric, 0.01 * Properties.Settings.Default.setAS_snapDistance);
             lblUnits.Text = mf.isMetric ? "Metric" : "Imperial";
 
             lblSummaryVehicleName.Text = gStr.gsCurrent + ": " + RegistrySettings.vehicleFileName;
 
-            lblTramWidth.Text = mf.isMetric ?
-                ((Properties.Settings.Default.setTram_tramWidth).ToString() + " m") :
-                ConvertMeterToFeet(Properties.Settings.Default.setTram_tramWidth);
+            lblTramWidth.Text = Distance.MediumDistanceString(mf.isMetric, Properties.Settings.Default.setTram_tramWidth);
 
-            lblToolOffset.Text = (mf.isMetric ?
-                (Properties.Settings.Default.setVehicle_toolOffset * mf.m2InchOrCm).ToString() :
-                (Properties.Settings.Default.setVehicle_toolOffset * mf.m2InchOrCm).ToString("N1")) +
-                mf.unitsInCm;
-
-            lblOverlap.Text = (mf.isMetric ?
-                (Properties.Settings.Default.setVehicle_toolOverlap * mf.m2InchOrCm).ToString() :
-                (Properties.Settings.Default.setVehicle_toolOverlap * mf.m2InchOrCm).ToString("N1")) +
-                mf.unitsInCm;
+            lblToolOffset.Text = Distance.SmallDistanceString(mf.isMetric, Properties.Settings.Default.setVehicle_toolOffset);
+            lblOverlap.Text = Distance.SmallDistanceString(mf.isMetric, Properties.Settings.Default.setVehicle_toolOverlap);
 
             lblLookahead.Text = Properties.Settings.Default.setVehicle_toolLookAheadOn.ToString() + " sec";
         }
@@ -68,13 +53,5 @@ namespace AgOpenGPS.Forms.Config
             lblSummaryWidth.Text = widthText;
         }
 
-        private string ConvertMeterToFeet(double meter)
-        {
-            double toFeet = meter * 3.28;
-            string feetInch = Convert.ToString((int)toFeet) + "' ";
-            double temp = Math.Round((toFeet - Math.Truncate(toFeet)) * 12, 0);
-            feetInch += Convert.ToString(temp) + '"';
-            return feetInch;
-        }
     }
 }

--- a/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigTool.Designer.cs
@@ -1118,7 +1118,7 @@ namespace AgOpenGPS
                 Properties.Settings.Default.Save();
 
                 lblVehicleToolWidth.Text = Convert.ToString((int)(numberOfSections * defaultSectionWidth * 100 * mf.cm2CmOrIn));
-                SectionFeetInchesTotalWidthLabelUpdate();
+                SectionFeetInchesTotalWidthLabelUpdate(mf.isMetric, mf.tool.width);
                 FillZoneNudsWithDefaultValues();
                 SetNudZoneVisibility();
             }
@@ -1311,43 +1311,17 @@ namespace AgOpenGPS
 
             lblVehicleToolWidth.Text = Convert.ToString((int)toolWidth);
 
-            SectionFeetInchesTotalWidthLabelUpdate();
+            SectionFeetInchesTotalWidthLabelUpdate(mf.isMetric, mf.tool.width);
         }
 
         //update tool width label at bottom of window
-        private void SectionFeetInchesTotalWidthLabelUpdate()
+        private void SectionFeetInchesTotalWidthLabelUpdate(bool isMetric, double toolWidthInMeters)
         {
-            if (mf.isMetric)
-            {
-                lblInchesCm.Text = gStr.gsCentimeters;
-                lblFeetMeters.Text = gStr.gsMeters;
-                lblSecTotalWidthFeet.Visible = false;
-                lblSecTotalWidthInches.Visible = false;
-                lblSecTotalWidthMeters.Visible = true;
-            }
-            else
-            {
-                lblInchesCm.Text = gStr.gsInches;
-                lblFeetMeters.Text = "Feet";
-                lblSecTotalWidthFeet.Visible = true;
-                lblSecTotalWidthInches.Visible = true;
-                lblSecTotalWidthMeters.Visible = false;
-            }
+            lblInchesCm.Text = isMetric ? gStr.gsCentimeters : gStr.gsInches;
+            lblFeetMeters.Text = isMetric ? gStr.gsMeters : "Feet";
 
-            if (mf.isMetric)
-            {
-                lblSecTotalWidthMeters.Text = ((int)(mf.tool.width * 100)).ToString() + " cm";
-                configSummaryControl.SetSummaryWidth(mf.tool.width.ToString("N2") + " m");
-            }
-            else
-            {
-                double toFeet = (Convert.ToDouble(lblVehicleToolWidth.Text) * 0.08334);
-                lblSecTotalWidthFeet.Text = Convert.ToString((int)toFeet) + "'";
-                double temp = Math.Round((toFeet - Math.Truncate(toFeet)) * 12, 0);
-                lblSecTotalWidthInches.Text = Convert.ToString(temp) + '"';
-
-                configSummaryControl.SetSummaryWidth(lblSecTotalWidthFeet.Text + " " + lblSecTotalWidthInches.Text);
-            }
+            lblSecTotalWidth.Text = Distance.MediumDistanceString(isMetric, toolWidthInMeters);
+            configSummaryControl.SetSummaryWidth(lblSecTotalWidth.Text);
         }
 
         //Convert section width to positions along toolbar

--- a/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.Designer.cs
@@ -477,10 +477,8 @@ namespace AgOpenGPS
             this.chkDisplayExtraGuides = new System.Windows.Forms.CheckBox();
             this.labelCurrentVehicle = new System.Windows.Forms.Label();
             this.lblInchesCm = new System.Windows.Forms.Label();
-            this.lblSecTotalWidthMeters = new System.Windows.Forms.Label();
+            this.lblSecTotalWidth = new System.Windows.Forms.Label();
             this.labelToolWidthBottom = new System.Windows.Forms.Label();
-            this.lblSecTotalWidthFeet = new System.Windows.Forms.Label();
-            this.lblSecTotalWidthInches = new System.Windows.Forms.Label();
             this.panelBottom = new System.Windows.Forms.Panel();
             this.lblFeetMeters = new System.Windows.Forms.Label();
             this.btnOK = new System.Windows.Forms.Button();
@@ -8518,15 +8516,15 @@ namespace AgOpenGPS
             // 
             // lblSecTotalWidthMeters
             // 
-            this.lblSecTotalWidthMeters.AutoSize = true;
-            this.lblSecTotalWidthMeters.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblSecTotalWidthMeters.ForeColor = System.Drawing.Color.Black;
-            this.lblSecTotalWidthMeters.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblSecTotalWidthMeters.Location = new System.Drawing.Point(632, 32);
-            this.lblSecTotalWidthMeters.Name = "lblSecTotalWidthMeters";
-            this.lblSecTotalWidthMeters.Size = new System.Drawing.Size(32, 25);
-            this.lblSecTotalWidthMeters.TabIndex = 302;
-            this.lblSecTotalWidthMeters.Text = "II";
+            this.lblSecTotalWidth.AutoSize = true;
+            this.lblSecTotalWidth.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblSecTotalWidth.ForeColor = System.Drawing.Color.Black;
+            this.lblSecTotalWidth.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.lblSecTotalWidth.Location = new System.Drawing.Point(632, 32);
+            this.lblSecTotalWidth.Name = "lblSecTotalWidthMeters";
+            this.lblSecTotalWidth.Size = new System.Drawing.Size(32, 25);
+            this.lblSecTotalWidth.TabIndex = 302;
+            this.lblSecTotalWidth.Text = "II";
             // 
             // labelToolWidthBottom
             // 
@@ -8540,40 +8538,14 @@ namespace AgOpenGPS
             this.labelToolWidthBottom.Text = "Tool Width:";
             this.labelToolWidthBottom.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // lblSecTotalWidthFeet
-            // 
-            this.lblSecTotalWidthFeet.AutoSize = true;
-            this.lblSecTotalWidthFeet.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblSecTotalWidthFeet.ForeColor = System.Drawing.Color.Black;
-            this.lblSecTotalWidthFeet.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblSecTotalWidthFeet.Location = new System.Drawing.Point(620, 32);
-            this.lblSecTotalWidthFeet.Name = "lblSecTotalWidthFeet";
-            this.lblSecTotalWidthFeet.Size = new System.Drawing.Size(36, 25);
-            this.lblSecTotalWidthFeet.TabIndex = 298;
-            this.lblSecTotalWidthFeet.Text = "FF";
-            // 
-            // lblSecTotalWidthInches
-            // 
-            this.lblSecTotalWidthInches.AutoSize = true;
-            this.lblSecTotalWidthInches.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblSecTotalWidthInches.ForeColor = System.Drawing.Color.Black;
-            this.lblSecTotalWidthInches.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblSecTotalWidthInches.Location = new System.Drawing.Point(679, 32);
-            this.lblSecTotalWidthInches.Name = "lblSecTotalWidthInches";
-            this.lblSecTotalWidthInches.Size = new System.Drawing.Size(32, 25);
-            this.lblSecTotalWidthInches.TabIndex = 300;
-            this.lblSecTotalWidthInches.Text = "II";
-            // 
             // panelBottom
             // 
             this.panelBottom.BackColor = System.Drawing.SystemColors.GradientInactiveCaption;
             this.panelBottom.Controls.Add(this.lblFeetMeters);
             this.panelBottom.Controls.Add(this.labelToolWidthBottom);
-            this.panelBottom.Controls.Add(this.lblSecTotalWidthInches);
-            this.panelBottom.Controls.Add(this.lblSecTotalWidthFeet);
             this.panelBottom.Controls.Add(this.btnOK);
             this.panelBottom.Controls.Add(this.lblInchesCm);
-            this.panelBottom.Controls.Add(this.lblSecTotalWidthMeters);
+            this.panelBottom.Controls.Add(this.lblSecTotalWidth);
             this.panelBottom.Controls.Add(this.labelCurrentVehicle);
             this.panelBottom.Controls.Add(this.labelUnitsBottom);
             this.panelBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
@@ -8879,10 +8851,8 @@ namespace AgOpenGPS
         private System.Windows.Forms.Label labelCoverage;
         private NudlessNumericUpDown nudMinCoverage;
         private System.Windows.Forms.Label labelNumOfSections;
-        private System.Windows.Forms.Label lblSecTotalWidthMeters;
+        private System.Windows.Forms.Label lblSecTotalWidth;
         private System.Windows.Forms.Label labelToolWidthBottom;
-        private System.Windows.Forms.Label lblSecTotalWidthFeet;
-        private System.Windows.Forms.Label lblSecTotalWidthInches;
         private System.Windows.Forms.Label lblInchesCm;
         private System.Windows.Forms.Button btnRemoveZeroOffset;
         private System.Windows.Forms.Label lblRollZeroOffset;

--- a/SourceCode/GPS/Forms/Settings/FormConfig.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.cs
@@ -109,7 +109,7 @@ namespace AgOpenGPS
 
             //tabTSections_Enter(this, e);
             lblVehicleToolWidth.Text = Convert.ToString((int)(mf.tool.width * 100 * mf.cm2CmOrIn));
-            SectionFeetInchesTotalWidthLabelUpdate();
+            SectionFeetInchesTotalWidthLabelUpdate(mf.isMetric, mf.tool.width);
 
             tab1.SelectedTab = tabSummary;
             //Label translations
@@ -359,7 +359,7 @@ namespace AgOpenGPS
 
         private void tabSummary_Enter(object sender, EventArgs e)
         {
-            SectionFeetInchesTotalWidthLabelUpdate();
+            SectionFeetInchesTotalWidthLabelUpdate(mf.isMetric, mf.tool.width);
             UpdateSummary();
         }
 


### PR DESCRIPTION
Fix bug #916: Correctly display imperial tram width.

First round to inches before splitting feets and inches. (Splitting first and round later results in things like 89'12")

Fix same problem in display of Tool Width at bottom row of ConfigTool