### PR TITLE
FormBndTool pt picker fixes2

### DIFF
--- a/SourceCode/GPS/Forms/Field/FormBndTool.cs
+++ b/SourceCode/GPS/Forms/Field/FormBndTool.cs
@@ -887,7 +887,7 @@ namespace AgOpenGPS
                     }
                 }
 
-                mf.bnd.bndList[bndSelect].FixFenceLine(0);
+                mf.bnd.bndList[bndSelect].FixFenceLine(bndSelect);
 
                 mf.CalculateMinMax();
                 mf.bnd.BuildTurnLines();


### PR DESCRIPTION
Some fixes with the point picker.
Inner boundaries were  already selectable but once 2 pts selected the changes were attemped the the outer one instead the selected one.

the inner boundaries were not displayed depite being selectable

Old one (develop):
<img width="1011" height="735" alt="image" src="https://github.com/user-attachments/assets/193455c5-b1ed-45eb-82f5-a93a9224c445" />


New:
<img width="1014" height="733" alt="image" src="https://github.com/user-attachments/assets/549dcde5-9000-495d-a164-e9e2bb63d67a" />
<img width="1016" height="739" alt="image" src="https://github.com/user-attachments/assets/3076e1ea-bc48-4569-af24-4d098169c809" />

Todo: Maybe change color of inner boundaries?