### PR TITLE
BndTool defaults fix

### DIFF
--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -253,8 +253,8 @@ namespace AgOpenGPS.Properties
         public bool AgShareEnabled = false;
         public bool AgShareUploadActive = false;
         public bool isHeadlandDistanceOn = false;
-        public int bndToolSpacing = 2;
-        public int bndToolSmooth = 4;
+        public int bndToolSpacing = 1;
+        public int bndToolSmooth = 1;
 
         public LoadResult Load()
         {


### PR DESCRIPTION
Spacing and Smooth set by index not value. 