### PR TITLE
Fix empty title in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 ﻿name: Bug Report
 description: Report a bug in a released version of AgOpenGPS
-title: ""
 labels: ["needs-triage"]
 type: "Bug"
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for AgOpenGPS
-title: ""
 labels: ["needs-triage"]
 type: "Feature"
 body:


### PR DESCRIPTION
The following error does currently exist:

> `title` must be of type String and cannot be empty.

That prevents the issue templates from working.