### PR TITLE
Bugfix/932 workedareapreview

### DIFF
--- a/SourceCode/GPS/Classes/CABLine.cs
+++ b/SourceCode/GPS/Classes/CABLine.cs
@@ -1,4 +1,3 @@
-using AgOpenGPS.Core.DrawLib;
 using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
 using System;
@@ -346,6 +345,7 @@ namespace AgOpenGPS
             mf.font.DrawText3D(desPtA.easting, desPtA.northing, "&A", mf.camHeading);
             mf.font.DrawText3D(desPtB.easting, desPtB.northing, "&B", mf.camHeading);
         }
+
         public void DrawABLines()
         {
             //Draw AB Points


### PR DESCRIPTION
The width and position of the worked area preview', must not depend on the tool overlap.