### PR TITLE
A Vertex2Array only worked once. Some code was misplaced in constructor.

### DIFF
--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.DrawArrays.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.DrawArrays.cs
@@ -1,0 +1,37 @@
+﻿using OpenTK.Graphics.OpenGL;
+
+namespace AgOpenGPS.Core.DrawLib
+{
+    // GLW is short for GL Wrapper.
+    // Please use this class in stead of direct calls to functions in the GL toolkit.
+    public static partial class GLW
+    {
+
+        // Inlined by the compiler, so no function call overhead
+        public static void DrawLineLoopArrays(Vertex2Array array)
+        {
+            DrawArrays(PrimitiveType.LineLoop, array);
+        }
+
+        // Inlined by the compiler, so no function call overhead
+        public static void DrawLineStripArrays(Vertex2Array array)
+        {
+            DrawArrays(PrimitiveType.LineStrip, array);
+        }
+
+        private static void DrawArrays(PrimitiveType primitiveType, Vertex2Array vertex2Array)
+        {
+            if (vertex2Array == null) return;
+            vertex2Array.BindBuffer();
+
+            GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Double, false, 0, 0);
+            GL.EnableVertexAttribArray(0);
+
+            GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+
+            GL.DisableVertexAttribArray(0);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        }
+
+    }
+}

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoCoordPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoCoordPrimitives.cs
@@ -73,7 +73,7 @@ namespace AgOpenGPS.Core.DrawLib
             if (vertices.Length >= MinVerticesForArray)
             {
                 Vertex2Array vertex2Array = new Vertex2Array(vertices);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 vertex2Array.Dispose();
             }
             else
@@ -101,11 +101,11 @@ namespace AgOpenGPS.Core.DrawLib
                 // background layer
                 SetLineWidth(backgroundStyle.Width);
                 SetColor(backgroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 // foreground layer
                 SetLineWidth(foregroundStyle.Width);
                 SetColor(foregroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
 
                 vertex2Array.Dispose();
             }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoLineSegmentPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.GeoLineSegmentPrimitives.cs
@@ -26,7 +26,7 @@ namespace AgOpenGPS.Core.DrawLib
             if (nVerticesPerSegment * lineSegments.Length >= MinVerticesForArray)
             {
                 Vertex2Array vertex2Array = new Vertex2Array(lineSegments);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 vertex2Array.Dispose();
             }
             else
@@ -55,11 +55,11 @@ namespace AgOpenGPS.Core.DrawLib
                 // background layer
                 SetLineWidth(backgroundStyle.Width);
                 SetColor(backgroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 // foreground layer
                 SetLineWidth(foregroundStyle.Width);
                 SetColor(foregroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 vertex2Array.Dispose();
             }
             else

--- a/SourceCode/AgOpenGPS.Core/DrawLib/GLW.XyPrimitives.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/GLW.XyPrimitives.cs
@@ -60,7 +60,7 @@ namespace AgOpenGPS.Core.DrawLib
             if (vertices.Length >= MinVerticesForArray)
             {
                 Vertex2Array vertex2Array = new Vertex2Array(vertices);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 vertex2Array.Dispose();
             }
             else
@@ -88,11 +88,11 @@ namespace AgOpenGPS.Core.DrawLib
                 // background layer
                 SetLineWidth(backgroundStyle.Width);
                 SetColor(backgroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
                 // foreground layer
                 SetLineWidth(foregroundStyle.Width);
                 SetColor(foregroundStyle.Color);
-                GL.DrawArrays(primitiveType, 0, vertex2Array.Length);
+                DrawArrays(primitiveType, vertex2Array);
 
                 vertex2Array.Dispose();
             }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/Vertex2Array.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/Vertex2Array.cs
@@ -5,23 +5,49 @@ namespace AgOpenGPS.Core.DrawLib
 {
     public class Vertex2Array : VertexArrayBase
     {
-        public Vertex2Array(XyCoord[] vertices) : base(2)
+        public Vertex2Array()
         {
-            Length = vertices.Length;
-            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * 2 * sizeof(double), vertices, BufferUsageHint.StaticDraw);
         }
 
-        public Vertex2Array(GeoCoord[] vertices) : base(2)
+        public Vertex2Array(XyCoord[] vertices)
         {
-            Length = vertices.Length;
-            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * 2 * sizeof(double), vertices, BufferUsageHint.StaticDraw);
+            SetBufferData(vertices);
         }
 
-        public Vertex2Array(GeoLineSegment[] lineSegments) : base(2)
+        public Vertex2Array(GeoCoord[] vertices)
         {
+            SetBufferData(vertices);
+        }
+
+        public Vertex2Array(GeoLineSegment[] lineSegments)
+        {
+            SetBufferData(lineSegments);
+        }
+
+        public void SetBufferData(XyCoord[] vertices)
+        {
+            BindBuffer();
+            Length = vertices.Length;
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * 2 * sizeof(double), vertices, BufferUsageHint.StaticDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        }
+
+        public void SetBufferData(GeoCoord[] vertices)
+        {
+            BindBuffer();
+            Length = vertices.Length;
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * 2 * sizeof(double), vertices, BufferUsageHint.StaticDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        }
+
+        public void SetBufferData(GeoLineSegment[] lineSegments)
+        {
+            BindBuffer();
             Length = 2 * lineSegments.Length;
             GL.BufferData(BufferTarget.ArrayBuffer, lineSegments.Length * 4 * sizeof(double), lineSegments, BufferUsageHint.StaticDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
         }
+
     }
 
 }

--- a/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
+++ b/SourceCode/AgOpenGPS.Core/DrawLib/VertexArrayBase.cs
@@ -1,5 +1,4 @@
-﻿using AgOpenGPS.Core.Models;
-using OpenTK.Graphics.OpenGL;
+﻿using OpenTK.Graphics.OpenGL;
 using System;
 
 namespace AgOpenGPS.Core.DrawLib
@@ -7,19 +6,16 @@ namespace AgOpenGPS.Core.DrawLib
     public abstract class VertexArrayBase : IDisposable
     {
         private int _bufId;
-        private bool isDisposed;
+        private bool _isDisposed;
 
-        public VertexArrayBase(int nDimensions)
+        public VertexArrayBase()
         {
             _bufId = GL.GenBuffer();
-            Bind();
-            GL.EnableVertexAttribArray(0);
-            GL.VertexAttribPointer(0, nDimensions, VertexAttribPointerType.Double, false, 0, 0);
         }
 
         public int Length { get; protected set; }
 
-        public void Bind()
+        public void BindBuffer()
         {
             GL.BindBuffer(BufferTarget.ArrayBuffer, _bufId);
         }
@@ -35,10 +31,10 @@ namespace AgOpenGPS.Core.DrawLib
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!isDisposed)
+            if (!_isDisposed)
             {
                 DeleteBuffer();
-                isDisposed = true;
+                _isDisposed = true;
             }
         }
 


### PR DESCRIPTION
For performance I want to use the Vertex2Array for multiple frames, (currently that is not yet the case.)

It turns out that Vertex2Array only worked once, because some code that was misplaced in the constructor should have been executed for each frame.