### PR TITLE
Use result pattern for remaining AgShare requests

### DIFF
--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareClient.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareClient.cs
@@ -113,25 +113,61 @@ namespace AgOpenGPS.Core.AgShare
         /// <summary>
         /// Retrieves a list of fields owned by the current user
         /// </summary>
-        public async Task<List<GetOwnFieldDto>> GetOwnFieldsAsync()
+        public async Task<AgShareResult<List<GetOwnFieldDto>>> GetOwnFieldsAsync()
         {
-            var response = await _client.GetAsync("/api/fields");
-            response.EnsureSuccessStatusCode();
+            try
+            {
+                var response = await _client.GetAsync("/api/fields");
+                string json = await response.Content.ReadAsStringAsync();
 
-            string json = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<GetOwnFieldDto>>(json);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = JsonConvert.DeserializeObject<List<GetOwnFieldDto>>(json);
+                    return AgShareResult<List<GetOwnFieldDto>>.Success(data);
+                }
+                else
+                {
+                    return AgShareResult<List<GetOwnFieldDto>>.Failure(AgShareError.WrongStatusCode(response.StatusCode, json));
+                }
+            }
+            catch (JsonException ex)
+            {
+                return AgShareResult<List<GetOwnFieldDto>>.Failure(AgShareError.JsonException(ex));
+            }
+            catch (HttpRequestException ex)
+            {
+                return AgShareResult<List<GetOwnFieldDto>>.Failure(AgShareError.HttpRequestException(ex));
+            }
         }
 
         /// <summary>
         /// Downloads a specific field
         /// </summary>
-        public async Task<GetFieldDto> DownloadFieldAsync(Guid fieldId)
+        public async Task<AgShareResult<GetFieldDto>> DownloadFieldAsync(Guid fieldId)
         {
-            var response = await _client.GetAsync($"/api/fields/{fieldId}");
-            response.EnsureSuccessStatusCode();
+            try
+            {
+                var response = await _client.GetAsync($"/api/fields/{fieldId}");
+                string json = await response.Content.ReadAsStringAsync();
 
-            string json = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<GetFieldDto>(json);
+                if (response.IsSuccessStatusCode)
+                {
+                    var data = JsonConvert.DeserializeObject<GetFieldDto>(json);
+                    return AgShareResult<GetFieldDto>.Success(data);
+                }
+                else
+                {
+                    return AgShareResult<GetFieldDto>.Failure(AgShareError.WrongStatusCode(response.StatusCode, json));
+                }
+            }
+            catch (JsonException ex)
+            {
+                return AgShareResult<GetFieldDto>.Failure(AgShareError.JsonException(ex));
+            }
+            catch (HttpRequestException ex)
+            {
+                return AgShareResult<GetFieldDto>.Failure(AgShareError.HttpRequestException(ex));
+            }
         }
 
         // !!! This is not implemented yet !!!

--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareError.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareError.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http;
+using Newtonsoft.Json;
 
 namespace AgOpenGPS.Core.AgShare
 {
@@ -10,6 +11,9 @@ namespace AgOpenGPS.Core.AgShare
 
         public static AgShareError WrongStatusCode(HttpStatusCode statusCode, string body)
             => new StatusCodeError(statusCode, body);
+
+        public static AgShareError JsonException(JsonException exception)
+            => new JsonError(exception);
 
         public static AgShareError HttpRequestException(HttpRequestException exception)
             => new HttpRequestError(exception);
@@ -29,6 +33,16 @@ namespace AgOpenGPS.Core.AgShare
 
         public HttpStatusCode StatusCode { get; }
         public string Body { get; }
+    }
+
+    public class JsonError : AgShareError
+    {
+        public JsonError(JsonException exception)
+        {
+            Exception = exception;
+        }
+
+        public JsonException Exception { get; }
     }
 
     public class HttpRequestError : AgShareError

