### PR TITLE
Performance 1: replace Vertex3 with Vertex2 if 3th coord was 0

### DIFF
--- a/SourceCode/GPS/Classes/CABCurve.cs
+++ b/SourceCode/GPS/Classes/CABCurve.cs
@@ -1020,15 +1020,18 @@ namespace AgOpenGPS
                 GL.Color3(0.95f, 0.42f, 0.750f);
                 GL.LineWidth(4.0f);
                 GL.Begin(PrimitiveType.LineStrip);
-                for (int h = 0; h < desList.Count; h++) GL.Vertex3(desList[h].easting, desList[h].northing, 0);
+                for (int h = 0; h < desList.Count; h++)
+                {
+                    GL.Vertex2(desList[h].easting, desList[h].northing);
+                }
                 GL.End();
 
                 GL.Enable(EnableCap.LineStipple);
                 GL.LineStipple(1, 0x0F00);
                 GL.Begin(PrimitiveType.Lines);
                 GL.Color3(0.99f, 0.99f, 0.0);
-                GL.Vertex3(desList[desList.Count - 1].easting, desList[desList.Count - 1].northing, 0);
-                GL.Vertex3(mf.pivotAxlePos.easting, mf.pivotAxlePos.northing, 0);
+                GL.Vertex2(desList[desList.Count - 1].easting, desList[desList.Count - 1].northing);
+                GL.Vertex2(mf.pivotAxlePos.easting, mf.pivotAxlePos.northing);
                 GL.End();
 
                 GL.Disable(EnableCap.LineStipple);
@@ -1049,11 +1052,10 @@ namespace AgOpenGPS
                 GL.Color3(0.96, 0.2f, 0.2f);
                 GL.Begin(PrimitiveType.Lines);
 
-                for (int h = 0; h < ptCount; h++) GL.Vertex3(
-                    mf.trk.gArr[mf.trk.idx].curvePts[h].easting,
-                    mf.trk.gArr[mf.trk.idx].curvePts[h].northing,
-                    0);
-
+                for (int h = 0; h < ptCount; h++)
+                {
+                    GL.Vertex2(mf.trk.gArr[mf.trk.idx].curvePts[h].easting, mf.trk.gArr[mf.trk.idx].curvePts[h].northing);
+                }
                 GL.End();
 
                 GL.Color3(0.40f, 0.90f, 0.95f);
@@ -1067,7 +1069,10 @@ namespace AgOpenGPS
                     GL.LineWidth(mf.ABLine.lineWidth);
                     GL.Color3(0.930f, 0.92f, 0.260f);
                     GL.Begin(PrimitiveType.Lines);
-                    for (int h = 0; h < smooList.Count; h++) GL.Vertex3(smooList[h].easting, smooList[h].northing, 0);
+                    for (int h = 0; h < smooList.Count; h++)
+                    {
+                        GL.Vertex2(smooList[h].easting, smooList[h].northing);
+                    }
                     GL.End();
                 }
             }
@@ -1089,14 +1094,19 @@ namespace AgOpenGPS
                         {
                             GL.PointSize(15.0f);
                             GL.Begin(PrimitiveType.Points);
-                            GL.Vertex3(mf.trk.gArr[mf.trk.idx].ptA.easting, mf.trk.gArr[mf.trk.idx].ptA.northing, 0);
+                            GL.Vertex2(
+                                mf.trk.gArr[mf.trk.idx].ptA.easting,
+                                mf.trk.gArr[mf.trk.idx].ptA.northing);
                             GL.End();
                         }
 
                         GL.Begin(PrimitiveType.LineLoop);
                     }
 
-                    for (int h = 0; h < curList.Count; h++) GL.Vertex3(curList[h].easting, curList[h].northing, 0);
+                    for (int h = 0; h < curList.Count; h++)
+                    {
+                        GL.Vertex2(curList[h].easting, curList[h].northing);
+                    }
                     GL.End();
 
                     GL.LineWidth(mf.ABLine.lineWidth);
@@ -1111,14 +1121,19 @@ namespace AgOpenGPS
                         {
                             GL.PointSize(15.0f);
                             GL.Begin(PrimitiveType.Points);
-                            GL.Vertex3(mf.trk.gArr[mf.trk.idx].ptA.easting, mf.trk.gArr[mf.trk.idx].ptA.northing, 0);
+                            GL.Vertex2(
+                                mf.trk.gArr[mf.trk.idx].ptA.easting,
+                                mf.trk.gArr[mf.trk.idx].ptA.northing);
                             GL.End();
                         }
 
                         GL.Begin(PrimitiveType.LineLoop);
                     }
 
-                    for (int h = 0; h < curList.Count; h++) GL.Vertex3(curList[h].easting, curList[h].northing, 0);
+                    for (int h = 0; h < curList.Count; h++)
+                    {
+                        GL.Vertex2(curList[h].easting, curList[h].northing);
+                    }
                     GL.End();
 
                     mf.yt.DrawYouTurn();
@@ -1139,7 +1154,9 @@ namespace AgOpenGPS
                 {
                     GL.Begin(PrimitiveType.LineStrip);
                     for (int h = 0; h < guideArr[i].Count; h++)
-                        GL.Vertex3(guideArr[i][h].easting, guideArr[i][h].northing, 0);
+                    {
+                        GL.Vertex2(guideArr[i][h].easting, guideArr[i][h].northing);
+                    }
                     GL.End();
                 }
                 GL.End();
@@ -1156,7 +1173,9 @@ namespace AgOpenGPS
                 {
                     GL.Begin(PrimitiveType.LineStrip);
                     for (int h = 0; h < guideArr[i].Count; h++)
-                        GL.Vertex3(guideArr[i][h].easting, guideArr[i][h].northing, 0);
+                    {
+                        GL.Vertex2(guideArr[i][h].easting, guideArr[i][h].northing);
+                    }
                     GL.End();
                 }
                 GL.End();

--- a/SourceCode/GPS/Classes/CContour.cs
+++ b/SourceCode/GPS/Classes/CContour.cs
@@ -603,14 +603,20 @@ namespace AgOpenGPS
             GL.LineWidth(mf.ABLine.lineWidth);
             GL.Color3(0.98f, 0.2f, 0.980f);
             GL.Begin(PrimitiveType.LineStrip);
-            for (int h = 0; h < ptCount; h++) GL.Vertex3(ctList[h].easting, ctList[h].northing, 0);
+            for (int h = 0; h < ptCount; h++)
+            {
+                GL.Vertex2(ctList[h].easting, ctList[h].northing);
+            }
             GL.End();
 
             GL.PointSize(mf.ABLine.lineWidth);
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(0.87f, 08.7f, 0.25f);
-            for (int h = 0; h < ptCount; h++) GL.Vertex3(ctList[h].easting, ctList[h].northing, 0);
+            for (int h = 0; h < ptCount; h++)
+            {
+                GL.Vertex2(ctList[h].easting, ctList[h].northing);
+            }
 
             GL.End();
 
@@ -629,14 +635,17 @@ namespace AgOpenGPS
             if (stripNum > -1)
             {
                 GL.Begin(PrimitiveType.Points);
-                for (int h = 0; h < stripList[stripNum].Count; h++) GL.Vertex3(stripList[stripNum][h].easting, stripList[stripNum][h].northing, 0);
+                for (int h = 0; h < stripList[stripNum].Count; h++)
+                {
+                    GL.Vertex2(stripList[stripNum][h].easting, stripList[stripNum][h].northing);
+                }
                 GL.End();
             }
 
             GL.Color3(0.35f, 0.30f, 0.90f);
             GL.PointSize(6.0f);
             GL.Begin(PrimitiveType.Points);
