### PR TITLE
Add GeoPolygonTest to show incorrect invalidation of BoundingBox

### DIFF
--- a/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoPolygonTests.cs
+++ b/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoPolygonTests.cs
@@ -28,15 +28,15 @@ namespace AgOpenGPS.Core.Tests.Models
         }
 
 
-        //[Test]
-        //public void Test_IsClockwise()
-        //{
-        //    // Act
-        //    bool isClockwise = _cwPolygon.IsClockwise;
+        [Test]
+        public void Test_IsClockwise()
+        {
+            // Act
+            bool isClockwise = _cwPolygon.IsClockwise;
 
-        //    // Assert
-        //    Assert.That(isClockwise, Is.EqualTo(true));
-        //}
+            // Assert
+            Assert.That(isClockwise, Is.EqualTo(true));
+        }
 
         [Test]
         public void Test_ClockwiseArea()
@@ -61,33 +61,33 @@ namespace AgOpenGPS.Core.Tests.Models
             Assert.That(bb.MaxEasting, Is.EqualTo(_maxEasting));
         }
 
-        //[Test]
-        //public void Test_ForceWinding()
-        //{
-        //    GeoPolygon cwPolygon = CopyPolygon(_cwPolygon);
-        //    double cwArea = cwPolygon.Area;
+        [Test]
+        public void Test_ForceWinding()
+        {
+            GeoPolygon cwPolygon = CopyPolygon(_cwPolygon);
+            double cwArea = cwPolygon.Area;
 
-        //    // Assert
-        //    Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
-        //    cwPolygon.ForceCounterClockwiseWinding();
-        //    Assert.That(cwPolygon.IsClockwise, Is.EqualTo(false));
-        //    Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
+            // Assert
+            Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
+            cwPolygon.ForceCounterClockwiseWinding();
+            Assert.That(cwPolygon.IsClockwise, Is.EqualTo(false));
+            Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
 
-        //    // Test no changes after ForceCounterClockwiseWinding when already CCW
-        //    cwPolygon.ForceCounterClockwiseWinding();
-        //    Assert.That(cwPolygon.IsClockwise, Is.EqualTo(false));
-        //    Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
+            // Test no changes after ForceCounterClockwiseWinding when already CCW
+            cwPolygon.ForceCounterClockwiseWinding();
+            Assert.That(cwPolygon.IsClockwise, Is.EqualTo(false));
+            Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
 
-        //    // Test changes after ForceClockwiseWinding when CCW
-        //    cwPolygon.ForceClockwiseWinding();
-        //    Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
-        //    Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
+            // Test changes after ForceClockwiseWinding when CCW
+            cwPolygon.ForceClockwiseWinding();
+            Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
+            Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
 
-        //    // Test no changes after ForceClockwiseWinding when already CW
-        //    cwPolygon.ForceClockwiseWinding();
-        //    Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
-        //    Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
-        //}
+            // Test no changes after ForceClockwiseWinding when already CW
+            cwPolygon.ForceClockwiseWinding();
+            Assert.That(cwPolygon.IsClockwise, Is.EqualTo(true));
+            Assert.That(cwPolygon.Area, Is.EqualTo(cwArea));
+        }
 
         [Test]
         public void Test_InvalidateArea()

--- a/SourceCode/AgOpenGPS.Core/Models/Base/GeoPolygons/GeoPolygon.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/GeoPolygons/GeoPolygon.cs
@@ -6,15 +6,15 @@ namespace AgOpenGPS.Core.Models
     public class GeoPolygon : GeoPathBase
     {
         protected readonly List<GeoCoord> _coords;
-        protected bool _areaValid;
-        private double _area;
-        private GeoBoundingBox _boundingBox;
+        protected bool _signedAreaValid;
+        private double _signedArea;
         private bool _bbValid;
+        private GeoBoundingBox _boundingBox;
 
         public GeoPolygon()
         {
             _coords = new List<GeoCoord>();
-            _areaValid = true;
+            Invalidate();
         }
 
         public override int Count => _coords.Count;
@@ -24,20 +24,10 @@ namespace AgOpenGPS.Core.Models
             get { return _coords[index]; }
         }
 
-        public GeoCoord Last => this[this.Count - 1];
+        public GeoCoord Last => this[Count - 1];
 
-        public double Area
-        {
-            get
-            {
-                if (!_areaValid)
-                {
-                    _area = CalculateArea();
-                    _areaValid = true;
-                }
-                return _area;
-            }
-        }
+        public double Area => Math.Abs(SignedArea);
+        public bool IsClockwise => SignedArea > 0;
 
         public GeoBoundingBox BoundingBox
         {
@@ -52,18 +42,29 @@ namespace AgOpenGPS.Core.Models
             }
         }
 
+        private double SignedArea
+        {
+            get
+            {
+                if (!_signedAreaValid)
+                {
+                    _signedArea = CalculateSignedArea();
+                    _signedAreaValid = true;
+                }
+                return _signedArea;
+            }
+        }
+
         public void Clear()
         {
             _coords.Clear();
-            _areaValid = false;
-            _bbValid = false;
+            Invalidate();
         }
 
         public virtual void Add(GeoCoord coord)
         {
             _coords.Add(coord);
-            _areaValid = false;
-            _bbValid = false;
+            Invalidate();
         }
 
         public bool IsFarAwayFromPath(GeoCoord testCoord, double minimumDistanceSquared)
@@ -92,7 +93,29 @@ namespace AgOpenGPS.Core.Models
             return result;
         }
 
-        private double CalculateArea()
+        public void ForceClockwiseWinding()
+        {
+            if (!IsClockwise)
+            {
+                ReverseWinding();
+            }
+        }
+
+        public void ForceCounterClockwiseWinding()
+        {
+            if (IsClockwise)
+            {
+                ReverseWinding();
+            }
+        }
+
+        private void ReverseWinding()
+        {
+            _coords.Reverse();
+            _signedArea = -_signedArea;
+        }
+
+        private double CalculateSignedArea()
         {
             double area = 0.0;
             int ptCount = _coords.Count;
@@ -103,10 +126,7 @@ namespace AgOpenGPS.Core.Models
             {
                 area += (_coords[j].Easting + _coords[i].Easting) * (_coords[j].Northing - _coords[i].Northing);
             }
-
-            area = 0.5 * Math.Abs(area);
-
-            return area;
+            return 0.5 * area;
         }
 
         private GeoBoundingBox CalculateBoundingBox()
@@ -118,6 +138,12 @@ namespace AgOpenGPS.Core.Models
                 bb.Include(coord);
             }
             return bb;
+        }
+
+        private void Invalidate()
+        {
+            _signedAreaValid = false;
+            _bbValid = false;
         }
     }
 


### PR DESCRIPTION
I have added one property and two methods to GeoPolygon:
IsClockwise,
ForceClockwiseWinding(), and
ForceCounterClockwiseWinding.
This is one of the small steps I need to do to implement a new class KmlFieldImporter.
KmlFieldImporter will simply return an instance of Field after import. As such, it does not need a dependency to the main form.

During implementation of the new 'Winding' functionality , I spotted a bug in the BoundingBox property of GeoPolygon
The bugfix is also part of this pull request.
