### PR TITLE
Add method Include(GeoBoundingBox) to GeoBoundingBox

### DIFF
--- a/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoBoundingBoxTests.cs
+++ b/SourceCode/AgOpenGPS.Core.Tests/Models/Base/GeoBoundingBoxTests.cs
@@ -20,5 +20,76 @@ namespace AgOpenGPS.Core.Tests.Models
             Assert.That(centerCoord, Is.EqualTo(correctCenterCoord));
         }
 
+        [Test]
+        public void Test_IncludeBoundingBox_NotEmpty_NotEmpty()
+        {
+            GeoCoord coordA1 = new GeoCoord(-10.0, 20.0);
+            GeoCoord coordA2 = new GeoCoord(-30.0, 40.0);
+            GeoBoundingBox bbA = GeoBoundingBox.CreateEmpty();
+            bbA.Include(coordA1);
+            bbA.Include(coordA2);
+
+            GeoCoord coordB1 = new GeoCoord(-20.0, 30.0);
+            GeoCoord coordB2 = new GeoCoord(-40.0, 50.0);
+            GeoBoundingBox bbB = GeoBoundingBox.CreateEmpty();
+            bbA.Include(coordB1);
+            bbA.Include(coordB2);
+            bbA.Include(bbB);
+
+            Assert.That(bbA.IsEmpty, Is.False);
+            Assert.That(bbA.MinNorthing, Is.EqualTo(-40.0));
+            Assert.That(bbA.MaxNorthing, Is.EqualTo(-10.0));
+            Assert.That(bbA.MinEasting, Is.EqualTo(20.0));
+            Assert.That(bbA.MaxEasting, Is.EqualTo(50.0));
+        }
+
+        [Test]
+        public void Test_IncludeBoundingBox_NotEmpty_Empty()
+        {
+            GeoCoord coordA1 = new GeoCoord(-10.0, 20.0);
+            GeoCoord coordA2 = new GeoCoord(-30.0, 40.0);
+            GeoBoundingBox bbA = GeoBoundingBox.CreateEmpty();
+            bbA.Include(coordA1);
+            bbA.Include(coordA2);
+
+            GeoBoundingBox bbB = GeoBoundingBox.CreateEmpty();
+            bbA.Include(bbB);
+
+            Assert.That(bbA.IsEmpty, Is.False);
+            Assert.That(bbA.MinNorthing, Is.EqualTo(-30.0));
+            Assert.That(bbA.MaxNorthing, Is.EqualTo(-10.0));
+            Assert.That(bbA.MinEasting, Is.EqualTo(20.0));
+            Assert.That(bbA.MaxEasting, Is.EqualTo(40.0));
+        }
+
+        [Test]
+        public void Test_IncludeBoundingBox_Empty_NotEmpty()
+        {
+            GeoBoundingBox bbA = GeoBoundingBox.CreateEmpty();
+
+            GeoCoord coordB1 = new GeoCoord(-20.0, 30.0);
+            GeoCoord coordB2 = new GeoCoord(-40.0, 50.0);
+            GeoBoundingBox bbB = GeoBoundingBox.CreateEmpty();
+            bbA.Include(coordB1);
+            bbA.Include(coordB2);
+            bbA.Include(bbB);
+
+            Assert.That(bbA.IsEmpty, Is.False);
+            Assert.That(bbA.MinNorthing, Is.EqualTo(-40.0));
+            Assert.That(bbA.MaxNorthing, Is.EqualTo(-20.0));
+            Assert.That(bbA.MinEasting, Is.EqualTo(30.0));
+            Assert.That(bbA.MaxEasting, Is.EqualTo(50.0));
+        }
+
+        [Test]
+        public void Test_IncludeBoundingBox_Empty_Empty()
+        {
+            GeoBoundingBox bbA = GeoBoundingBox.CreateEmpty();
+            GeoBoundingBox bbB = GeoBoundingBox.CreateEmpty();
+            bbA.Include(bbB);
+
+            Assert.That(bbA.IsEmpty, Is.True);
+        }
+
     }
 }

--- a/SourceCode/AgOpenGPS.Core/Models/Base/GeoBoundingBox.cs
+++ b/SourceCode/AgOpenGPS.Core/Models/Base/GeoBoundingBox.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AgOpenGPS.Core.Models
+﻿namespace AgOpenGPS.Core.Models
 {
     public struct GeoBoundingBox
     {
@@ -35,6 +33,12 @@ namespace AgOpenGPS.Core.Models
         {
             _minCoord = _minCoord.Min(geoCoord);
             _maxCoord = _maxCoord.Max(geoCoord);
+        }
+
+        public void Include(GeoBoundingBox bb)
+        {
+            _minCoord = _minCoord.Min(bb.MinCoord);
+            _maxCoord = _maxCoord.Max(bb.MaxCoord);
         }
 
         public bool IsInside(GeoCoord testCoord)


### PR DESCRIPTION
The new method
Include(GeoBoundingBox bb) 

is a small preparation step to start using QuadStrip in the future. QuadStrip keeps track of its own GeoBoundingBox and will help to simplify the calulation of the bounding box of the worked area. It also might speed up rendering, because it could help to skip rendering  of QuadStrip that are outside the Viewport