-            GL.Vertex3(stripList[stripNum][pt].easting, stripList[stripNum][pt].northing, 0);
+            GL.Vertex2(stripList[stripNum][pt].easting, stripList[stripNum][pt].northing);
             GL.End();
 
             if (mf.isPureDisplayOn && distanceFromCurrentLinePivot != 32000 && !mf.isStanleyUsed)
@@ -646,7 +655,7 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.Points);
 
                 GL.Color3(1.0f, 0.95f, 0.095f);
-                GL.Vertex3(goalPointCT.easting, goalPointCT.northing, 0.0);
+                GL.Vertex2(goalPointCT.easting, goalPointCT.northing);
                 GL.End();
                 GL.PointSize(1.0f);
             }
@@ -659,5 +668,5 @@ namespace AgOpenGPS
             ptList?.Clear();
             ctList?.Clear();
         }
-    }//class
-}//namespace
+    }
+}

--- a/SourceCode/GPS/Classes/CFence.cs
+++ b/SourceCode/GPS/Classes/CFence.cs
@@ -85,13 +85,6 @@ namespace AgOpenGPS
                 }
             }
 
-            ////closest points  TooDoo
-            //GL.Color3(0.70f, 0.95f, 0.95f);
-            //GL.PointSize(6.0f);
-            //GL.Begin(PrimitiveType.Points);
-            //GL.Vertex3(mf.bnd.closestTurnPt.easting, mf.bnd.closestTurnPt.northing, 0);
-            //GL.End();
-
             if (bndBeingMadePts.Count > 0)
             {
                 //the boundary so far
@@ -99,9 +92,12 @@ namespace AgOpenGPS
                 GL.LineWidth(mf.ABLine.lineWidth);
                 GL.Color3(0.825f, 0.22f, 0.90f);
                 GL.Begin(PrimitiveType.LineStrip);
-                for (int h = 0; h < bndBeingMadePts.Count; h++) GL.Vertex3(bndBeingMadePts[h].easting, bndBeingMadePts[h].northing, 0);
+                for (int h = 0; h < bndBeingMadePts.Count; h++)
+                {
+                    GL.Vertex2(bndBeingMadePts[h].easting, bndBeingMadePts[h].northing);
+                }
                 GL.Color3(0.295f, 0.972f, 0.290f);
-                GL.Vertex3(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing, 0);
+                GL.Vertex2(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing);
                 GL.End();
 
                 //line from last point to pivot marker
@@ -114,34 +110,45 @@ namespace AgOpenGPS
                 {
                     if (isDrawRightSide)
                     {
-                        GL.Vertex3(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing, 0);
+                        GL.Vertex2(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing);
 
-                        GL.Vertex3(pivot.easting + (Math.Sin(pivot.heading - glm.PIBy2) * -createBndOffset),
-                                pivot.northing + (Math.Cos(pivot.heading - glm.PIBy2) * -createBndOffset), 0);
-                        GL.Vertex3(bndBeingMadePts[bndBeingMadePts.Count - 1].easting, bndBeingMadePts[bndBeingMadePts.Count - 1].northing, 0);
+                        GL.Vertex2(
+                            pivot.easting + (Math.Sin(pivot.heading - glm.PIBy2) * -createBndOffset),
+                            pivot.northing + (Math.Cos(pivot.heading - glm.PIBy2) * -createBndOffset));
+                        GL.Vertex2(
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].easting,
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].northing);
                     }
                     else
                     {
-                        GL.Vertex3(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing, 0);
-
-                        GL.Vertex3(pivot.easting + (Math.Sin(pivot.heading - glm.PIBy2) * createBndOffset),
-                                pivot.northing + (Math.Cos(pivot.heading - glm.PIBy2) * createBndOffset), 0);
-                        GL.Vertex3(bndBeingMadePts[bndBeingMadePts.Count - 1].easting, bndBeingMadePts[bndBeingMadePts.Count - 1].northing, 0);
+                        GL.Vertex2(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing);
+                        GL.Vertex2(
+                            pivot.easting + (Math.Sin(pivot.heading - glm.PIBy2) * createBndOffset),
+                            pivot.northing + (Math.Cos(pivot.heading - glm.PIBy2) * createBndOffset));
+                        GL.Vertex2(
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].easting,
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].northing);
                     }
                 }
                 else //draw from tool
                 {
                     if (isDrawRightSide)
                     {
-                        GL.Vertex3(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing, 0);
-                        GL.Vertex3(mf.section[mf.tool.numOfSections - 1].rightPoint.easting, mf.section[mf.tool.numOfSections - 1].rightPoint.northing, 0);
-                        GL.Vertex3(bndBeingMadePts[bndBeingMadePts.Count - 1].easting, bndBeingMadePts[bndBeingMadePts.Count - 1].northing, 0);
+                        GL.Vertex2(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing);
+                        GL.Vertex2(
+                            mf.section[mf.tool.numOfSections - 1].rightPoint.easting,
+                            mf.section[mf.tool.numOfSections - 1].rightPoint.northing);
+                        GL.Vertex2(
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].easting,
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].northing);
                     }
                     else
                     {
-                        GL.Vertex3(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing, 0);
-                        GL.Vertex3(mf.section[0].leftPoint.easting, mf.section[0].leftPoint.northing, 0);
-                        GL.Vertex3(bndBeingMadePts[bndBeingMadePts.Count - 1].easting, bndBeingMadePts[bndBeingMadePts.Count - 1].northing, 0);
+                        GL.Vertex2(bndBeingMadePts[0].easting, bndBeingMadePts[0].northing);
+                        GL.Vertex2(mf.section[0].leftPoint.easting, mf.section[0].leftPoint.northing);
+                        GL.Vertex2(
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].easting,
+                            bndBeingMadePts[bndBeingMadePts.Count - 1].northing);
                     }
                 }
                 GL.End();
@@ -151,7 +158,10 @@ namespace AgOpenGPS
                 GL.Color3(0.0f, 0.95f, 0.95f);
                 GL.PointSize(6.0f);
                 GL.Begin(PrimitiveType.Points);
-                for (int h = 0; h < bndBeingMadePts.Count; h++) GL.Vertex3(bndBeingMadePts[h].easting, bndBeingMadePts[h].northing, 0);
+                for (int h = 0; h < bndBeingMadePts.Count; h++)
+                {
+                    GL.Vertex2(bndBeingMadePts[h].easting, bndBeingMadePts[h].northing);
+                }
                 GL.End();
             }
         }

--- a/SourceCode/GPS/Classes/CGLM.cs
+++ b/SourceCode/GPS/Classes/CGLM.cs
@@ -116,7 +116,7 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.LineStrip);
                 for (int i = 0; i < polygon.Count; i++)
                 {
-                    GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
+                    GL.Vertex2(polygon[i].easting, polygon[i].northing);
                 }
                 GL.End();
             }
@@ -129,7 +129,7 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.LineLoop);
                 for (int i = 0; i < polygon.Count; i++)
                 {
-                    GL.Vertex3(polygon[i].easting, polygon[i].northing, 0);
+                    GL.Vertex2(polygon[i].easting, polygon[i].northing);
                 }
                 GL.End();
             }

--- a/SourceCode/GPS/Classes/CRecordedPath.cs
+++ b/SourceCode/GPS/Classes/CRecordedPath.cs
@@ -629,7 +629,10 @@ namespace AgOpenGPS
             GL.LineWidth(1);
             GL.Color3(0.98f, 0.92f, 0.460f);
             GL.Begin(PrimitiveType.LineStrip);
-            for (int h = 0; h < ptCount; h++) GL.Vertex3(recList[h].easting, recList[h].northing, 0);
+            for (int h = 0; h < ptCount; h++)
+            {
+                GL.Vertex2(recList[h].easting, recList[h].northing);
+            }
             GL.End();
 
             if (!isRecordOn)
