### PR TITLE
Correct articulated hitch heading orientation

### DIFF
--- a/SourceCode/AgIO/Source/Classes/CGLM.cs
+++ b/SourceCode/AgIO/Source/Classes/CGLM.cs
@@ -5,6 +5,13 @@ namespace AgIO
 {
     public static class glm
     {
+        private const double DefaultZeroTolerance = 1e-6;
+
+        public static bool IsZero(double value, double tolerance = DefaultZeroTolerance)
+        {
+            return Math.Abs(value) <= tolerance;
+        }
+
         //Regex file expression
         public const string fileRegex = "(^(PRN|AUX|NUL|CON|COM[1-9]|LPT[1-9]|(\\.+)$)(\\..*)?$)|(([\\x00-\\x1f\\\\?*:\";‌​|/<>])+)|([\\.]+)";
 

--- a/SourceCode/GPS/Classes/CGLM.cs
+++ b/SourceCode/GPS/Classes/CGLM.cs
@@ -9,6 +9,13 @@ namespace AgOpenGPS
 
     public static class glm
     {
+        private const double DefaultZeroTolerance = 1e-6;
+
+        public static bool IsZero(double value, double tolerance = DefaultZeroTolerance)
+        {
+            return Math.Abs(value) <= tolerance;
+        }
+
         public static bool InRangeBetweenAB(double start_x, double start_y, double end_x, double end_y,
           double point_x, double point_y)
         {

--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -122,6 +122,61 @@ namespace AgOpenGPS
             isDisplayTramControl = Properties.Settings.Default.setTool_isDisplayTramControl;
         }
 
+        public double GetHitchLengthFromVehiclePivot()
+        {
+            double pivotToHitch = hitchLength;
+
+            if (mf.vehicle.VehicleConfig.Type == VehicleType.Articulated && !glm.IsZero(pivotToHitch))
+            {
+                double halfWheelbase = 0.5 * mf.vehicle.VehicleConfig.Wheelbase;
+
+                if (!glm.IsZero(halfWheelbase))
+                {
+                    pivotToHitch += Math.Sign(pivotToHitch) * halfWheelbase;
+                }
+            }
+
+            return pivotToHitch;
+        }
+
+        public double GetHitchHeadingFromVehiclePivot(double pivotToHitchLength)
+        {
+            double hitchHeading = mf.fixHeading;
+
+            if (mf.vehicle.VehicleConfig.Type == VehicleType.Articulated && !glm.IsZero(pivotToHitchLength))
+            {
+                double steerAngleDegrees = mf.timerSim.Enabled ? mf.sim.steerAngle : mf.mc.actualSteerAngleDegrees;
+                double halfArticulationRadians = glm.toRadians(0.5 * steerAngleDegrees);
+
+                if (pivotToHitchLength > 0)
+                {
+                    hitchHeading -= halfArticulationRadians;
+                }
+                else
+                {
+                    hitchHeading += halfArticulationRadians;
+                }
+
+                hitchHeading = NormalizeAngle(hitchHeading);
+            }
+
+            return hitchHeading;
+        }
+
+        private static double NormalizeAngle(double angle)
+        {
+            if (angle < 0)
+            {
+                angle = (angle % glm.twoPI) + glm.twoPI;
+            }
+            else if (angle >= glm.twoPI)
+            {
+                angle %= glm.twoPI;
+            }
+
+            return angle;
+        }
+
         private void DrawHitch(double trailingTank)
         {
             XyCoord[] vertices = {
@@ -155,8 +210,12 @@ namespace AgOpenGPS
             GL.PushMatrix();
 
             //translate down to the hitch pin
-            GL.Translate(Math.Sin(mf.fixHeading) * (hitchLength),
-                            Math.Cos(mf.fixHeading) * (hitchLength), 0);
+            double pivotToHitchLength = GetHitchLengthFromVehiclePivot();
+            double hitchHeading = GetHitchHeadingFromVehiclePivot(pivotToHitchLength);
+            GL.Translate(
+                Math.Sin(hitchHeading) * pivotToHitchLength,
+                Math.Cos(hitchHeading) * pivotToHitchLength,
+                0);
 
             //settings doesn't change trailing hitch length if set to rigid, so do it here
             double trailingTank, trailingTool;

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -145,18 +145,33 @@ namespace AgOpenGPS
             if (mf.isFirstHeadingSet && !mf.tool.isToolFrontFixed)
             {
                 // Draw the rigid hitch
+                double hitchLengthFromPivot = mf.tool.GetHitchLengthFromVehiclePivot();
+                double hitchHeading = mf.tool.GetHitchHeadingFromVehiclePivot(hitchLengthFromPivot);
+                double hitchAngleOffset = hitchHeading - mf.fixHeading;
+                double sinOffset = Math.Sin(hitchAngleOffset);
+                double cosOffset = Math.Cos(hitchAngleOffset);
+
+                XyCoord TransformVertex(double lateral, double longitudinal)
+                {
+                    double x = lateral * cosOffset + longitudinal * sinOffset;
+                    double y = longitudinal * cosOffset - lateral * sinOffset;
+                    return new XyCoord(x, y);
+                }
+
                 XyCoord[] vertices;
                 if (!mf.tool.isToolRearFixed)
                 {
-                    vertices = new XyCoord[] {
-                        new XyCoord(0, mf.tool.hitchLength), new XyCoord(0, 0)
+                    vertices = new XyCoord[]
+                    {
+                        TransformVertex(0, hitchLengthFromPivot), TransformVertex(0, 0)
                     };
                 }
                 else
                 {
-                    vertices = new XyCoord[] {
-                        new XyCoord(-0.35, mf.tool.hitchLength), new XyCoord(-0.35, 0),
-                        new XyCoord( 0.35, mf.tool.hitchLength), new XyCoord( 0.35, 0)
+                    vertices = new XyCoord[]
+                    {
+                        TransformVertex(-0.35, hitchLengthFromPivot), TransformVertex(-0.35, 0),
+                        TransformVertex( 0.35, hitchLengthFromPivot), TransformVertex( 0.35, 0)
                     };
                 }
                 LineStyle backgroundLineStyle = new LineStyle(4, Colors.Black);

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -1298,8 +1298,11 @@ namespace AgOpenGPS
             
 
             //determine where the rigid vehicle hitch ends
-            hitchPos.easting = pn.fix.easting + (Math.Sin(fixHeading) * (tool.hitchLength - vehicle.VehicleConfig.AntennaPivot));
-            hitchPos.northing = pn.fix.northing + (Math.Cos(fixHeading) * (tool.hitchLength - vehicle.VehicleConfig.AntennaPivot));
+            double hitchLengthFromPivot = tool.GetHitchLengthFromVehiclePivot();
+            double hitchHeading = tool.GetHitchHeadingFromVehiclePivot(hitchLengthFromPivot);
+            double hitchDistanceFromAntenna = hitchLengthFromPivot - vehicle.VehicleConfig.AntennaPivot;
+            hitchPos.easting = pn.fix.easting + (Math.Sin(hitchHeading) * hitchDistanceFromAntenna);
+            hitchPos.northing = pn.fix.northing + (Math.Cos(hitchHeading) * hitchDistanceFromAntenna);
 
             //tool attached via a trailing hitch
             if (tool.isToolTrailing)
@@ -1315,7 +1318,7 @@ namespace AgOpenGPS
                     }
 
                     ////the tool is seriously jacknifed or just starting out so just spring it back.
-                    over = Math.Abs(Math.PI - Math.Abs(Math.Abs(tankPos.heading - fixHeading) - Math.PI));
+                    over = Math.Abs(Math.PI - Math.Abs(Math.Abs(tankPos.heading - hitchHeading) - Math.PI));
 
                     if (over < 2.0 && startCounter > 50)
                     {
@@ -1326,14 +1329,14 @@ namespace AgOpenGPS
                     //criteria for a forced reset to put tool directly behind vehicle
                     if (over > 2.0 | startCounter < 51)
                     {
-                        tankPos.heading = fixHeading;
+                        tankPos.heading = hitchHeading;
                         tankPos.easting = hitchPos.easting + (Math.Sin(tankPos.heading) * (tool.tankTrailingHitchLength));
                         tankPos.northing = hitchPos.northing + (Math.Cos(tankPos.heading) * (tool.tankTrailingHitchLength));
                     }
                 }
                 else
                 {
-                    tankPos.heading = fixHeading;
+                    tankPos.heading = hitchHeading;
                     tankPos.easting = hitchPos.easting;
                     tankPos.northing = hitchPos.northing;
                 }
@@ -1372,11 +1375,11 @@ namespace AgOpenGPS
             //rigidly connected to vehicle
             else
             {
-                toolPivotPos.heading = fixHeading;
+                toolPivotPos.heading = hitchHeading;
                 toolPivotPos.easting = hitchPos.easting;
                 toolPivotPos.northing = hitchPos.northing;
 
-                toolPos.heading = fixHeading;
+                toolPos.heading = hitchHeading;
                 toolPos.easting = hitchPos.easting;
                 toolPos.northing = hitchPos.northing;
             }


### PR DESCRIPTION
## Summary
- adjust the articulated hitch heading calculation so rear-mounted hitches stay aligned with the rear frame instead of the front half while steering

## Testing
- not run (dotnet CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68efe0946e688332bc17ef03dd77a2c0