--- a/SourceCode/AgOpenGPS.Core/AgShare/AgShareResult.cs
+++ b/SourceCode/AgOpenGPS.Core/AgShare/AgShareResult.cs
@@ -22,4 +22,26 @@ namespace AgOpenGPS.Core.AgShare
 
         public static AgShareResult Failure(AgShareError error) => new AgShareResult(error);
     }
+
+    public class AgShareResult<T>
+        where T : class
+    {
+        private AgShareResult(T data)
+        {
+            Data = data ?? throw new ArgumentNullException(nameof(data));
+        }
+
+        private AgShareResult(AgShareError error)
+        {
+            Error = error ?? throw new ArgumentNullException(nameof(error));
+        }
+
+        public bool IsSuccessful => Error == null;
+        public T Data { get; }
+        public AgShareError Error { get; }
+
+        public static AgShareResult<T> Success(T data) => new AgShareResult<T>(data);
+
+        public static AgShareResult<T> Failure(AgShareError error) => new AgShareResult<T>(error);
+    }
 }

--- a/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
+++ b/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
@@ -27,17 +27,16 @@ namespace AgOpenGPS
         {
             try
             {
-                var dto = await _client.DownloadFieldAsync(fieldId);
+                var result = await _client.DownloadFieldAsync(fieldId);
 
-                // Validate DTO
-                if (dto == null)
+                if (!result.IsSuccessful)
                 {
                     Log.EventWriter($"[AgShare] Download failed for fieldId={fieldId}: Failed to deserialize field data");
                     return false;
                 }
 
                 // Parse DTO - validation is now done inside Parse method
-                var model = AgShareFieldParser.Parse(dto);
+                var model = AgShareFieldParser.Parse(result.Data);
 
                 string fieldDir = Path.Combine(RegistrySettings.fieldsDirectory, model.Name);
                 FieldFileWriter.WriteAllFiles(model, fieldDir);
@@ -54,7 +53,15 @@ namespace AgOpenGPS
         // Retrieves a list of user-owned fields
         public async Task<List<GetOwnFieldDto>> GetOwnFieldsAsync()
         {
-            return await _client.GetOwnFieldsAsync();
+            var result = await _client.GetOwnFieldsAsync();
+
+            if (!result.IsSuccessful)
+            {
+                Log.EventWriter($"[AgShare] Download own fields failed");
+                return new List<GetOwnFieldDto>();
+            }
+
+            return result.Data;
         }
 
         // Downloads a field DTO for preview only
@@ -62,9 +69,9 @@ namespace AgOpenGPS
         {
             try
             {
-                var dto = await _client.DownloadFieldAsync(fieldId);
+                var result = await _client.DownloadFieldAsync(fieldId);
 
-                if (dto == null)
+                if (!result.IsSuccessful)
                 {
                     Log.EventWriter($"[AgShare] Preview download failed for fieldId={fieldId}: Failed to deserialize field data");
                     return null;
@@ -72,9 +79,9 @@ namespace AgOpenGPS
 
                 // Validation is done in Parse method
                 // If validation fails, the outer catch will handle it
-                AgShareFieldParser.Parse(dto);
+                AgShareFieldParser.Parse(result.Data);
 
-                return dto;
+                return result.Data;
             }
             catch (Exception ex)
             {

--- a/SourceCode/GPS/Classes/AgShare/AgShareUploader.cs
+++ b/SourceCode/GPS/Classes/AgShare/AgShareUploader.cs
@@ -97,8 +97,12 @@ namespace AgOpenGPS
                 bool isPublic = false;
                 try
                 {
-                    var field = await _client.DownloadFieldAsync(snapshot.FieldId);
-                    if (field != null) isPublic = field.IsPublic;
+                    var downloadResult = await _client.DownloadFieldAsync(snapshot.FieldId);
+                    if (downloadResult.IsSuccessful)
+                    {
+                        var field = downloadResult.Data;
+                        isPublic = field.IsPublic;
+                    }
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
This should also catch a few more exceptions that were previously not handled.