@@ -642,7 +645,7 @@ namespace AgOpenGPS
                 //GL.Vertex(rEast, rNorth, 0.0);
 
                 GL.Color3(1.0f, 0.5f, 0.95f);
-                GL.Vertex3(recList[currentPositonIndex].easting, recList[currentPositonIndex].northing, 0);
+                GL.Vertex2(recList[currentPositonIndex].easting, recList[currentPositonIndex].northing);
                 GL.End();
                 GL.PointSize(1.0f);
             }
@@ -657,7 +660,9 @@ namespace AgOpenGPS
                 GL.Color3(0.298f, 0.96f, 0.2960f);
                 GL.Begin(PrimitiveType.Points);
                 for (int h = 0; h < shuttleDubinsList.Count; h++)
-                    GL.Vertex3(shuttleDubinsList[h].easting, shuttleDubinsList[h].northing, 0);
+                {
+                    GL.Vertex2(shuttleDubinsList[h].easting, shuttleDubinsList[h].northing);
+                }
                 GL.End();
             }
         }

--- a/SourceCode/GPS/Classes/CTool.cs
+++ b/SourceCode/GPS/Classes/CTool.cs
@@ -278,21 +278,20 @@ namespace AgOpenGPS
 
                 //lookahead section on
                 GL.Color3(0.20f, 0.7f, 0.2f);
-                GL.Vertex3(mf.tool.farLeftPosition, (mf.tool.lookAheadDistanceOnPixelsLeft) * 0.1 + trailingTool, 0);
-                GL.Vertex3(mf.tool.farRightPosition, (mf.tool.lookAheadDistanceOnPixelsRight) * 0.1 + trailingTool, 0);
+                GL.Vertex2(mf.tool.farLeftPosition, (mf.tool.lookAheadDistanceOnPixelsLeft) * 0.1 + trailingTool);
+                GL.Vertex2(mf.tool.farRightPosition, (mf.tool.lookAheadDistanceOnPixelsRight) * 0.1 + trailingTool);
 
                 //lookahead section off
                 GL.Color3(0.70f, 0.2f, 0.2f);
-                GL.Vertex3(mf.tool.farLeftPosition, (mf.tool.lookAheadDistanceOffPixelsLeft) * 0.1 + trailingTool, 0);
-                GL.Vertex3(mf.tool.farRightPosition, (mf.tool.lookAheadDistanceOffPixelsRight) * 0.1 + trailingTool, 0);
+                GL.Vertex2(mf.tool.farLeftPosition, (mf.tool.lookAheadDistanceOffPixelsLeft) * 0.1 + trailingTool);
+                GL.Vertex2(mf.tool.farRightPosition, (mf.tool.lookAheadDistanceOffPixelsRight) * 0.1 + trailingTool);
 
                 if (mf.vehicle.isHydLiftOn)
                 {
                     GL.Color3(0.70f, 0.2f, 0.72f);
-                    GL.Vertex3(mf.section[0].positionLeft, (mf.vehicle.hydLiftLookAheadDistanceLeft * 0.1) + trailingTool, 0);
-                    GL.Vertex3(mf.section[mf.tool.numOfSections - 1].positionRight, (mf.vehicle.hydLiftLookAheadDistanceRight * 0.1) + trailingTool, 0);
+                    GL.Vertex2(mf.section[0].positionLeft, (mf.vehicle.hydLiftLookAheadDistanceLeft * 0.1) + trailingTool);
+                    GL.Vertex2(mf.section[mf.tool.numOfSections - 1].positionRight, (mf.vehicle.hydLiftLookAheadDistanceRight * 0.1) + trailingTool);
                 }
-
                 GL.End();
             }
 
@@ -352,10 +351,9 @@ namespace AgOpenGPS
                 for (int i = 1; i < zones; i++)
                 {
                     GL.Color3(0.5f, 0.80f, 0.950f);
-                    GL.Vertex3(mf.section[zoneRanges[i]].positionLeft, trailingTool - 0.4, 0);
-                    GL.Vertex3(mf.section[zoneRanges[i]].positionLeft, trailingTool + 0.2, 0);
+                    GL.Vertex2(mf.section[zoneRanges[i]].positionLeft, trailingTool - 0.4);
+                    GL.Vertex2(mf.section[zoneRanges[i]].positionLeft, trailingTool + 0.2);
                 }
-
                 GL.End();
             }
 
@@ -375,9 +373,9 @@ namespace AgOpenGPS
                     // section markers
                     GL.Begin(PrimitiveType.Points);
                     GLW.SetColor(rightMarkerColor);
-                    GL.Vertex3(rightX, trailingTool, 0);
+                    GL.Vertex2(rightX, trailingTool);
                     GLW.SetColor(leftMarkerColor);
-                    GL.Vertex3(leftX, trailingTool, 0);
+                    GL.Vertex2(leftX, trailingTool);
                     GL.End();
                 }
             }

--- a/SourceCode/GPS/Classes/CTram.cs
+++ b/SourceCode/GPS/Classes/CTram.cs
@@ -73,7 +73,9 @@ namespace AgOpenGPS
                     {
                         GL.Begin(PrimitiveType.LineStrip);
                         for (int h = 0; h < tramList[i].Count; h++)
-                            GL.Vertex3(tramList[i][h].easting, tramList[i][h].northing, 0);
+                        {
+                            GL.Vertex2(tramList[i][h].easting, tramList[i][h].northing);
+                        }
                         GL.End();
                     }
                 }
@@ -84,10 +86,16 @@ namespace AgOpenGPS
                 if (tramBndOuterArr.Count > 0)
                 {
                     GL.Begin(PrimitiveType.LineStrip);
-                    for (int h = 0; h < tramBndOuterArr.Count; h++) GL.Vertex3(tramBndOuterArr[h].easting, tramBndOuterArr[h].northing, 0);
+                    for (int h = 0; h < tramBndOuterArr.Count; h++)
+                    {
+                        GL.Vertex2(tramBndOuterArr[h].easting, tramBndOuterArr[h].northing);
+                    }
                     GL.End();
                     GL.Begin(PrimitiveType.LineStrip);
-                    for (int h = 0; h < tramBndInnerArr.Count; h++) GL.Vertex3(tramBndInnerArr[h].easting, tramBndInnerArr[h].northing, 0);
+                    for (int h = 0; h < tramBndInnerArr.Count; h++)
+                    {
+                        GL.Vertex2(tramBndInnerArr[h].easting, tramBndInnerArr[h].northing);
+                    }
                     GL.End();
                 }
             }
@@ -105,7 +113,9 @@ namespace AgOpenGPS
                     {
                         GL.Begin(PrimitiveType.LineStrip);
                         for (int h = 0; h < tramList[i].Count; h++)
-                            GL.Vertex3(tramList[i][h].easting, tramList[i][h].northing, 0);
+                        {
+                            GL.Vertex2(tramList[i][h].easting, tramList[i][h].northing);
+                        }
                         GL.End();
                     }
                 }
@@ -116,10 +126,16 @@ namespace AgOpenGPS
                 if (tramBndOuterArr.Count > 0)
                 {
                     GL.Begin(PrimitiveType.LineStrip);
-                    for (int h = 0; h < tramBndOuterArr.Count; h++) GL.Vertex3(tramBndOuterArr[h].easting, tramBndOuterArr[h].northing, 0);
+                    for (int h = 0; h < tramBndOuterArr.Count; h++)
+                    {
+                        GL.Vertex2(tramBndOuterArr[h].easting, tramBndOuterArr[h].northing);
+                    }
                     GL.End();
                     GL.Begin(PrimitiveType.LineStrip);
-                    for (int h = 0; h < tramBndInnerArr.Count; h++) GL.Vertex3(tramBndInnerArr[h].easting, tramBndInnerArr[h].northing, 0);
+                    for (int h = 0; h < tramBndInnerArr.Count; h++)
+                    {
+                        GL.Vertex2(tramBndInnerArr[h].easting, tramBndInnerArr[h].northing);
+                    }
                     GL.End();
                 }
             }

