### PR TITLE
Add method HeadingString to GeoDir.

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/GeoDir.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/GeoDir.cs
@@ -12,15 +12,36 @@ namespace AgOpenGPS.Core.Models
         public GeoDir(GeoDelta delta)
         {
             AngleInRadians = Math.Atan2(delta.EastingDelta, delta.NorthingDelta);
+            if (AngleInRadians < 0.0) AngleInRadians += 2 * Math.PI;
         }
 
+        // The returned angle will be in the range [0.0 ... 2 * PI >
+        // Also internally, GeoDir will always keep the angle in this range, so it does not need to be checked
+        // for each frame that wants to display the HeadingString.
         public double AngleInRadians { get; }
+
+        // The returned angle will be in the range [0.0 ... 360 >
         public double AngleInDegrees => Units.RadiansToDegrees(AngleInRadians);
 
-        public GeoDir PerpendicularLeft => new GeoDir(AngleInRadians - 0.5 * Math.PI);
+        public GeoDir PerpendicularLeft => new GeoDir(
+            0.5 * Math.PI < AngleInRadians
+            ? AngleInRadians - 0.5 * Math.PI
+            : AngleInRadians + 1.5 * Math.PI);
 
-        public GeoDir PerpendicularRight => new GeoDir(AngleInRadians + 0.5 * Math.PI);
-        public GeoDir Inverted => new GeoDir(AngleInRadians + Math.PI);
+        public GeoDir PerpendicularRight => new GeoDir(
+            1.5 * Math.PI < AngleInRadians
+            ? AngleInRadians - 1.5 * Math.PI
+            : AngleInRadians + 0.5 * Math.PI);
+
+        public GeoDir Inverted => new GeoDir(
+            Math.PI < AngleInRadians
+            ? AngleInRadians - Math.PI
+            : AngleInRadians + Math.PI);
+
+        public string HeadingString(string formatString = "N1")
+        {
+            return AngleInDegrees.ToString(formatString) + "\u00B0";
+        }
 
         public static GeoDelta operator *(double distance, GeoDir dir)
         {
@@ -29,12 +50,19 @@ namespace AgOpenGPS.Core.Models
 
         public static GeoDir operator +(GeoDir dir, double angleInRadians)
         {
-            return new GeoDir(dir.AngleInRadians + angleInRadians);
+            return new GeoDir(NormalizeAngle(dir.AngleInRadians + angleInRadians));
         }
 
         public static GeoDir operator -(GeoDir dir, double angleInRadians)
         {
-            return new GeoDir(dir.AngleInRadians - angleInRadians);
+            return new GeoDir(NormalizeAngle(dir.AngleInRadians - angleInRadians));
+        }
+
+        private static double NormalizeAngle(double angleInRadians)
+        {
+            while (angleInRadians < 0.0) angleInRadians += 2 * Math.PI;
+            while (2 * Math.PI < angleInRadians) angleInRadians -= 2 * Math.PI;
+            return angleInRadians;
         }
 
     }

--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -1482,8 +1482,8 @@ namespace AgOpenGPS
         public string Longitude { get { return Convert.ToString(Math.Round(AppModel.CurrentLatLon.Longitude, 7)); } }
         public string SatsTracked { get { return Convert.ToString(pn.satellitesTracked); } }
         public string HDOP { get { return Convert.ToString(pn.hdop); } }
-        public string Heading { get { return Convert.ToString(Math.Round(glm.toDegrees(fixHeading), 1)) + "\u00B0"; } }
-        public string GPSHeading { get { return (Math.Round(glm.toDegrees(gpsHeading), 1)) + "\u00B0"; } }
+        public string Heading => AppModel.FixHeading.HeadingString();
+        public string GPSHeading => new GeoDir(gpsHeading).HeadingString();
         public string FixQuality
         {
             get


### PR DESCRIPTION
The new method HeadingString helps to consistently format the display of headings in the whole app.

It avoids the use of Math.Round and delegates the formatting to the ToString function.

The following example shows why Math.Round should be avoided.
Convert.ToString(Math.Round(4.1, 1)) will return "4.1" (or "4,1")

But Convert.ToString(Math.Round(4.0, 1)) will  return "4" and drop the decimal (and as a result is not clear about the accuracy)
