### PR TITLE
Split title of `FormABDraw`

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.Designer.cs
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.Designer.cs
@@ -19,7 +19,7 @@ namespace AgOpenGPS.Core.Translations {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class gStr {
@@ -61,11 +61,20 @@ namespace AgOpenGPS.Core.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Draw AB - Click 2 points on the Boundary to Begin.
+        ///   Looks up a localized string similar to Draw AB.
         /// </summary>
         public static string gsABDraw {
             get {
                 return ResourceManager.GetString("gsABDraw", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click 2 points on the Boundary to Begin.
+        /// </summary>
+        public static string gsABDrawHint {
+            get {
+                return ResourceManager.GetString("gsABDrawHint", resourceCulture);
             }
         }
         

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.cs.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.cs.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Draw AB - Klepněte na tlačítko 2 body na boundary začít</value>
+    <value>Draw AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klepněte na tlačítko 2 body na boundary začít</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Linie</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.da.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.da.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Tegn AB - Klik 2 punkter på grænsen for at begynde</value>
+    <value>Tegn AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klik 2 punkter på grænsen for at begynde</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Linje</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.de.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.de.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Erstellen einer AB-Linie - Klicken Sie auf 2 Punkte auf der Grenze, um zu beginnen</value>
+    <value>Erstellen einer AB-Linie</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klicken Sie auf 2 Punkte auf der Grenze, um zu beginnen</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>A-B Linie</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.es.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.es.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Dibujar AB - Seleccione 2 puntos en el Lindero para empezar</value>
+    <value>Dibujar AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Seleccione 2 puntos en el Lindero para empezar</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Línea AB</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.et.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.et.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Joonesta AB - Alustamiseks klõpsa piiril kahel punktil</value>
+    <value>Joonesta AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Alustamiseks klõpsa piiril kahel punktil</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB-joon</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.fi.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.fi.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Piirrä AB, Valitse kaksi pistettä reunalinjalta</value>
+    <value>Piirrä AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Valitse kaksi pistettä reunalinjalta</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Ab -linja</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.fr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.fr.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Tracer AB - Cliquez sur deux points pour commencer</value>
+    <value>Tracer AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Cliquez sur deux points pour commencer</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Ligne AB</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.hr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.hr.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Generiraj AB - Klikni 2 Točke za početak</value>
+    <value>Generiraj AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klikni 2 Točke za početak</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Linija</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.hu.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.hu.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>AB rajzolás - Válassz 2 pontot a határon a kezdéshez</value>
+    <value>AB rajzolás</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Válassz 2 pontot a határon a kezdéshez</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB egyenes</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.it.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.it.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Traccia AB - clicca 2 punti sul confine per tracciare la linea</value>
+    <value>Traccia AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Clicca 2 punti sul confine per tracciare la linea</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Linea AB</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ja.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ja.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>線分ABを描画 - 境界線上の2点をクリックして開始</value>
+    <value>線分ABを描画</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>境界線上の2点をクリックして開始</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>ABライン</value>
@@ -662,11 +665,11 @@
   <data name="gsLongtitude" xml:space="preserve">
     <value>経度</value>
   </data>
-  <data name="gsLookAheadTiming" xml:space="preserve">
-    <value>先読み時間設定</value>
-  </data>
   <data name="gsLookAhead" xml:space="preserve">
     <value>先を見据えて：</value>
+  </data>
+  <data name="gsLookAheadTiming" xml:space="preserve">
+    <value>先読み時間設定</value>
   </data>
   <data name="gsLowerTime" xml:space="preserve">
     <value>低時間</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ko.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ko.resx
@@ -117,7 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="gsABDraw" xml:space="preserve">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="gsABDrawHint" xml:space="preserve">
     <value>A점B점을찍은후시작하세요</value>
   </data>
   <data name="gsABline" xml:space="preserve">

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.lt.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.lt.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Nubrėžti AB. Pažymėkite 2 taškus ant ribos, kad pradėti</value>
+    <value>Nubrėžti AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Pažymėkite 2 taškus ant ribos, kad pradėti</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB linija</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.lv.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.lv.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Zīmējiet AB. Lai sāktu, atzīmējiet 2 punktus uz lauka robežas</value>
+    <value>Zīmējiet AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Lai sāktu, atzīmējiet 2 punktus uz lauka robežas</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Līnija</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Maak AB - Klik 2 punten om te beginnen</value>
+    <value>Maak AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klik 2 punten om te beginnen</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB-lijn</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.no.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.no.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Tegn AB - Klikk 2 punkter på grensen for å begynne</value>
+    <value>Tegn AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klikk 2 punkter på grensen for å begynne</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Linje</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.pl.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.pl.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Narysuj AB - Kliknij 2 punkty na granicy, aby rozpocząć</value>
+    <value>Narysuj AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Kliknij 2 punkty na granicy, aby rozpocząć</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Prosta AB</value>
@@ -149,6 +152,9 @@
   </data>
   <data name="gsAdvancedTramLines" xml:space="preserve">
     <value>Utwórz zaaw. ścieżki technologiczne</value>
+  </data>
+  <data name="gsAgShareDownloader" xml:space="preserve">
+    <value>Pobierz pola z AgShare</value>
   </data>
   <data name="gsAgree" xml:space="preserve">
     <value>Zgadzam się na warunki i zasady</value>
@@ -392,6 +398,12 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsDistanceToFlag" xml:space="preserve">
     <value>Odległość do flagi</value>
   </data>
+  <data name="gsDownloadAll" xml:space="preserve">
+    <value>Pobierz wszystkie</value>
+  </data>
+  <data name="gsDownloading" xml:space="preserve">
+    <value>Trwa pobieranie...Proszę czekać</value>
+  </data>
   <data name="gsDriveIn" xml:space="preserve">
     <value>Pola w pobliżu</value>
   </data>
@@ -503,6 +515,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsForNow" xml:space="preserve">
     <value>Tymczasowo</value>
   </data>
+  <data name="gsForceOverwrite" xml:space="preserve">
+    <value>Wymuś nadpisanie</value>
+  </data>
   <data name="gsFormFlag" xml:space="preserve">
     <value>Flagi</value>
   </data>
@@ -514,6 +529,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   </data>
   <data name="gsGap" xml:space="preserve">
     <value>Odstęp</value>
+  </data>
+  <data name="gsGetSelected" xml:space="preserve">
+    <value>Pobierz zaznaczone</value>
   </data>
   <data name="gsGrid" xml:space="preserve">
     <value>Siatka</value>
@@ -572,6 +590,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsInner" xml:space="preserve">
     <value>Wewnętrzny</value>
   </data>
+  <data name="gsIntegral" xml:space="preserve">
+    <value>Całka</value>
+  </data>
   <data name="gsIntegralInfo" xml:space="preserve">
     <value>Powoli zwiększy kąt skrętu, aby zmniejszyć błąd śledzenia</value>
   </data>
@@ -601,6 +622,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   </data>
   <data name="gsLatLon" xml:space="preserve">
     <value>Szerokość + Długość</value>
+  </data>
+  <data name="gsLateral" xml:space="preserve">
+    <value>Boczny</value>
   </data>
   <data name="gsLatitude" xml:space="preserve">
     <value>Szerokość geograficzna</value>
@@ -725,6 +749,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsNothingDeleted" xml:space="preserve">
     <value>Nic nie usunięto</value>
   </data>
+  <data name="gsNudge" xml:space="preserve">
+    <value>Przes. ścieżki:</value>
+  </data>
   <data name="gsNudgeDistance" xml:space="preserve">
     <value>Przyrost przes.</value>
   </data>
@@ -794,6 +821,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsPointsToProcess" xml:space="preserve">
     <value>Punkty do przetworzenia</value>
   </data>
+  <data name="gsPolygons" xml:space="preserve">
+    <value>Wielokąty</value>
+  </data>
   <data name="gsPresetColor" xml:space="preserve">
     <value>Wybierz wstępnie ustawiony kolor</value>
   </data>
@@ -814,6 +844,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   </data>
   <data name="gsRaiseTime" xml:space="preserve">
     <value>Czas podnoszenia</value>
+  </data>
+  <data name="gsRate" xml:space="preserve">
+    <value>Wydajność</value>
   </data>
   <data name="gsReallyResetEverything" xml:space="preserve">
     <value>Musisz wszystko ponownie zrestartować?</value>
@@ -920,6 +953,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsSelectButtons" xml:space="preserve">
     <value>Wybierz przyciski</value>
   </data>
+  <data name="gsSelectPreset" xml:space="preserve">
+    <value>Wybierz kolor domyślny</value>
+  </data>
   <data name="gsSendAndSave" xml:space="preserve">
     <value>Wyślij + Zapisz</value>
   </data>
@@ -968,6 +1004,9 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsSpacing" xml:space="preserve">
     <value>Rozstaw (cm)</value>
   </data>
+  <data name="gsSpeedo" xml:space="preserve">
+    <value>Prędkościomierz</value>
+  </data>
   <data name="gsStart" xml:space="preserve">
     <value>Start</value>
   </data>
@@ -986,11 +1025,20 @@ Kolejność, w jakiej je naciśniesz, będzie kolejnością, w jakiej pojawią s
   <data name="gsSteerAngle" xml:space="preserve">
     <value>Kąt skrętu</value>
   </data>
+  <data name="gsSteerBar" xml:space="preserve">
+    <value>Pasek naprowadzania</value>
+  </data>
   <data name="gsSteerChart" xml:space="preserve">
     <value>Wykres Autoprowadzenia</value>
   </data>
   <data name="gsSteerInReverse" xml:space="preserve">
     <value>Kierowanie podczas cofania</value>
+  </data>
+  <data name="gsSteerResponse" xml:space="preserve">
+    <value>Reaktywność prowadzenia</value>
+  </data>
+  <data name="gsSteerSwitch" xml:space="preserve">
+    <value>Przycisk autoprowadzenia</value>
   </data>
   <data name="gsSteerWizard" xml:space="preserve">
     <value>Kreator kierowania</value>
@@ -1034,11 +1082,29 @@ UŻYWAJ NA WŁASNE RYZYKO.</value>
   <data name="gsToolsMenu" xml:space="preserve">
     <value>Menu narzędzi</value>
   </data>
+  <data name="gsTotal" xml:space="preserve">
+    <value>Całkowity</value>
+  </data>
+  <data name="gsTrack" xml:space="preserve">
+    <value>Rozstaw kół</value>
+  </data>
+  <data name="gsTracks" xml:space="preserve">
+    <value>Ścieżki</value>
+  </data>
   <data name="gsTramLines" xml:space="preserve">
     <value>Ścieżki technologiczne</value>
   </data>
+  <data name="gsTramWidth" xml:space="preserve">
+    <value>Rozstaw ścieżek tech.:</value>
+  </data>
   <data name="gsTurnABCurveOn" xml:space="preserve">
     <value>Włącz krzywą AB</value>
+  </data>
+  <data name="gsTurnOffDelay" xml:space="preserve">
+    <value>Wył. z opóźn.</value>
+  </data>
+  <data name="gsTurnOffRecordedPath" xml:space="preserve">
+    <value>Wył. nagrywanie ścieżki</value>
   </data>
   <data name="gsTurnOnContourOrMakeABLine" xml:space="preserve">
     <value>Włącz kontur linii AB</value>
@@ -1132,68 +1198,5 @@ UŻYWAJ NA WŁASNE RYZYKO.</value>
   </data>
   <data name="v_AboutIntro" xml:space="preserve">
     <value>https://www.youtube.com/watch?v=iN2cZ8avHag</value>
-  </data>
-  <data name="gsTurnOffRecordedPath" xml:space="preserve">
-    <value>Wył. nagrywanie ścieżki</value>
-  </data>
-  <data name="gsSteerSwitch" xml:space="preserve">
-    <value>Przycisk autoprowadzenia</value>
-  </data>
-  <data name="gsAgShareDownloader" xml:space="preserve">
-    <value>Pobierz pola z AgShare</value>
-  </data>
-  <data name="gsTracks" xml:space="preserve">
-    <value>Ścieżki</value>
-  </data>
-  <data name="gsLateral" xml:space="preserve">
-    <value>Boczny</value>
-  </data>
-  <data name="gsTotal" xml:space="preserve">
-    <value>Całkowity</value>
-  </data>
-  <data name="gsSpeedo" xml:space="preserve">
-    <value>Prędkościomierz</value>
-  </data>
-  <data name="gsDownloadAll" xml:space="preserve">
-    <value>Pobierz wszystkie</value>
-  </data>
-  <data name="gsRate" xml:space="preserve">
-    <value>Wydajność</value>
-  </data>
-  <data name="gsTramWidth" xml:space="preserve">
-    <value>Rozstaw ścieżek tech.:</value>
-  </data>
-  <data name="gsSteerResponse" xml:space="preserve">
-    <value>Reaktywność prowadzenia</value>
-  </data>
-  <data name="gsSteerBar" xml:space="preserve">
-    <value>Pasek naprowadzania</value>
-  </data>
-  <data name="gsSelectPreset" xml:space="preserve">
-    <value>Wybierz kolor domyślny</value>
-  </data>
-  <data name="gsIntegral" xml:space="preserve">
-    <value>Całka</value>
-  </data>
-  <data name="gsTrack" xml:space="preserve">
-    <value>Rozstaw kół</value>
-  </data>
-  <data name="gsPolygons" xml:space="preserve">
-    <value>Wielokąty</value>
-  </data>
-  <data name="gsDownloading" xml:space="preserve">
-    <value>Trwa pobieranie...Proszę czekać</value>
-  </data>
-  <data name="gsForceOverwrite" xml:space="preserve">
-    <value>Wymuś nadpisanie</value>
-  </data>
-  <data name="gsNudge" xml:space="preserve">
-    <value>Przes. ścieżki:</value>
-  </data>
-  <data name="gsTurnOffDelay" xml:space="preserve">
-    <value>Wył. z opóźn.</value>
-  </data>
-  <data name="gsGetSelected" xml:space="preserve">
-    <value>Pobierz zaznaczone</value>
   </data>
 </root>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.pt.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.pt.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Desenhe AB - Clique em 2 pontos no limite para começar</value>
+    <value>Desenhe AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Clique em 2 pontos no limite para começar</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Linha AB</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Draw AB - Click 2 points on the Boundary to Begin</value>
+    <value>Draw AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Click 2 points on the Boundary to Begin</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB Line</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ro.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ro.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Desenați AB - Faceți clic pe 2 puncte de pe limită pentru a începe</value>
+    <value>Desenați AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Faceți clic pe 2 puncte de pe limită pentru a începe</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Linie AB</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ru.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ru.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Линия АВ - Поставьте 2 точки на границе поля</value>
+    <value>Линия АВ</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Поставьте 2 точки на границе поля</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>Линия АВ</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.sr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.sr.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,13 +118,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Generiši AB - Klikni 2 tačke za početak</value>
+    <value>Generiši AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Klikni 2 tačke za početak</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB linija</value>
   </data>
+  <data name="gsADConverter" xml:space="preserve">
+    <value>AD Converter</value>
+  </data>
   <data name="gsAOGMenu" xml:space="preserve">
     <value>AOG Meni</value>
+  </data>
+  <data name="gsAPlus" xml:space="preserve">
+    <value>A+</value>
   </data>
   <data name="gsAbout" xml:space="preserve">
     <value>O programu...</value>
@@ -153,6 +162,12 @@
   <data name="gsAgressiveness" xml:space="preserve">
     <value>Agresivnost</value>
   </data>
+  <data name="gsAllSettings" xml:space="preserve">
+    <value>Vidi sve Postavke</value>
+  </data>
+  <data name="gsAlpha" xml:space="preserve">
+    <value>Alpha</value>
+  </data>
   <data name="gsAntennaHeight" xml:space="preserve">
     <value>Visina antene</value>
   </data>
@@ -168,6 +183,9 @@
   <data name="gsAquireDescription" xml:space="preserve">
     <value>Uhvati = Factor * Hold</value>
   </data>
+  <data name="gsAquireFactor" xml:space="preserve">
+    <value>Aquire Factor</value>
+  </data>
   <data name="gsArea" xml:space="preserve">
     <value>Površina</value>
   </data>
@@ -179,6 +197,15 @@
   <data name="gsAttachmentStyle" xml:space="preserve">
     <value>Tip priključka</value>
   </data>
+  <data name="gsAuto" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="gsAutoOffAgIO" xml:space="preserve">
+    <value>Auto Off AgIO</value>
+  </data>
+  <data name="gsAutoStartAgIO" xml:space="preserve">
+    <value>Auto Start AgIO</value>
+  </data>
   <data name="gsAutoSteer" xml:space="preserve">
     <value>Autopilot</value>
   </data>
@@ -187,6 +214,9 @@
   </data>
   <data name="gsAutoSteerPort" xml:space="preserve">
     <value>Port autopilota</value>
+  </data>
+  <data name="gsAutoSwitchDualFix" xml:space="preserve">
+    <value>Auto Dual &lt;&gt; Fix</value>
   </data>
   <data name="gsAutoSwitchDualFixSpeed" xml:space="preserve">
     <value>Prekidač brzine</value>
@@ -262,6 +292,9 @@
   </data>
   <data name="gsCloseFieldFirst" xml:space="preserve">
     <value>Najpre zatvorite polje</value>
+  </data>
+  <data name="gsCmPix" xml:space="preserve">
+    <value>Cm -&gt; Pixel</value>
   </data>
   <data name="gsColorPicker" xml:space="preserve">
     <value>Izbor boje</value>
@@ -578,6 +611,9 @@
   <data name="gsInner" xml:space="preserve">
     <value>Unutrašnja</value>
   </data>
+  <data name="gsIntegral" xml:space="preserve">
+    <value>Integral</value>
+  </data>
   <data name="gsIntegralInfo" xml:space="preserve">
     <value>Postupno će povećavati kut upravljanja kako bi smanjio grešku praćenja linije</value>
   </data>
@@ -604,6 +640,9 @@
   </data>
   <data name="gsLanguage" xml:space="preserve">
     <value>Jezik</value>
+  </data>
+  <data name="gsLatLon" xml:space="preserve">
+    <value>Lat+Long</value>
   </data>
   <data name="gsLateral" xml:space="preserve">
     <value>Bočno</value>
@@ -755,6 +794,9 @@
   <data name="gsOn" xml:space="preserve">
     <value>ON</value>
   </data>
+  <data name="gsOnDelay" xml:space="preserve">
+    <value>On-Delay</value>
+  </data>
   <data name="gsOnOff" xml:space="preserve">
     <value>ON/OFF</value>
   </data>
@@ -868,6 +910,9 @@
   </data>
   <data name="gsRemoveOffset" xml:space="preserve">
     <value>Ukini pomeraj</value>
+  </data>
+  <data name="gsReset" xml:space="preserve">
+    <value>Reset</value>
   </data>
   <data name="gsResetAll" xml:space="preserve">
     <value>Resetuj sve</value>
@@ -1027,6 +1072,9 @@
   </data>
   <data name="gsStartNewField" xml:space="preserve">
     <value>Novo polje</value>
+  </data>
+  <data name="gsStatus" xml:space="preserve">
+    <value>Status</value>
   </data>
   <data name="gsSteerAngle" xml:space="preserve">
     <value>Ugao zakretanja</value>
@@ -1211,51 +1259,6 @@ KORIŠTENJE NA VLASTITU ODGOVORNOST.</value>
   </data>
   <data name="gsZoomIn" xml:space="preserve">
     <value>Uvećaj</value>
-  </data>
-  <data name="gsADConverter" xml:space="preserve">
-    <value>AD Converter</value>
-  </data>
-  <data name="gsAPlus" xml:space="preserve">
-    <value>A+</value>
-  </data>
-  <data name="gsAllSettings" xml:space="preserve">
-    <value>Vidi sve Postavke</value>
-  </data>
-  <data name="gsAlpha" xml:space="preserve">
-    <value>Alpha</value>
-  </data>
-  <data name="gsAquireFactor" xml:space="preserve">
-    <value>Aquire Factor</value>
-  </data>
-  <data name="gsAuto" xml:space="preserve">
-    <value>Auto</value>
-  </data>
-  <data name="gsAutoOffAgIO" xml:space="preserve">
-    <value>Auto Off AgIO</value>
-  </data>
-  <data name="gsAutoStartAgIO" xml:space="preserve">
-    <value>Auto Start AgIO</value>
-  </data>
-  <data name="gsAutoSwitchDualFix" xml:space="preserve">
-    <value>Auto Dual &lt;&gt; Fix</value>
-  </data>
-  <data name="gsCmPix" xml:space="preserve">
-    <value>Cm -&gt; Pixel</value>
-  </data>
-  <data name="gsIntegral" xml:space="preserve">
-    <value>Integral</value>
-  </data>
-  <data name="gsLatLon" xml:space="preserve">
-    <value>Lat+Long</value>
-  </data>
-  <data name="gsOnDelay" xml:space="preserve">
-    <value>On-Delay</value>
-  </data>
-  <data name="gsReset" xml:space="preserve">
-    <value>Reset</value>
-  </data>
-  <data name="gsStatus" xml:space="preserve">
-    <value>Status</value>
   </data>
   <data name="v_AboutIntro" xml:space="preserve">
     <value>https://www.youtube.com/watch?v=iN2cZ8avHag</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.tr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.tr.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -117,7 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="gsABDraw" xml:space="preserve">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="gsABDrawHint" xml:space="preserve">
     <value>AB çizgisinde rota oluşturmak için 2 sınır noktasına tıkla</value>
   </data>
   <data name="gsABline" xml:space="preserve">

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.uk.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.uk.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>Намалюйте AB - Клацніть 2 точки на межі, щоб почати</value>
+    <value>Намалюйте AB</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>Клацніть 2 точки на межі, щоб почати</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>АВ лінії</value>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.zh-CHS.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.zh-CHS.resx
@@ -118,7 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="gsABDraw" xml:space="preserve">
-    <value>绘制AB线段 - 在边界线上点击两个点开始</value>
+    <value>绘制AB线段</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>在边界线上点击两个点开始</value>
   </data>
   <data name="gsABline" xml:space="preserve">
     <value>AB 直线</value>

--- a/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
@@ -50,7 +50,7 @@ namespace AgOpenGPS
         private void FormABDraw_Load(object sender, EventArgs e)
         {
             //translate
-            this.Text = gStr.gsABDraw;
+            Text = $"{gStr.gsABDraw} - {gStr.gsABDrawHint}";
 
             originalLine = mf.trk.idx;
 


### PR DESCRIPTION
Splits the original title "Draw AB - Click 2 points on the Boundary to Begin" into two parts:
- `gsABDraw`: "Draw AB"
- `gsABDrawHint`: "Click 2 points on the Boundary to Begin"

That allows for more flexibility in the future (like putting the hint somewhere else for example).