--- a/SourceCode/GPS/Classes/CVehicle.cs
+++ b/SourceCode/GPS/Classes/CVehicle.cs
@@ -279,22 +279,22 @@ namespace AgOpenGPS
             {
                 GL.Color4(1.2, 1.20, 0.0, VehicleConfig.Opacity);
                 GL.Begin(PrimitiveType.TriangleFan);
-                GL.Vertex3(0, VehicleConfig.AntennaPivot, -0.0);
-                GL.Vertex3(1.0, -0, 0.0);
+                GL.Vertex2(0, VehicleConfig.AntennaPivot);
+                GL.Vertex2(1.0, -0);
                 GL.Color4(0.0, 1.20, 1.22, VehicleConfig.Opacity);
-                GL.Vertex3(0, VehicleConfig.Wheelbase, 0.0);
+                GL.Vertex2(0, VehicleConfig.Wheelbase);
                 GL.Color4(1.220, 0.0, 1.2, VehicleConfig.Opacity);
-                GL.Vertex3(-1.0, -0, 0.0);
-                GL.Vertex3(1.0, -0, 0.0);
+                GL.Vertex2(-1.0, -0);
+                GL.Vertex2(1.0, -0);
                 GL.End();
 
                 GL.LineWidth(3);
                 GL.Color3(0.12, 0.12, 0.12);
                 GL.Begin(PrimitiveType.LineLoop);
                 {
-                    GL.Vertex3(-1.0, 0, 0);
-                    GL.Vertex3(1.0, 0, 0);
-                    GL.Vertex3(0, VehicleConfig.Wheelbase, 0);
+                    GL.Vertex2(-1.0, 0);
+                    GL.Vertex2(1.0, 0);
+                    GL.Vertex2(0, VehicleConfig.Wheelbase);
                 }
                 GL.End();
             }
@@ -315,10 +315,10 @@ namespace AgOpenGPS
                     GL.Color3(0.0, 1.270, 0.0);
                     GL.Begin(PrimitiveType.LineStrip);
                     {
-                        GL.Vertex3(0.0, 0, 0);
+                        GL.Vertex2(0.0, 0.0);
                         GL.Color3(1.270, 1.220, 0.20);
-                        GL.Vertex3(mf.bnd.createBndOffset, 0, 0);
-                        GL.Vertex3(mf.bnd.createBndOffset * 0.75, 0.25, 0);
+                        GL.Vertex2(mf.bnd.createBndOffset, 0);
+                        GL.Vertex2(mf.bnd.createBndOffset * 0.75, 0.25);
                     }
                     GL.End();
                 }
@@ -329,10 +329,10 @@ namespace AgOpenGPS
                     GL.Color3(0.0, 1.270, 0.0);
                     GL.Begin(PrimitiveType.LineStrip);
                     {
-                        GL.Vertex3(0.0, 0, 0);
+                        GL.Vertex2(0.0, 0.0);
                         GL.Color3(1.270, 1.220, 0.20);
-                        GL.Vertex3(-mf.bnd.createBndOffset, 0, 0);
-                        GL.Vertex3(-mf.bnd.createBndOffset * 0.75, 0.25, 0);
+                        GL.Vertex2(-mf.bnd.createBndOffset, 0);
+                        GL.Vertex2(-mf.bnd.createBndOffset * 0.75, 0.25);
                     }
                     GL.End();
                 }

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -2892,41 +2892,9 @@ namespace AgOpenGPS
             GL.Begin(PrimitiveType.Points);
             for (int i = 0; i < ytList.Count; i++)
             {
-                GL.Vertex3(ytList[i].easting, ytList[i].northing, 0);
+                GL.Vertex2(ytList[i].easting, ytList[i].northing);
             }
             GL.End();
-
-            //GL.PointSize(12.0f);
-            //GL.Begin(PrimitiveType.Points);
-            //GL.Color3(0.95f, 0.73f, 1.0f);
-            //GL.Vertex3(inClosestTurnPt.closePt.easting, inClosestTurnPt.closePt.northing, 0);
-            //GL.Color3(0.395f, 0.925f, 0.30f);
-            //GL.Vertex3(outClosestTurnPt.closePt.easting, outClosestTurnPt.closePt.northing, 0);
-            //GL.End();
-            //GL.PointSize(1.0f);
-
-            //if (nextCurve != null)
-            //{
-            //    GL.Begin(PrimitiveType.Points);
-            //    GL.Color3(0.95f, 0.41f, 0.980f);
-            //    for (int i = 0; i < nextCurve.curList.Count; i++)
-            //    {
-            //        GL.Vertex3(nextCurve.curList[i].easting, nextCurve.curList[i].northing, 0);
-            //    }
-            //    GL.End();
-            //}
-
-            //if (ytList2?.Count > 0)
-            //{
-            //    GL.PointSize(mf.ABLine.lineWidth + 2);
-            //    GL.Color3(0.3f, 0.941f, 0.980f);
-            //    GL.Begin(PrimitiveType.Points);
-            //    for (int i = 0; i < ytList2.Count; i++)
-            //    {
-            //        GL.Vertex3(ytList2[i].easting, ytList2[i].northing, 0);
-            //    }
-            //    GL.End();
-            //}
         }
 
         public class CClose

--- a/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormABDraw.cs
@@ -10,9 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Windows.Forms;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace AgOpenGPS
 {
@@ -740,30 +738,17 @@ namespace AgOpenGPS
 
                     GL.Begin(PrimitiveType.Lines);
 
-                    GL.Vertex3(gTemp[i].ptA.easting - (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength), gTemp[i].ptA.northing - (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength), 0);
-                    GL.Vertex3(gTemp[i].ptB.easting + (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength), gTemp[i].ptB.northing + (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength), 0);
+                    GL.Vertex2(
+                        gTemp[i].ptA.easting - (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength),
+                        gTemp[i].ptA.northing - (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength));
+                    GL.Vertex2(
+                        gTemp[i].ptB.easting + (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength),
+                        gTemp[i].ptB.northing + (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength));
 
                     GL.End();
 
                     GL.Disable(EnableCap.LineStipple);
-
-                    //if (mf.ABLine.numABLineSelected > 0)
-                    //{
-                    //    GL.Color3(1.0f, 0.0f, 0.0f);
-
-                    //    GL.LineWidth(4);
-                    //    GL.Begin(PrimitiveType.Lines);
-
-                    //    GL.Vertex3(gTemp[mf.ABLine.numABLineSelected - 1].ptA.easting - (Math.Sin(gTemp[mf.ABLine.numABLineSelected - 1].heading) * mf.ABLine.abLength),
-                    //        gTemp[mf.ABLine.numABLineSelected - 1].ptA.northing - (Math.Cos(gTemp[mf.ABLine.numABLineSelected - 1].heading) * mf.ABLine.abLength), 0);
-                    //    GL.Vertex3(gTemp[mf.ABLine.numABLineSelected - 1].ptA.easting + (Math.Sin(gTemp[mf.ABLine.numABLineSelected - 1].heading) * mf.ABLine.abLength),
-                    //        gTemp[mf.ABLine.numABLineSelected - 1].ptA.northing + (Math.Cos(gTemp[mf.ABLine.numABLineSelected - 1].heading) * mf.ABLine.abLength), 0);
-
-                    //    GL.End();
-                    //}
-
                 }
