### PR TITLE
Fix goal point displaying in Stanley mode

### DIFF
--- a/SourceCode/GPS/Classes/CABCurve.cs
+++ b/SourceCode/GPS/Classes/CABCurve.cs
@@ -1054,16 +1054,6 @@ namespace AgOpenGPS
                     for (int h = 0; h < curList.Count; h++) GL.Vertex3(curList[h].easting, curList[h].northing, 0);
                     GL.End();
 
-                    if (!mf.isStanleyUsed && mf.camera.camSetDistance > -200)
-                    {
-                        //Draw lookahead Point
-                        GL.PointSize(4.0f);
-                        GL.Begin(PrimitiveType.Points);
-                        GL.Color3(1.0f, 0.95f, 0.195f);
-                        GL.Vertex3(goalPointCu.easting, goalPointCu.northing, 0.0);
-                        GL.End();
-                    }
-
                     //GL.Disable(EnableCap.LineSmooth);
 
                     mf.yt.DrawYouTurn();

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -439,7 +439,7 @@ namespace AgOpenGPS
 
                     if (camera.camSetDistance > -250)
                     {
-                        if (trk.idx > -1)
+                        if (trk.idx > -1 && !isStanleyUsed)
                         {
                             PointStyle backgroundPointStyle = new PointStyle(12.0f, Colors.Black);
                             PointStyle foregroundPointStyle = new PointStyle(6.0f, Colors.GoalPointColor);


### PR DESCRIPTION
Fixes yellow lookahead dot incorrectly appearing when using Stanley guidance mode. Stanley uses a different steering algorithm and doesn't use lookahead points like Pure Pursuit does.

**Changes:**
- Add Stanley mode check to goal point rendering in OpenGL.Designer.cs
- Remove duplicate drawing code from CABCurve.cs

**Test plan:**
- [x] Switch between Pure Pursuit and Stanley modes
- [x] Verify yellow dot appears only in Pure Pursuit mode
- [x] Verify yellow dot disappears immediately when switching to Stanley