### PR TITLE
Simplify FormAgShareDownloader: let it use GeoBoundingBox

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Models/Base/GeoBoundingBox.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/GeoBoundingBox.cs
@@ -27,6 +27,8 @@ namespace AgOpenGPS.Core.Models
         public double MaxNorthing => _maxCoord.Northing;
         public double MinEasting => _minCoord.Easting;
         public double MaxEasting => _maxCoord.Easting;
+        public GeoCoord MinCoord => _minCoord;
+        public GeoCoord MaxCoord => _maxCoord;
 
         public void Include(GeoCoord geoCoord)
         {
@@ -40,6 +42,7 @@ namespace AgOpenGPS.Core.Models
                 _minCoord.Northing <= testCoord.Northing && testCoord.Northing <= _maxCoord.Northing &&
                 _minCoord.Easting <= testCoord.Easting && testCoord.Easting <= _maxCoord.Easting;
         }
+
     }
 
 }

--- a/SourceCode/GPS/Classes/AgShare/Helpers/LocalFieldModel.cs
+++ b/SourceCode/GPS/Classes/AgShare/Helpers/LocalFieldModel.cs
@@ -27,6 +27,11 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
             Northing = n;
             Heading = heading;
         }
+
+        public GeoCoord ToGeoCoord()
+        {
+            return new GeoCoord(Northing, Easting);
+        }
     }
 
 


### PR DESCRIPTION
This PR is a gentle reminder that we have a GeoBoundingBox available for computations like this.