-
                 else if (gTemp[i].mode == TrackMode.Curve || gTemp[i].mode == TrackMode.bndCurve)
                 {
                     GL.Enable(EnableCap.LineStipple);
@@ -784,7 +769,7 @@ namespace AgOpenGPS
                     GL.Begin(PrimitiveType.LineStrip);
                     foreach (vec3 pts in gTemp[i].curvePts)
                     {
-                        GL.Vertex3(pts.easting, pts.northing, 0);
+                        GL.Vertex2(pts.easting, pts.northing);
                     }
                     GL.End();
 
@@ -796,15 +781,12 @@ namespace AgOpenGPS
                     GL.Color3(1.0f, 0.75f, 0.350f);
                     GL.Begin(PrimitiveType.Points);
 
-                    GL.Vertex3(gTemp[i].curvePts[0].easting,
-                                gTemp[i].curvePts[0].northing,
-                                0);
-
+                    GL.Vertex2(gTemp[i].curvePts[0].easting, gTemp[i].curvePts[0].northing);
 
                     GL.Color3(0.5f, 0.5f, 1.0f);
-                    GL.Vertex3(gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].easting,
-                                gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].northing,
-                                0);
+                    GL.Vertex2(
+                        gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].easting,
+                        gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].northing);
                     GL.End();
                 }
             }
@@ -817,18 +799,35 @@ namespace AgOpenGPS
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(0, 0, 0);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
+            if (end != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[end].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
 
             GL.PointSize(16);
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(1.0f, 0.75f, 0.350f);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
             GL.Color3(0.5f, 0.5f, 1.0f);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (end != 99999)
+            {
+                GL.Vertex2(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormHeadAche.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadAche.cs
@@ -549,7 +549,9 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.Lines);
                 for (int i = 0; i < mf.bnd.bndList[j].fenceLine.Count; i++)
                 {
-                    GL.Vertex3(mf.bnd.bndList[j].fenceLine[i].easting, mf.bnd.bndList[j].fenceLine[i].northing, 0);
+                    GL.Vertex2(
+                        mf.bnd.bndList[j].fenceLine[i].easting,
+                        mf.bnd.bndList[j].fenceLine[i].northing);
                 }
                 GL.End();
             }
@@ -605,7 +607,7 @@ namespace AgOpenGPS
                     GL.Begin(PrimitiveType.Points);
                     foreach (vec3 item in mf.hdl.tracksArr[i].trackPts)
                     {
-                        GL.Vertex3(item.easting, item.northing, 0);
+                        GL.Vertex2(item.easting, item.northing);
                     }
                     GL.End();
                 }
@@ -620,7 +622,7 @@ namespace AgOpenGPS
                     GL.Begin(PrimitiveType.LineStrip);
                     foreach (vec3 item in mf.hdl.tracksArr[mf.hdl.idx].trackPts)
                     {
-                        GL.Vertex3(item.easting, item.northing, 0);
+                        GL.Vertex2(item.easting, item.northing);
                     }
                     GL.End();
 
@@ -628,17 +630,25 @@ namespace AgOpenGPS
                     GL.PointSize(28);
                     GL.Color3(0, 0, 0);
                     GL.Begin(PrimitiveType.Points);
-                    GL.Vertex3(mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].easting, mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].northing, 0);
+                    GL.Vertex2(
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].easting,
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].northing);
                     GL.Color3(0, 0, 0);
-                    GL.Vertex3(mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].easting, mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].northing, 0);
+                    GL.Vertex2(
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].easting,
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].northing);
                     GL.End();
 
                     GL.PointSize(20);
                     GL.Color3(1.0f, 0.7f, 0.35f);
                     GL.Begin(PrimitiveType.Points);
-                    GL.Vertex3(mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].easting, mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].northing, 0);
+                    GL.Vertex2(
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].easting,
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[0].northing);
                     GL.Color3(0.6f, 0.75f, 0.99f);
-                    GL.Vertex3(mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].easting, mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].northing, 0);
+                    GL.Vertex2(
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].easting,
+                        mf.hdl.tracksArr[mf.hdl.idx].trackPts[cnt].northing);
                     GL.End();
                 }
             }
@@ -649,7 +659,7 @@ namespace AgOpenGPS
 
             for (int i = 0; i < mf.bnd.bndList[0].hdLine.Count; i++)
             {
-                GL.Vertex3(mf.bnd.bndList[0].hdLine[i].easting, mf.bnd.bndList[0].hdLine[i].northing, 0);
+                GL.Vertex2(mf.bnd.bndList[0].hdLine[i].easting, mf.bnd.bndList[0].hdLine[i].northing);
             }
             GL.End();
         }
@@ -661,18 +671,37 @@ namespace AgOpenGPS
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(0, 0, 0);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
+            if (end != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[end].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
 
             GL.PointSize(16);
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(1.0f, 0.75f, 0.350f);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
             GL.Color3(0.5f, 0.75f, 1.0f);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (end != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[end].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormHeadLine.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadLine.cs
@@ -446,7 +446,7 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.LineStrip);
                 for (int i = 0; i < mf.bnd.bndList[j].fenceLine.Count; i++)
                 {
-                    GL.Vertex3(mf.bnd.bndList[j].fenceLine[i].easting, mf.bnd.bndList[j].fenceLine[i].northing, 0);
+                    GL.Vertex2(mf.bnd.bndList[j].fenceLine[i].easting, mf.bnd.bndList[j].fenceLine[i].northing);
                 }
                 GL.End();
             }
@@ -467,23 +467,13 @@ namespace AgOpenGPS
         }
         private void DrawBuiltLines()
         {
-            //GL.LineWidth(8);
-            //GL.Color3(0.03f, 0.0f, 0.150f);
-            //GL.Begin(PrimitiveType.LineLoop);
-
-            //for (int i = 0; i < mf.bnd.bndList[0].hdLine.Count; i++)
-            //{
-            //    GL.Vertex3(mf.bnd.bndList[0].hdLine[i].easting, mf.bnd.bndList[0].hdLine[i].northing, 0);
-            //}
-            //GL.End();
-
             GL.LineWidth(8);
             GL.Color3(0.943f, 0.9083f, 0.09150f);
             GL.Begin(PrimitiveType.LineLoop);
 
             for (int i = 0; i < mf.bnd.bndList[0].hdLine.Count; i++)
             {
-                GL.Vertex3(mf.bnd.bndList[0].hdLine[i].easting, mf.bnd.bndList[0].hdLine[i].northing, 0);
+                GL.Vertex2(mf.bnd.bndList[0].hdLine[i].easting, mf.bnd.bndList[0].hdLine[i].northing);
             }
             GL.End();
 
@@ -505,7 +495,7 @@ namespace AgOpenGPS
                 GL.Begin(PrimitiveType.LineStrip);
                 foreach (vec3 item in sliceArr)
                 {
-                    GL.Vertex3(item.easting, item.northing, 0);
+                    GL.Vertex2(item.easting, item.northing);
                 }
                 GL.End();
 
@@ -513,9 +503,9 @@ namespace AgOpenGPS
                 GL.PointSize(24);
                 GL.Color3(1.0f, 0.6f, 0.3f);
                 GL.Begin(PrimitiveType.Points);
-                GL.Vertex3(sliceArr[0].easting, sliceArr[0].northing, 0);
+                GL.Vertex2(sliceArr[0].easting, sliceArr[0].northing);
                 GL.Color3(0.5f, 0.73f, 0.99f);
-                GL.Vertex3(sliceArr[cnt].easting, sliceArr[cnt].northing, 0);
+                GL.Vertex2(sliceArr[cnt].easting, sliceArr[cnt].northing);
                 GL.End();
             }
         }
