### PR TITLE
Disable IDE1006 (Naming Styles) for private methods

### DIFF
--- a/SourceCode/.editorconfig
+++ b/SourceCode/.editorconfig
@@ -1,5 +1,46 @@
 ﻿[*.cs]
 
+#### Naming styles ####
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = *
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = *
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = *
+
+dotnet_naming_symbols.private_event_handler_method.applicable_kinds = method
+dotnet_naming_symbols.private_event_handler_method.applicable_accessibilities = private
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+dotnet_naming_style.begins_with_i.required_prefix = I
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+
+dotnet_naming_rule.private_event_handler_method_none.symbols = private_event_handler_method
+dotnet_naming_rule.private_event_handler_method_none.style = pascal_case
+dotnet_naming_rule.private_event_handler_method_none.severity = none
+
 # CS1690: Accessing a member on a field of a marshal-by-reference class may cause a runtime exception
 dotnet_diagnostic.CS1690.severity = silent
 


### PR DESCRIPTION
Since WinForms generates event handler methods that look like this:
```csharp
private void btnZoomIn_Click(object sender, EventArgs e)
```
the analyzer rule [IDE1006](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules#rule-id-ide1006-naming-rule-violation) will be triggered.

In order to fix this, but not loose this analyzer completely, I suggest this solution:
- Add the following default naming styles (because once a custom one is defined, they are not provided automatically anymore):
  - Interfaces should begin with `I`
  - Types (classes, structs, enums) and non-field members (properties, methods, events) should be PascalCase
- Then we can add our custom rule:
  - Private methods should not be reported