### PR TITLE
Fix AccessViolationException when closing application

### DIFF
--- a/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Texture2D.cs
@@ -100,7 +100,12 @@ namespace AgOpenGPS.Core.DrawLib
         {
             if (!isDisposed)
             {
-                DeleteTexture();
+                if (disposing)
+                {
+                    // Only delete texture when explicitly disposed, not during finalization
+                    // OpenGL calls require an active context and must be on the correct thread
+                    DeleteTexture();
+                }
                 isDisposed = true;
             }
         }


### PR DESCRIPTION
- Prevents AccessViolationException crashes when closing the application by only calling OpenGL texture deletion during explicit disposal, not during finalization
- OpenGL calls require an active context and must be on the correct thread, which cannot be guaranteed during garbage collection finalization