@@ -526,18 +516,37 @@ namespace AgOpenGPS
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(0, 0, 0);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
+            if (end != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[end].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
 
             GL.PointSize(18);
             GL.Begin(PrimitiveType.Points);
 
             GL.Color3(1.0f, 0.75f, 0.350f);
-            if (start != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[start].easting, mf.bnd.bndList[bndSelect].fenceLine[start].northing, 0);
-
+            if (start != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[start].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[start].northing);
+            }
             GL.Color3(0.5f, 0.75f, 1.0f);
-            if (end != 99999) GL.Vertex3(mf.bnd.bndList[bndSelect].fenceLine[end].easting, mf.bnd.bndList[bndSelect].fenceLine[end].northing, 0);
+            if (end != 99999)
+            {
+                GL.Vertex2(
+                    mf.bnd.bndList[bndSelect].fenceLine[end].easting,
+                    mf.bnd.bndList[bndSelect].fenceLine[end].northing);
+            }
             GL.End();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormTramLine.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormTramLine.cs
@@ -7,11 +7,7 @@ using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Globalization;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Windows.Forms;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace AgOpenGPS
 {
@@ -616,12 +612,12 @@ namespace AgOpenGPS
 
             GL.Begin(PrimitiveType.Points);
             GL.Color3(1.0, 0, 0);
-            GL.Vertex3(ptA.easting, ptA.northing, 0);
+            GL.Vertex2(ptA.easting, ptA.northing);
             GL.End();
 
             GL.Begin(PrimitiveType.Points);
             GL.Color3(0, 1.0, 0);
-            GL.Vertex3(ptB.easting, ptB.northing, 0);
+            GL.Vertex2(ptB.easting, ptB.northing);
             GL.End();
 
             if (step == 2)
@@ -630,10 +626,9 @@ namespace AgOpenGPS
 
                 GL.Begin(PrimitiveType.Lines);
                 GL.Color3(1.0, 0, 0);
-                GL.Vertex3(ptA.easting, ptA.northing, 0);
+                GL.Vertex2(ptA.easting, ptA.northing);
                 GL.Color3(0, 1.0, 0);
-                GL.Vertex3(ptB.easting, ptB.northing, 0);
-
+                GL.Vertex2(ptB.easting, ptB.northing);
                 GL.End();
             }
 
@@ -653,7 +648,9 @@ namespace AgOpenGPS
                 {
                     GL.Begin(PrimitiveType.LineStrip);
                     for (int h = 0; h < mf.tram.tramList[i].Count; h++)
-                        GL.Vertex3(mf.tram.tramList[i][h].easting, mf.tram.tramList[i][h].northing, 0);
+                    {
+                        GL.Vertex2(mf.tram.tramList[i][h].easting, mf.tram.tramList[i][h].northing);
+                    }
                     GL.End();
                 }
             }
@@ -663,10 +660,16 @@ namespace AgOpenGPS
                 GL.Color4(0.830f, 0.72f, 0.3530f, mf.tram.alpha);
 
                 GL.Begin(PrimitiveType.LineLoop);
-                for (int h = 0; h < mf.tram.tramBndOuterArr.Count; h++) GL.Vertex3(mf.tram.tramBndOuterArr[h].easting, mf.tram.tramBndOuterArr[h].northing, 0);
+                for (int h = 0; h < mf.tram.tramBndOuterArr.Count; h++)
+                {
+                    GL.Vertex2(mf.tram.tramBndOuterArr[h].easting, mf.tram.tramBndOuterArr[h].northing);
+                }
                 GL.End();
                 GL.Begin(PrimitiveType.LineLoop);
-                for (int h = 0; h < mf.tram.tramBndInnerArr.Count; h++) GL.Vertex3(mf.tram.tramBndInnerArr[h].easting, mf.tram.tramBndInnerArr[h].northing, 0);
+                for (int h = 0; h < mf.tram.tramBndInnerArr.Count; h++)
+                {
+                    GL.Vertex2(mf.tram.tramBndInnerArr[h].easting, mf.tram.tramBndInnerArr[h].northing);
+                }
                 GL.End();
             }
         }
@@ -683,7 +686,9 @@ namespace AgOpenGPS
                 {
                     GL.Begin(PrimitiveType.LineStrip);
                     for (int h = 0; h < tramList[i].Count; h++)
-                        GL.Vertex3(tramList[i][h].easting, tramList[i][h].northing, 0);
+                    {
+                        GL.Vertex2(tramList[i][h].easting, tramList[i][h].northing);
+                    }
                     GL.End();
                 }
             }
@@ -709,10 +714,12 @@ namespace AgOpenGPS
                     GL.Color3(1.0f, 0.20f, 0.20f);
 
                     GL.Begin(PrimitiveType.Lines);
-
-                    GL.Vertex3(gTemp[i].ptA.easting - (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength), gTemp[i].ptA.northing - (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength), 0);
-                    GL.Vertex3(gTemp[i].ptB.easting + (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength), gTemp[i].ptB.northing + (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength), 0);
-
+                    GL.Vertex2(
+                        gTemp[i].ptA.easting - (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength),
+                        gTemp[i].ptA.northing - (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength));
+                    GL.Vertex2(
+                        gTemp[i].ptB.easting + (Math.Sin(gTemp[i].heading) * mf.ABLine.abLength),
+                        gTemp[i].ptB.northing + (Math.Cos(gTemp[i].heading) * mf.ABLine.abLength));
                     GL.End();
 
                     GL.Disable(EnableCap.LineStipple);
@@ -738,7 +745,7 @@ namespace AgOpenGPS
                     GL.Begin(PrimitiveType.LineStrip);
                     foreach (vec3 pts in gTemp[i].curvePts)
                     {
-                        GL.Vertex3(pts.easting, pts.northing, 0);
+                        GL.Vertex2(pts.easting, pts.northing);
                     }
                     GL.End();
 
@@ -750,15 +757,12 @@ namespace AgOpenGPS
                     GL.Color3(1.0f, 0.75f, 0.350f);
                     GL.Begin(PrimitiveType.Points);
 
-                    GL.Vertex3(gTemp[i].curvePts[0].easting,
-                                gTemp[i].curvePts[0].northing,
-                                0);
-
+                    GL.Vertex2(gTemp[i].curvePts[0].easting, gTemp[i].curvePts[0].northing);
 
                     GL.Color3(0.5f, 0.5f, 1.0f);
-                    GL.Vertex3(gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].easting,
-                                gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].northing,
-                                0);
+                    GL.Vertex2(
+                        gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].easting,
+                        gTemp[i].curvePts[gTemp[i].curvePts.Count - 1].northing);
                     GL.End();
                 }
             }

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -184,12 +184,18 @@ namespace AgOpenGPS
                                         int step = mipmap;
                                         for (int i = 1; i < count2; i += step)
                                         {
-                                            GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
-                                            GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
+                                            GL.Vertex2(triList[i].easting, triList[i].northing); i++;
+                                            GL.Vertex2(triList[i].easting, triList[i].northing); i++;
                                             if (count2 - i <= (mipmap + 2)) step = 0;//too small to mipmap it
                                         }
                                     }
-                                    else { for (int i = 1; i < count2; i++) GL.Vertex3(triList[i].easting, triList[i].northing, 0); }
+                                    else
+                                    {
+                                        for (int i = 1; i < count2; i++)
+                                        {
+                                            GL.Vertex2(triList[i].easting, triList[i].northing);
+                                        }
+                                    }
                                     GL.End();
 
                                     if (isSectionlinesOn)
@@ -204,11 +210,17 @@ namespace AgOpenGPS
                                             int step = mipmap;
                                             for (int i = 1; i < count2; i += step + 2)
                                             {
-                                                GL.Vertex3(triList[i].easting, triList[i].northing, 0);
+                                                GL.Vertex2(triList[i].easting, triList[i].northing);
                                                 if (count2 - i <= (mipmap + 2)) step = 0;//too small to mipmap it
                                             }
                                         }
