### PR TITLE
Fix articulated hitch offset for tool projection

### DIFF
--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -122,6 +122,23 @@ namespace AgOpenGPS
             isDisplayTramControl = Properties.Settings.Default.setTool_isDisplayTramControl;
         }
 
+        public double GetHitchLengthFromVehiclePivot()
+        {
+            double pivotToHitch = hitchLength;
+
+            if (mf.vehicle.VehicleConfig.Type == VehicleType.Articulated && !glm.IsZero(pivotToHitch))
+            {
+                double halfWheelbase = 0.5 * mf.vehicle.VehicleConfig.Wheelbase;
+
+                if (!glm.IsZero(halfWheelbase))
+                {
+                    pivotToHitch += Math.Sign(pivotToHitch) * halfWheelbase;
+                }
+            }
+
+            return pivotToHitch;
+        }
+
         private void DrawHitch(double trailingTank)
         {
             XyCoord[] vertices = {
@@ -155,8 +172,11 @@ namespace AgOpenGPS
             GL.PushMatrix();
 
             //translate down to the hitch pin
-            GL.Translate(Math.Sin(mf.fixHeading) * (hitchLength),
-                            Math.Cos(mf.fixHeading) * (hitchLength), 0);
+            double pivotToHitchLength = GetHitchLengthFromVehiclePivot();
+            GL.Translate(
+                Math.Sin(mf.fixHeading) * pivotToHitchLength,
+                Math.Cos(mf.fixHeading) * pivotToHitchLength,
+                0);
 
             //settings doesn't change trailing hitch length if set to rigid, so do it here
             double trailingTank, trailingTool;

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -145,18 +145,19 @@ namespace AgOpenGPS
             if (mf.isFirstHeadingSet && !mf.tool.isToolFrontFixed)
             {
                 // Draw the rigid hitch
+                double hitchLengthFromPivot = mf.tool.GetHitchLengthFromVehiclePivot();
                 XyCoord[] vertices;
                 if (!mf.tool.isToolRearFixed)
                 {
                     vertices = new XyCoord[] {
-                        new XyCoord(0, mf.tool.hitchLength), new XyCoord(0, 0)
+                        new XyCoord(0, hitchLengthFromPivot), new XyCoord(0, 0)
                     };
                 }
                 else
                 {
                     vertices = new XyCoord[] {
-                        new XyCoord(-0.35, mf.tool.hitchLength), new XyCoord(-0.35, 0),
-                        new XyCoord( 0.35, mf.tool.hitchLength), new XyCoord( 0.35, 0)
+                        new XyCoord(-0.35, hitchLengthFromPivot), new XyCoord(-0.35, 0),
+                        new XyCoord( 0.35, hitchLengthFromPivot), new XyCoord( 0.35, 0)
                     };
                 }
                 LineStyle backgroundLineStyle = new LineStyle(4, Colors.Black);

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -1298,8 +1298,9 @@ namespace AgOpenGPS
             
 
             //determine where the rigid vehicle hitch ends
-            hitchPos.easting = pn.fix.easting + (Math.Sin(fixHeading) * (tool.hitchLength - vehicle.VehicleConfig.AntennaPivot));
-            hitchPos.northing = pn.fix.northing + (Math.Cos(fixHeading) * (tool.hitchLength - vehicle.VehicleConfig.AntennaPivot));
+            double hitchLengthFromPivot = tool.GetHitchLengthFromVehiclePivot();
+            hitchPos.easting = pn.fix.easting + (Math.Sin(fixHeading) * (hitchLengthFromPivot - vehicle.VehicleConfig.AntennaPivot));
+            hitchPos.northing = pn.fix.northing + (Math.Cos(fixHeading) * (hitchLengthFromPivot - vehicle.VehicleConfig.AntennaPivot));
 
             //tool attached via a trailing hitch
             if (tool.isToolTrailing)


### PR DESCRIPTION
## Summary
- add a helper to derive the hitch offset from the vehicle pivot for articulated tractors
- use the articulated-aware hitch length when drawing the hitch and positioning the tool

## Testing
- dotnet build SourceCode/AgOpenGPS.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68efe0946e688332bc17ef03dd77a2c0