### PR TITLE
Use result pattern for AgShare requests

### DIFF
--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareClient.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareClient.cs
@@ -50,7 +50,7 @@ namespace AgOpenGPS.Core.AgShare
         /// <summary>
         /// Checks if the API key and connection are valid
         /// </summary>
-        public static async Task<(bool ok, string message)> CheckApiAsync(string baseUrl, string apiKey)
+        public static async Task<AgShareResult> CheckApiAsync(string baseUrl, string apiKey)
         {
             try
             {
@@ -61,41 +61,52 @@ namespace AgOpenGPS.Core.AgShare
                     tempClient.BaseAddress = new Uri(baseUrl);
 
                     var response = await tempClient.GetAsync("/api/fields");
-                    string responseBody = await response.Content.ReadAsStringAsync();
 
                     if (response.IsSuccessStatusCode)
-                        return (true, "Connection OK");
+                    {
+                        return AgShareResult.Success();
+                    }
                     else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-                        return (false, "Invalid API key");
+                    {
+                        return AgShareResult.Failure(AgShareError.InvalidApiKey());
+                    }
                     else
-                        return (false, $"Status {response.StatusCode}: {responseBody}");
+                    {
+                        string responseBody = await response.Content.ReadAsStringAsync();
+                        return AgShareResult.Failure(AgShareError.WrongStatusCode(response.StatusCode, responseBody));
+                    }
                 }
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
-                return (false, $"Error: {ex.Message}");
+                return AgShareResult.Failure(AgShareError.HttpRequestException(ex));
             }
         }
 
         /// <summary>
         /// Uploads a field by ID
         /// </summary>
-        public async Task<(bool ok, string message)> UploadFieldAsync(Guid fieldId, UploadFieldDto fieldPayload)
+        public async Task<AgShareResult> UploadFieldAsync(Guid fieldId, UploadFieldDto fieldPayload)
         {
             try
             {
-                var json = JsonConvert.SerializeObject(fieldPayload, Formatting.Indented);
+                var json = JsonConvert.SerializeObject(fieldPayload);
                 var content = new StringContent(json, Encoding.UTF8, "application/json");
                 var response = await _client.PutAsync($"/api/fields/{fieldId}", content);
 
                 if (response.IsSuccessStatusCode)
-                    return (true, "Upload successful");
+                {
+                    return AgShareResult.Success();
+                }
                 else
-                    return (false, $"Upload failed: {response.StatusCode}");
+                {
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    return AgShareResult.Failure(AgShareError.WrongStatusCode(response.StatusCode, responseBody));
+                }
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
-                return (false, $"Exception: {ex.Message}");
+                return AgShareResult.Failure(AgShareError.HttpRequestException(ex));
             }
         }
 

--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareError.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareError.cs
@@ -1,0 +1,43 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace AgOpenGPS.Core.AgShare
+{
+    public abstract class AgShareError
+    {
+        public static AgShareError InvalidApiKey()
+            => new InvalidApiKeyError();
+
+        public static AgShareError WrongStatusCode(HttpStatusCode statusCode, string body)
+            => new StatusCodeError(statusCode, body);
+
+        public static AgShareError HttpRequestException(HttpRequestException exception)
+            => new HttpRequestError(exception);
+    }
+
+    public class InvalidApiKeyError : AgShareError
+    {
+    }
+
+    public class StatusCodeError : AgShareError
+    {
+        public StatusCodeError(HttpStatusCode statusCode, string body)
+        {
+            StatusCode = statusCode;
+            Body = body;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+        public string Body { get; }
+    }
+
+    public class HttpRequestError : AgShareError
+    {
+        public HttpRequestError(HttpRequestException exception)
+        {
+            Exception = exception;
+        }
+
+        public HttpRequestException Exception { get; }
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareResult.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace AgOpenGPS.Core.AgShare
+{
+    public class AgShareResult
+    {
+        private static readonly AgShareResult _success = new AgShareResult();
+
+        private AgShareResult()
+        {
+        }
+
+        private AgShareResult(AgShareError error)
+        {
+            Error = error ?? throw new ArgumentNullException(nameof(error));
+        }
+
+        public bool IsSuccessful => Error == null;
+        public AgShareError Error { get; }
+
+        public static AgShareResult Success() => _success;
+
+        public static AgShareResult Failure(AgShareError error) => new AgShareResult(error);
+    }
+}

--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>
 

--- a/SourceCode/GPS/Classes/AgShare/AgShareUploader.cs
+++ b/SourceCode/GPS/Classes/AgShare/AgShareUploader.cs
@@ -120,11 +120,9 @@ namespace AgOpenGPS
                     AbLines = abLines
                 };
 
-                var uploadResult = await _client.UploadFieldAsync(snapshot.FieldId, payload);
-                bool ok = uploadResult.ok;
-                string message = uploadResult.message;
+                var result = await _client.UploadFieldAsync(snapshot.FieldId, payload);
 
-                if (ok)
+                if (result.IsSuccessful)
                 {
                     string txtPath = Path.Combine(snapshot.FieldDirectory, "agshare.txt");
                     File.WriteAllText(txtPath, snapshot.FieldId.ToString());

--- a/SourceCode/GPS/Forms/FormAgShareSettings.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.cs
@@ -2,9 +2,9 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
-using AgOpenGPS.Properties;
 using AgOpenGPS.Controls;
 using AgOpenGPS.Core.AgShare;
+using AgOpenGPS.Properties;
 
 namespace AgOpenGPS
 {
@@ -74,9 +74,9 @@ namespace AgOpenGPS
             var baseUrl = textBoxServer.Text;
             var apiKey = textBoxApiKey.Text;
 
-            (bool success, string message) = await AgShareClient.CheckApiAsync(baseUrl, apiKey);
+            var result = await AgShareClient.CheckApiAsync(baseUrl, apiKey);
 
-            if (success)
+            if (result.IsSuccessful)
             {
                 labelStatus.Text = "✔ Connection successful";
                 labelStatus.ForeColor = Color.Green;
@@ -84,8 +84,24 @@ namespace AgOpenGPS
             }
             else
             {
-                labelStatus.Text = $"❌ {message}";
+                string error = ConvertError(result.Error);
+                labelStatus.Text = $"❌ {error}";
                 labelStatus.ForeColor = Color.Red;
+            }
+        }
+
+        private string ConvertError(AgShareError error)
+        {
+            switch (error)
+            {
+                case InvalidApiKeyError _:
+                    return "Invalid API key";
+                case StatusCodeError statusCodeError:
+                    return $"Status {statusCodeError.StatusCode}: {statusCodeError.Body}";
+                case HttpRequestError httpRequestError:
+                    return $"Error: {httpRequestError.Exception.Message}";
+                default:
+                    throw new InvalidOperationException($"Unknown {nameof(AgShareError)}: {error.GetType()}");
             }
         }
 


### PR DESCRIPTION
This allows us to handle the different errors in the frontend (e.g. `FormAgShareSettings`) which will eventually allow us to translate the errors.