### PR TITLE
Performance improvements for GLW

### DIFF
--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoCoordPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoCoordPrimitives.cs
@@ -50,9 +50,21 @@ namespace AgOpenGPS.Core.DrawLib
 
         private static void DrawPrimitive(PrimitiveType primitiveType, GeoCoord[] vertices)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(vertices);
-            GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
-            vertex2Array.Dispose();
+            if (vertices.Length >= MinVerticesForArray)
+            {
+                Vertex2Array vertex2Array = new Vertex2Array(vertices);
+                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                vertex2Array.Dispose();
+            }
+            else
+            {
+                GL.Begin(primitiveType);
+                foreach (GeoCoord vertex in vertices)
+                {
+                    Vertex2(vertex);
+                }
+                GL.End();
+            }
         }
 
         private static void DrawPrimitiveLayered(
@@ -60,13 +72,29 @@ namespace AgOpenGPS.Core.DrawLib
             LineStyle[] lineStyles,
             GeoCoord[] vertices)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(vertices);
-            foreach (LineStyle lineStyle in lineStyles)
+            if (lineStyles.Length * vertices.Length >= MinVerticesForArray)
             {
-                SetLineStyle(lineStyle);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                Vertex2Array vertex2Array = new Vertex2Array(vertices);
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                }
+                vertex2Array.Dispose();
             }
-            vertex2Array.Dispose();
+            else
+            {
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.Begin(primitiveType);
+                    foreach (GeoCoord vertex in vertices)
+                    {
+                        Vertex2(vertex);
+                    }
+                    GL.End();
+                }
+            }
         }
 
         public static void Vertex2(GeoCoord geoCoord)

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoLineSegmentPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoLineSegmentPrimitives.cs
@@ -1,5 +1,6 @@
 ﻿using AgOpenGPS.Core.Models;
 using OpenTK.Graphics.OpenGL;
+using System.Linq;
 
 namespace AgOpenGPS.Core.DrawLib
 {
@@ -21,9 +22,22 @@ namespace AgOpenGPS.Core.DrawLib
 
         private static void DrawPrimitive(PrimitiveType primitiveType, GeoLineSegment[] lineSegments)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(lineSegments);
-            GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
-            vertex2Array.Dispose();
+            if (2 * lineSegments.Length >= MinVerticesForArray)
+            {
+                Vertex2Array vertex2Array = new Vertex2Array(lineSegments);
+                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                vertex2Array.Dispose();
+            }
+            else
+            {
+                GL.Begin(primitiveType);
+                foreach (var segment in lineSegments)
+                {
+                    Vertex2(segment.CoordA);
+                    Vertex2(segment.CoordB);
+                }
+                GL.End();
+            }
         }
 
         private static void DrawPrimitiveLayered(
@@ -31,13 +45,30 @@ namespace AgOpenGPS.Core.DrawLib
             LineStyle[] lineStyles,
             GeoLineSegment[] lineSegments)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(lineSegments);
-            foreach (LineStyle lineStyle in lineStyles)
+            if (2 * lineStyles.Length * lineSegments.Length >= MinVerticesForArray)
             {
-                SetLineStyle(lineStyle);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                Vertex2Array vertex2Array = new Vertex2Array(lineSegments);
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                }
+                vertex2Array.Dispose();
             }
-            vertex2Array.Dispose();
+            else
+            {
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.Begin(primitiveType);
+                    foreach (var segment in lineSegments)
+                    {
+                        Vertex2(segment.CoordA);
+                        Vertex2(segment.CoordB);
+                    }
+                    GL.End();
+                }
+            }
         }
 
     }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.Primitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.Primitives.cs
@@ -6,6 +6,13 @@ namespace AgOpenGPS.Core.DrawLib
     // Please use this class in stead of direct calls to functions in the GL toolkit.
     public static partial class GLW
     {
+        // To optimize performance of the various DrawPrimitive functions, these functions will
+        // take the number of vertices into account.
+        // When the number of vertices is MinVerticesForArray or higher, a Vertex2Array is used
+        // to pass the vertices as bulk.
+        // For smaller numbers, the vertices are simply passed one by one.
+        private const int MinVerticesForArray = 40;
+
         public static void BeginPointsPrimitive()
         {
             GL.Begin(PrimitiveType.Points);

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.XyPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.XyPrimitives.cs
@@ -63,9 +63,21 @@ namespace AgOpenGPS.Core.DrawLib
 
         private static void DrawPrimitive(PrimitiveType primitiveType, XyCoord[] vertices)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(vertices);
-            GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
-            vertex2Array.Dispose();
+            if (vertices.Length >= MinVerticesForArray)
+            {
+                Vertex2Array vertex2Array = new Vertex2Array(vertices);
+                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                vertex2Array.Dispose();
+            }
+            else
+            {
+                GL.Begin(primitiveType);
+                foreach (XyCoord vertex in vertices)
+                {
+                    GL.Vertex2(vertex.X, vertex.Y);
+                }
+                GL.End();
+            }
         }
 
         private static void DrawPrimitiveLayered(
@@ -73,13 +85,29 @@ namespace AgOpenGPS.Core.DrawLib
             LineStyle[] lineStyles,
             XyCoord[] vertices)
         {
-            Vertex2Array vertex2Array = new Vertex2Array(vertices);
-            foreach (LineStyle lineStyle in lineStyles)
+            if (vertices.Length * vertices.Length >= MinVerticesForArray)
             {
-                SetLineStyle(lineStyle);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                Vertex2Array vertex2Array = new Vertex2Array(vertices);
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                }
+                vertex2Array.Dispose();
             }
-            vertex2Array.Dispose();
+            else
+            {
+                foreach (LineStyle lineStyle in lineStyles)
+                {
+                    SetLineStyle(lineStyle);
+                    GL.Begin(primitiveType);
+                    foreach (XyCoord vertex in vertices)
+                    {
+                        GL.Vertex2(vertex.X, vertex.Y);
+                    }
+                    GL.End();
+                }
+            }
         }
 
     }


### PR DESCRIPTION
For performance, the various Drawprimitive functions should not use Vertex2Array for small number of vertices.