-                                        else { for (int i = 1; i < count2; i += 2) GL.Vertex3(triList[i].easting, triList[i].northing, 0); }
+                                        else
+                                        {
+                                            for (int i = 1; i < count2; i += 2)
+                                            {
+                                                GL.Vertex2(triList[i].easting, triList[i].northing);
+                                            }
+                                        }
                                         GL.End();
 
                                         GL.Begin(PrimitiveType.LineStrip);
@@ -218,11 +230,17 @@ namespace AgOpenGPS
                                             int step = mipmap;
                                             for (int i = 2; i < count2; i += step + 2)
                                             {
-                                                GL.Vertex3(triList[i].easting, triList[i].northing, 0);
+                                                GL.Vertex2(triList[i].easting, triList[i].northing);
                                                 if (count2 - i <= (mipmap + 2)) step = 0;//too small to mipmap it
                                             }
                                         }
-                                        else { for (int i = 2; i < count2; i += 2) GL.Vertex3(triList[i].easting, triList[i].northing, 0); }
+                                        else
+                                        {
+                                            for (int i = 2; i < count2; i += 2)
+                                            {
+                                                GL.Vertex2(triList[i].easting, triList[i].northing);
+                                            }
+                                        }
                                         GL.End();
                                     }
 
@@ -254,11 +272,11 @@ namespace AgOpenGPS
                                             //GL.LineWidth(3.0f);
 
                                             GL.Begin(PrimitiveType.Triangles);
-                                            GL.Vertex3(left.easting, left.northing, 0);
-                                            GL.Vertex3(right.easting, right.northing, 0);
+                                            GL.Vertex2(left.easting, left.northing);
+                                            GL.Vertex2(right.easting, right.northing);
 
                                             GL.Color4(0.85, 0.85, 1, 1.0);
-                                            GL.Vertex3(ptTip.easting, ptTip.northing, 0);
+                                            GL.Vertex2(ptTip.easting, ptTip.northing);
                                             GL.End();
                                         }
                                     }
@@ -297,18 +315,18 @@ namespace AgOpenGPS
                                         vec2 pt = new vec2((cosSectionHeading * section[triStrip[j].currentStartSectionNum].positionLeft) + toolPos.easting,
                                                 (sinSectionHeading * section[triStrip[j].currentStartSectionNum].positionLeft) + toolPos.northing);
 
-                                        GL.Vertex3(pt.easting, pt.northing, 0);
+                                        GL.Vertex2(pt.easting, pt.northing);
 
                                         //Right side of triangle
                                         pt = new vec2((cosSectionHeading * section[triStrip[j].currentEndSectionNum].positionRight) + toolPos.easting,
                                            (sinSectionHeading * section[triStrip[j].currentEndSectionNum].positionRight) + toolPos.northing);
 
-                                        GL.Vertex3(pt.easting, pt.northing, 0);
+                                        GL.Vertex2(pt.easting, pt.northing);
 
                                         int last = triStrip[j].patchList[patchCount].Count;
 
-                                        GL.Vertex3(triStrip[j].patchList[patchCount][last - 2].easting, triStrip[j].patchList[patchCount][last - 2].northing, 0);
-                                        GL.Vertex3(triStrip[j].patchList[patchCount][last - 1].easting, triStrip[j].patchList[patchCount][last - 1].northing, 0);
+                                        GL.Vertex2(triStrip[j].patchList[patchCount][last - 2].easting, triStrip[j].patchList[patchCount][last - 2].northing);
+                                        GL.Vertex2(triStrip[j].patchList[patchCount][last - 1].easting, triStrip[j].patchList[patchCount][last - 1].northing);
                                         GL.End();
                                     }
                                     catch
@@ -411,8 +429,10 @@ namespace AgOpenGPS
                             GL.LineStipple(1, 0x0707);
                             GL.Begin(PrimitiveType.Lines);
                             GL.Color3(0.930f, 0.72f, 0.32f);
-                            GL.Vertex3(pivotAxlePos.easting, pivotAxlePos.northing, 0);
-                            GL.Vertex3(flagPts[flagNumberPicked - 1].easting, flagPts[flagNumberPicked - 1].northing, 0);
+                            GL.Vertex2(pivotAxlePos.easting, pivotAxlePos.northing);
+                            GL.Vertex2(
+                                flagPts[flagNumberPicked - 1].easting,
+                                flagPts[flagNumberPicked - 1].northing);
                             GL.End();
                             GL.Disable(EnableCap.LineStipple);
                         }
@@ -631,10 +651,12 @@ namespace AgOpenGPS
                     }
 
                     GL.Begin(PrimitiveType.LineLoop);
-                    GL.Vertex3(-oglMain.Width / 2, 0, 0);
-                    GL.Vertex3(oglMain.Width / 2, 0, 0);
-                    GL.Vertex3(oglMain.Width / 2, oglMain.Height, 0);
-                    GL.Vertex3(-oglMain.Width / 2, oglMain.Height, 0);
+                    // Todo: the next four lines do an integer divide that results
+                    // in an integer with rounding errors. Probably a small bug.
+                    GL.Vertex2(-oglMain.Width / 2, 0);
+                    GL.Vertex2(oglMain.Width / 2, 0);
+                    GL.Vertex2(oglMain.Width / 2, oglMain.Height);
+                    GL.Vertex2(-oglMain.Width / 2, oglMain.Height);
                     GL.End();
 
                     GL.PopMatrix();
@@ -844,7 +866,9 @@ namespace AgOpenGPS
                         {
                             //draw the triangles in each triangle strip
                             GL.Begin(PrimitiveType.TriangleStrip);
-                            for (int i = 1; i < count2; i++) GL.Vertex3(triList[i].easting, triList[i].northing, 0);
+                            {
+                                for (int i = 1; i < count2; i++) GL.Vertex2(triList[i].easting, triList[i].northing);
+                            }
                             GL.End();
                         }
                     }
@@ -864,7 +888,9 @@ namespace AgOpenGPS
                     {
                         GL.Begin(PrimitiveType.LineStrip);
                         for (int h = 0; h < tram.tramList[i].Count; h++)
-                            GL.Vertex3(tram.tramList[i][h].easting, tram.tramList[i][h].northing, 0);
+                        {
+                            GL.Vertex2(tram.tramList[i][h].easting, tram.tramList[i][h].northing);
+                        }
                         GL.End();
                     }
                 }
@@ -874,9 +900,13 @@ namespace AgOpenGPS
                     //boundary tram list
                     GL.Begin(PrimitiveType.LineStrip);
                     for (int h = 0; h < tram.tramBndOuterArr.Count; h++)
-                        GL.Vertex3(tram.tramBndOuterArr[h].easting, tram.tramBndOuterArr[h].northing, 0);
+                    {
+                        GL.Vertex2(tram.tramBndOuterArr[h].easting, tram.tramBndOuterArr[h].northing);
+                    }
                     for (int h = 0; h < tram.tramBndInnerArr.Count; h++)
-                        GL.Vertex3(tram.tramBndInnerArr[h].easting, tram.tramBndInnerArr[h].northing, 0);
+                    {
+                        GL.Vertex2(tram.tramBndInnerArr[h].easting, tram.tramBndInnerArr[h].northing);
+                    }
                     GL.End();
                 }
             }
