### PR TITLE
Field path must fit in 'Delete For Sure' Dialog

### DIFF
--- a/SourceCode/GPS/Forms/Pickers/FormFilePicker.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormFilePicker.cs
@@ -333,9 +333,19 @@ namespace AgOpenGPS
                 return;
 
             string dir2Delete = Path.Combine(RegistrySettings.fieldsDirectory, fieldName);
-
+            int maxLength = 45;
+            string multiLineDir = dir2Delete;
+            // Split directory name if it is too long for 1 line
+            if (maxLength < dir2Delete.Length)
+            {
+                int sep = dir2Delete.LastIndexOf('\\', maxLength);
+                if (sep != -1)
+                {
+                    multiLineDir = dir2Delete.Insert(sep + 1, "\n");
+                }
+            }
             // Keep this dialog here; it is a user action (delete confirmation), not loader validation.
-            if (FormDialog.Show(dir2Delete, gStr.gsDeleteForSure, MessageBoxButtons.YesNo) != DialogResult.OK)
+            if (FormDialog.Show(gStr.gsDeleteForSure, multiLineDir, MessageBoxButtons.YesNo) != DialogResult.OK)
                 return;
 
             try


### PR DESCRIPTION
When deleting a field, a confirmation dialog is shown with the path of the field.
This change splits the path of the field in two lines if it does not fit.
It solves the first part of issue # 906, but it does not change the texts.
