### PR TITLE
parsed wrong field for roll. (check with unicore, bynav, comnav)

### DIFF
--- a/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/NMEA.Designer.cs
@@ -948,8 +948,9 @@ namespace AgIO
                 float.TryParse(words[2], NumberStyles.Float, CultureInfo.InvariantCulture, out headingTrueDual);
                 headingTrueDualData = headingTrueDual;
 
+
                 //  Console.WriteLine(HeadingForced);
-                float.TryParse(words[3], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);
+                float.TryParse(words[4], NumberStyles.Float, CultureInfo.InvariantCulture, out rollK);
                 // Console.WriteLine(nRoll);
 
                 int.TryParse(words[5], NumberStyles.Float, CultureInfo.InvariantCulture, out int trasolution);


### PR DESCRIPTION
unicore:
<img width="950" height="456" alt="image" src="https://github.com/user-attachments/assets/d5148c2f-9c21-49be-86d7-358789b1926c" />

bynav:
<img width="1170" height="340" alt="image" src="https://github.com/user-attachments/assets/37eb4469-4f63-4cc6-97c7-1d8a09b92782" />

comnav:
<img width="532" height="386" alt="image" src="https://github.com/user-attachments/assets/97af3081-7644-4881-b587-bcb695280ac9" />

