### PR TITLE
Display of the angle and inverse angle of the current abline

### DIFF
--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -198,11 +198,12 @@ namespace AgOpenGPS
                                     oppositeAbAngle = oppositeAbAngle - 360;
                                 }
 
-                                lblCurrentField.Text = "Line: " + trk.gArr[trk.idx].name + " - " + glm.toDegrees(trk.gArr[trk.idx].heading).ToString("N3") + ", " + oppositeAbAngle.ToString("N3");
+                                GeoDir headingDir = new GeoDir(trk.gArr[trk.idx].heading);
+                                lblCurrentField.Text = gStr.gsABline + ": " + trk.gArr[trk.idx].name + "  " + headingDir.HeadingString("N3") + ", " + headingDir.Inverted.HeadingString("N3");
                             }
                             else
                             {
-                                lblCurrentField.Text = "Line: " + gStr.gsNoGuidanceLines;
+                                lblCurrentField.Text = gStr.gsABline + ": " + gStr.gsNoGuidanceLines;
                             }
                             break;
 


### PR DESCRIPTION
Display of the angle and inverse angle of the current abline in the currentField line (top main window). Accuracy of 5 decimal places. 1. to visualize the abline angle when working with abline names; 2. to verify the direction of travel—for example, when driving with a Dual system; 3. for exchange with other drivers/systems.

![abheadingandreverse](https://github.com/user-attachments/assets/f4b13fd2-f8fa-4075-b201-27b4755b8b0c)