@@ -1501,8 +1531,8 @@ namespace AgOpenGPS
                                 int step = mipmap;
                                 for (int i = 1; i < count2; i += step)
                                 {
-                                    GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
-                                    GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
+                                    GL.Vertex2(triList[i].easting, triList[i].northing); i++;
+                                    GL.Vertex2(triList[i].easting, triList[i].northing); i++;
 
                                     //too small to mipmap it
                                     if (count2 - i <= (mipmap))
@@ -1512,7 +1542,7 @@ namespace AgOpenGPS
 
                             else
                             {
-                                for (int i = 1; i < count2; i++) GL.Vertex3(triList[i].easting, triList[i].northing, 0);
+                                for (int i = 1; i < count2; i++) GL.Vertex2(triList[i].easting, triList[i].northing);
                             }
                             GL.End();
 
@@ -1568,144 +1598,6 @@ namespace AgOpenGPS
                 {
                     fd.actualAreaCovered = fd.overlapPercent = 0;
                 }
-
-                //GL.Flush();
-                ////oglZoom.MakeCurrent();
-                ////oglZoom.SwapBuffers();
-
-                //if (oglZoom.Width != 400)
-                //{
-                //    oglZoom.MakeCurrent();
-
-                //    GL.Disable(EnableCap.Blend);
-
-                //    GL.Clear(ClearBufferMask.DepthBufferBit | ClearBufferMask.ColorBufferBit);
-                //    GL.LoadIdentity();                  // Reset The View
-
-                //    //back the camera up
-                //    GL.Translate(0, 0, -maxFieldDistance*0.92);
-
-                //    //translate to that spot in the world 
-                //    GL.Translate(-fieldCenterX, -fieldCenterY, 0);
-
-                //    //draw the ABLine
-                //    if ((ABLine.isABLineSet | ABLine.isMakingABLine) && ABLine.isBtnABLineOn)
-                //    {
-                //        //Draw reference AB line
-                //        GL.LineWidth(1);
-                //        GL.Enable(EnableCap.LineStipple);
-                //        GL.LineStipple(1, 0x00F0);
-
-                //        GL.Begin(PrimitiveType.Lines);
-                //        GL.Color3(0.9f, 0.2f, 0.2f);
-                //        GL.Vertex3(ABLine.refLineEndA.easting, ABLine.refLineEndA.northing, 0);
-                //        GL.Vertex3(ABLine.refLineEndB.easting, ABLine.refLineEndB.northing, 0);
-                //        GL.End();
-                //        GL.Disable(EnableCap.LineStipple);
-
-                //        //raw current AB Line
-                //        GL.Begin(PrimitiveType.Lines);
-                //        GL.Color3(0.9f, 0.20f, 0.90f);
-                //        GL.Vertex3(ABLine.currentLinePtA.easting, ABLine.currentLinePtA.northing, 0.0);
-                //        GL.Vertex3(ABLine.currentLinePtB.easting, ABLine.currentLinePtB.northing, 0.0);
-                //        GL.End();
-                //    }
-
-                //    //draw curve if there is one
-                //    if (curve.isCurveSet && curve.isBtnTrackOn)
-                //    {
-                //        int ptC = curve.curList.Count;
-                //        if (ptC > 0)
-                //        {
-                //            GL.LineWidth(2);
-                //            GL.Color3(0.925f, 0.2f, 0.90f);
-                //            GL.Begin(PrimitiveType.LineStrip);
-                //            for (int h = 0; h < ptC; h++) GL.Vertex3(curve.curList[h].easting, curve.curList[h].northing, 0);
-                //            GL.End();
-                //        }
-                //    }
-
-                //    //draw all the fences
-                //    bnd.DrawFenceLines();
-
-                //    GL.PointSize(8.0f);
-                //    GL.Begin(PrimitiveType.Points);
-                //    GL.Color3(0.95f, 0.90f, 0.0f);
-                //    GL.Vertex3(pivotAxlePos.easting, pivotAxlePos.northing, 0.0);
-                //    GL.End();
-
-                //    GL.PointSize(1.0f);
-
-                //    if (isDay) GL.Color3(sectionColorDay.R, sectionColorDay.G, sectionColorDay.B);
-                //    else GL.Color3(sectionColorDay.R, sectionColorDay.G, sectionColorDay.B);
-
-                //    //GL.Color3((byte)0, (byte)200, (byte)0);
-                //    int cnt, step, patchCount;
-                //    int mipmap = 8;
-
-                //    //draw patches j= # of sections
-                //    for (int j = 0; j < triStrip.Count; j++)
-                //    {
-                //        //every time the section turns off and on is a new patch
-                //        patchCount = triStrip[j].patchList.Count;
-
-                //        if (patchCount > 0)
-                //        {
-                //            //for every new chunk of patch
-                //            foreach (var triList in triStrip[j].patchList)
-                //            {
-                //                //draw the triangle in each triangle strip
-                //                GL.Begin(PrimitiveType.TriangleStrip);
-                //                cnt = triList.Count;
-
-                //                //if large enough patch and camera zoomed out, fake mipmap the patches, skip triangles
-                //                if (cnt >= (mipmap))
-                //                {
-                //                    step = mipmap;
-                //                    for (int i = 1; i < cnt; i += step)
-                //                    {
-                //                        GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
-                //                        GL.Vertex3(triList[i].easting, triList[i].northing, 0); i++;
-
-                //                        //too small to mipmap it
-                //                        if (cnt - i <= (mipmap + 2))
-                //                            step = 0;
-                //                    }
-                //                }
-
-                //                else
-                //                {
-                //                    for (int i = 1; i < cnt; i++)
-                //                        GL.Vertex3(triList[i].easting, triList[i].northing, 0);
-                //                }
-                //                GL.End();
-
-                //            }
-                //        }
-                //    } //end of section patches
-
-                //    GL.Flush();
-
-                //    //byte[] overPix = new byte[oglZoom.Height * oglZoom.Width + 1];
-
-                //    //GL.ReadPixels(0, 0, oglZoom.Width, oglZoom.Width, OpenTK.Graphics.OpenGL.PixelFormat.Green, PixelType.UnsignedByte, overPix);
-
-                //    //int more = 0;
-
-                //    //for (int i = 0; i < oglZoom.Width * oglZoom.Width; i++)
-                //    //{
-
-                //    //    if (overPix[i] == 200)
-                //    //    {
-                //    //        more++;
-                //    //    }
-                //    //}
-
-                //    //double scale = ((maxFieldDistance * maxFieldDistance) / (oglZoom.Height * oglZoom.Width) * (double)more)/10000;
-
-                //    oglZoom.MakeCurrent();
-                //    oglZoom.SwapBuffers();
-                //}
             }
         }
 
@@ -1972,7 +1864,7 @@ namespace AgOpenGPS
                     }
                     flagColorRgb.Blue = (byte)flag.ID;
                     GLW.SetColor(flagColorRgb);
-                    GL.Vertex3(flag.easting, flag.northing, 0);
+                    GL.Vertex2(flag.easting, flag.northing);
                     GL.End();
 
                     font.DrawText3D(flag.easting, flag.northing, flagColor + flag.notes, camHeading);


### PR DESCRIPTION
I replaced all occurences of
Vertex3(someEasting, someNorthing, 0);
with
Vertex2(someEasting, someNorthing)

The speed gain on the CPU will be negigible. It only save one fast XOR instruction for the caller. (The zero is not loaded from the code, but generated by a XOR instruction. XOR is bitwise exclusive OR and the fastest way to set a bitpattern to all zeros, is to XOR it with itself. (And the representation of value 0.0 of type double is 64 zero bits)
Anyway, this PR will reduce the load for the bus to the GPU, so if the bottleneck is  on the CPU it will not speed up anything, but if the bottleneck is on the transfer to the GPU this will help significantly. (So it helps to find out where the bottleneck is actually.)

To be honest, I can not imagine that the bus to the GPU is the bottleneck, because any OpenGL toolkit will buffer everything if the bus can not keep up. But that could also degrade performance, because a large buffer will cause a lot of cash evictions for other more important things that you probably need the next frame.