### PR TITLE
AgShare cloud load, settings improvements and bug fixes (6.8.3)

### DIFF
--- a/SourceCode/AgIO/Source/Properties/RegistrySettings.cs
+++ b/SourceCode/AgIO/Source/Properties/RegistrySettings.cs
@@ -71,8 +71,7 @@ namespace AgIO
             //make sure directories exist and are in right place if not default workingDir
             CreateDirectories();
 
-            //keep below 500 kb
-            Log.CheckLogSize(Path.Combine(logsDirectory, "AgIO_Events_Log.txt"), 1000000);
+            Log.CheckLogSize(Path.Combine(logsDirectory, "AgIO_Events_Log.txt"));
 
             Properties.Settings.Default.Load();
         }

--- a/SourceCode/AgLibrary/Logging/Log.cs
+++ b/SourceCode/AgLibrary/Logging/Log.cs
@@ -38,9 +38,19 @@ namespace AgLibrary.Logging
         {
             if (logsDirectory != "")
             {
-                using (StreamWriter writer = new StreamWriter(logsDirectory, true))
+                try
                 {
-                    writer.Write(sbEvents);
+                    using (StreamWriter writer = new StreamWriter(logsDirectory, true))
+                    {
+                        writer.Write(sbEvents);
+                    }
+                }
+                catch
+                {
+                    // suppressing an edge-case error for eg if someone has onedrive client locking the file
+                }
+                finally
+                {
                     sbEvents.Clear();
                 }
             }

--- a/SourceCode/AgLibrary/Logging/Log.cs
+++ b/SourceCode/AgLibrary/Logging/Log.cs
@@ -46,49 +46,19 @@ namespace AgLibrary.Logging
             }
         }
 
-        public static void CheckLogSize(string logFile, int sizeLimit)
+        public static void CheckLogSize(string logFile, int maxLines = 100)
         {
             logsDirectory = logFile;
 
-            //system event log file
-            FileInfo txtfile = new FileInfo(logFile);
-            if (txtfile.Exists)
+            if (!File.Exists(logFile)) return;
+
+            string[] lines = File.ReadAllLines(logFile);
+            if (lines.Length > maxLines)
             {
-                if (txtfile.Length > (sizeLimit))       // ## NOTE: 0.5MB max file size
-                {
-                    StringBuilder sbF = new StringBuilder();
-                    long bytes = txtfile.Length - sizeLimit;
-                    bytes = (sizeLimit * 2) / 10 + bytes;
-                    sbEvents.Append("Log File Reduced by: " + bytes.ToString());
-
-                    //create some extra space
-                    int bytesSoFar = 0;
-
-                    using (StreamReader reader = new StreamReader(logFile))
-                    {
-                        try
-                        {
-                            //Date time line
-                            while (!reader.EndOfStream)
-                            {
-                                bytesSoFar += reader.ReadLine().Length;
-                                if (bytesSoFar > bytes)
-                                    break;
-                            }
-
-                            while (!reader.EndOfStream)
-                            {
-                                sbF.AppendLine(reader.ReadLine());
-                            }
-                        }
-                        catch { }
-                    }
-
-                    using (StreamWriter writer = new StreamWriter(logFile))
-                    {
-                        writer.WriteLine(sbF);
-                    }
-                }
+                string[] trimmed = new string[maxLines];
+                Array.Copy(lines, lines.Length - maxLines, trimmed, 0, maxLines);
+                File.WriteAllLines(logFile, trimmed);
+                sbEvents.Append("Log trimmed to last " + maxLines + " lines\r");
             }
         }
     }

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.Designer.cs
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.Designer.cs
@@ -185,7 +185,99 @@ namespace AgOpenGPS.Core.Translations {
                 return ResourceManager.GetString("gsAgShareDownloader", resourceCulture);
             }
         }
-        
+
+        public static string gsAgShareActivate {
+            get { return ResourceManager.GetString("gsAgShareActivate", resourceCulture); }
+        }
+
+        public static string gsAgShareActivated {
+            get { return ResourceManager.GetString("gsAgShareActivated", resourceCulture); }
+        }
+
+        public static string gsAgShareApiKey {
+            get { return ResourceManager.GetString("gsAgShareApiKey", resourceCulture); }
+        }
+
+        public static string gsAgShareAutoLoad {
+            get { return ResourceManager.GetString("gsAgShareAutoLoad", resourceCulture); }
+        }
+
+        public static string gsAgShareAutoUpload {
+            get { return ResourceManager.GetString("gsAgShareAutoUpload", resourceCulture); }
+        }
+
+        public static string gsAgShareButtonsHint {
+            get { return ResourceManager.GetString("gsAgShareButtonsHint", resourceCulture); }
+        }
+
+        public static string gsAgShareConnecting {
+            get { return ResourceManager.GetString("gsAgShareConnecting", resourceCulture); }
+        }
+
+        public static string gsAgShareConnectionOk {
+            get { return ResourceManager.GetString("gsAgShareConnectionOk", resourceCulture); }
+        }
+
+        public static string gsAgShareDeactivated {
+            get { return ResourceManager.GetString("gsAgShareDeactivated", resourceCulture); }
+        }
+
+        public static string gsAgShareEnterDetails {
+            get { return ResourceManager.GetString("gsAgShareEnterDetails", resourceCulture); }
+        }
+
+        public static string gsAgShareInvalidApiKey {
+            get { return ResourceManager.GetString("gsAgShareInvalidApiKey", resourceCulture); }
+        }
+
+        public static string gsAgShareLocalOnly {
+            get { return ResourceManager.GetString("gsAgShareLocalOnly", resourceCulture); }
+        }
+
+        public static string gsAgSharePaste {
+            get { return ResourceManager.GetString("gsAgSharePaste", resourceCulture); }
+        }
+
+        public static string gsAgShareRegisterHere {
+            get { return ResourceManager.GetString("gsAgShareRegisterHere", resourceCulture); }
+        }
+
+        public static string gsAgShareSaved {
+            get { return ResourceManager.GetString("gsAgShareSaved", resourceCulture); }
+        }
+
+        public static string gsAgShareServer {
+            get { return ResourceManager.GetString("gsAgShareServer", resourceCulture); }
+        }
+
+        public static string gsAgShareSettings {
+            get { return ResourceManager.GetString("gsAgShareSettings", resourceCulture); }
+        }
+
+        public static string gsAgShareTestConnection {
+            get { return ResourceManager.GetString("gsAgShareTestConnection", resourceCulture); }
+        }
+
+        public static string gsAgShareUploadOff {
+            get { return ResourceManager.GetString("gsAgShareUploadOff", resourceCulture); }
+        }
+
+        public static string gsAgShareUploadOn {
+            get { return ResourceManager.GetString("gsAgShareUploadOn", resourceCulture); }
+        }
+
+        public static string gsAgShareAutoLoadActive {
+            get { return ResourceManager.GetString("gsAgShareAutoLoadActive", resourceCulture); }
+        }
+
+        public static string gsAgShareFieldLoaded {
+            get { return ResourceManager.GetString("gsAgShareFieldLoaded", resourceCulture); }
+        }
+
+        public static string gsAgShareLoadFailed {
+            get { return ResourceManager.GetString("gsAgShareLoadFailed", resourceCulture); }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to View All Settings.
         /// </summary>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.cs.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.cs.resx
@@ -153,6 +153,79 @@
   <data name="gsAdvancedTramLines" xml:space="preserve">
     <value>Votvoř pokročilé kolejové řádky</value>
   </data>
+  <data name="gsAgShareDownloader" xml:space="preserve">
+    <value>Stáhnout pole z AgShare</value>
+  </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Aktivovat</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Aktivováno</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>API klíč</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Načítání z cloudu</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Automatické nahrávání</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Automatické nahrávání: nahrát změny pole při zavření
+Načítání z cloudu: vždy stáhnout nejnovější verzi z AgShare při otevření</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Připojování...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Připojení úspěšné</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Deaktivováno</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Zadejte server a API klíč, poté otestujte připojení</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Neplatný API klíč</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Pouze lokální</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Vložit ze schránky</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Zaregistrujte se zde pro použití AgShare</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Nastavení uloženo</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>Nastavení AgShare</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Otestovat připojení</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Nahrávání vypnuto</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Nahrávání zapnuto</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>Pole jsou automaticky načítána z cloudu</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Pole načteno z AgShare</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>Pole nelze načíst z cloudu, používá se lokální verze.</value>
+  </data>
   <data name="gsAgressiveness" xml:space="preserve">
     <value>Agresivita</value>
   </data>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.de.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.de.resx
@@ -1211,6 +1211,76 @@ VERWENDUNG AUF EIGENES RISIKO.</value>
   <data name="gsAgShareDownloader" xml:space="preserve">
     <value>Felder von AgShare herunterladen</value>
   </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Aktivieren</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Aktiviert</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>API-Schlüssel</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Cloud-Laden</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Auto-Upload</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Auto-Upload: Feldänderungen beim Schließen hochladen
+Cloud-Laden: Immer neueste Version beim Öffnen von AgShare herunterladen</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Verbinde...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Verbindung erfolgreich</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Deaktiviert</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Server und API-Schlüssel eingeben, dann Verbindung testen</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Ungültiger API-Schlüssel</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Nur Lokal</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Aus Zwischenablage einfügen</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Hier registrieren zur Nutzung von AgShare</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Einstellungen gespeichert</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>AgShare-Einstellungen</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Verbindung testen</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Upload Aus</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Upload Ein</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>Felder werden automatisch aus der Cloud geladen</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Feld von AgShare geladen</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>Feld konnte nicht aus der Cloud geladen werden, lokale Version wird verwendet.</value>
+  </data>
   <data name="gsDownloadAll" xml:space="preserve">
     <value>Alle herunterladen</value>
   </data>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.fr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.fr.resx
@@ -156,6 +156,76 @@
   <data name="gsAgShareDownloader" xml:space="preserve">
     <value>Télécharger les Parcelles depuis AgShare</value>
   </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Activer</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>Clé API</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Chargement cloud</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Téléversement auto</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Téléversement auto : envoyer les modifications à la fermeture
+Chargement cloud : toujours télécharger la dernière version depuis AgShare à l'ouverture</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Connexion en cours...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Connexion réussie</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Entrez le serveur et la clé API, puis testez la connexion</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Clé API invalide</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Local uniquement</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Coller depuis le presse-papiers</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Inscrivez-vous ici pour utiliser AgShare</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Paramètres enregistrés</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Serveur</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>Paramètres AgShare</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Tester la connexion</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Téléversement désactivé</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Téléversement activé</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>Les parcelles sont chargées automatiquement depuis le cloud</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Parcelle chargée depuis AgShare</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>Impossible de charger la parcelle depuis le cloud, utilisation de la version locale.</value>
+  </data>
   <data name="gsAgressiveness" xml:space="preserve">
     <value>Agressivité</value>
   </data>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.hu.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.hu.resx
@@ -156,6 +156,76 @@
   <data name="gsAgShareDownloader" xml:space="preserve">
     <value>Területek letöltése az AgShareből</value>
   </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Aktiválás</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Aktiválva</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>API-kulcs</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Felhő betöltés</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Auto-feltöltés</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Auto-feltöltés: mező változások feltöltése bezáráskor
+Felhő betöltés: mindig a legújabb verzió letöltése AgShareből megnyitáskor</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Csatlakozás...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Csatlakozás sikeres</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Deaktivált</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Adja meg a szervert és az API-kulcsot, majd tesztelje a kapcsolatot</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Érvénytelen API-kulcs</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Csak helyi</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Beillesztés vágólapról</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Regisztráljon itt az AgShare használatához</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Beállítások mentve</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Szerver</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>AgShare beállítások</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Kapcsolat tesztelése</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Feltöltés ki</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Feltöltés be</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>A mezők automatikusan töltődnek be a felhőből</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Mező betöltve az AgShareből</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>A mező nem tölthető be a felhőből, helyi verzió kerül felhasználásra.</value>
+  </data>
   <data name="gsAgree" xml:space="preserve">
     <value>Elfogad</value>
   </data>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
@@ -150,6 +150,76 @@
   <data name="gsAgShareDownloader" xml:space="preserve">
     <value>Download velden vanaf AgShare</value>
   </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Activeren</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Geactiveerd</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>API-sleutel</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Cloud Laden</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Auto-Upload</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Auto-Upload: veldwijzigingen uploaden bij sluiten
+Cloud Laden: altijd nieuwste versie downloaden van AgShare bij openen</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Verbinden...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Verbinding geslaagd</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Gedeactiveerd</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Voer server en API-sleutel in, test daarna de verbinding</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Ongeldige API-sleutel</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Alleen Lokaal</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Plakken vanuit klembord</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Registreer hier om AgShare te gebruiken</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Instellingen opgeslagen</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>AgShare-instellingen</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Verbinding testen</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Upload Uit</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Upload Aan</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>Velden worden automatisch geladen vanuit de cloud</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Veld geladen vanuit AgShare</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>Veld kon niet worden geladen vanuit de cloud, lokale versie wordt gebruikt.</value>
+  </data>
   <data name="gsAgressiveness" xml:space="preserve">
     <value>Agressiviteit</value>
   </data>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.resx
@@ -156,6 +156,76 @@
   <data name="gsAgShareDownloader" xml:space="preserve">
     <value>Download Fields From AgShare</value>
   </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>Activate</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>Activated</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>API Key</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>Cloud Load</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>Auto-Upload</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>Auto-Upload: upload field changes on close
+Cloud Load: always download latest from AgShare on open</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>Connecting...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>Connection successful</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>Deactivated</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>Enter server and API key, then test the connection</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>Invalid API key</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>Local Only</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>Paste from Clipboard</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>Register here to use AgShare</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>Settings saved</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>AgShare Settings</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>Test Connection</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>Upload Off</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>Upload On</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>Fields are auto loaded from cloud</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>Field loaded from AgShare</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>Could not load field from cloud, using local version.</value>
+  </data>
   <data name="gsAgree" xml:space="preserve">
     <value>Agree</value>
   </data>

--- a/SourceCode/AgOpenGPS.Tests/AgOpenGPS.Tests.csproj
+++ b/SourceCode/AgOpenGPS.Tests/AgOpenGPS.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SourceCode/GPS/Classes/CFenceLine.cs
+++ b/SourceCode/GPS/Classes/CFenceLine.cs
@@ -16,6 +16,8 @@ namespace AgOpenGPS
         {
             //to calc heading based on next and previous points to give an average heading.
             int cnt = fenceLine.Count;
+            if (cnt < 2) return; // Need at least 2 points to calculate headings
+
             vec3[] arr = new vec3[cnt];
             cnt--;
             fenceLine.CopyTo(arr);
@@ -45,6 +47,9 @@ namespace AgOpenGPS
 
         public void FixFenceLine(int bndNum)
         {
+            // Cannot fix a fence line with insufficient points
+            if (fenceLine.Count < 2) return;
+
             double spacing;
             //close if less then 20 ha, 40ha, more
             if (area < 200000) spacing = 1.1;
@@ -134,6 +139,8 @@ namespace AgOpenGPS
         {
             //reverse the boundary
             int cnt = fenceLine.Count;
+            if (cnt < 2) return; // Need at least 2 points to reverse
+
             vec3[] arr = new vec3[cnt];
             cnt--;
             fenceLine.CopyTo(arr);
@@ -152,7 +159,7 @@ namespace AgOpenGPS
             Debug.WriteLine("CalculateFenceArea is Called");
             RemoveSelfIntersections();
             int ptCount = fenceLine.Count;
-            if (ptCount < 1) return false;
+            if (ptCount < 3) return false; // Need at least 3 points for a valid boundary
 
             area = 0;         // Accumulates area in the loop
             int j = ptCount - 1;  // The last vertex is the 'previous' one to the first

--- a/SourceCode/GPS/Classes/CSmartWAS.cs
+++ b/SourceCode/GPS/Classes/CSmartWAS.cs
@@ -126,6 +126,10 @@ namespace AgOpenGPS
             if (Math.Abs(mf.guidanceLineDistanceOff) > MAX_DIST_OFF_MM) return;
             if (Math.Abs(steerAngleDegrees) > MAX_ANGLE_DEG) return;
 
+            // Normalize for WAS inversion: inverted WAS flips the required correction direction
+            bool wasInverted = (Properties.VehicleSettings.Default.setArdSteer_setting0 & 1) != 0;
+            if (wasInverted) steerAngleDegrees = -steerAngleDegrees;
+
             lock (dataLock)
             {
                 steerAngleHistory.Add(steerAngleDegrees);

--- a/SourceCode/GPS/Classes/CTurnLines.cs
+++ b/SourceCode/GPS/Classes/CTurnLines.cs
@@ -8,6 +8,7 @@ namespace AgOpenGPS
         {
             //to calc heading based on next and previous points to give an average heading.
             int cnt = turnLine.Count;
+            if (cnt < 2) return;
             vec3[] arr = new vec3[cnt];
             cnt--;
             turnLine.CopyTo(arr);

--- a/SourceCode/GPS/Forms/Config/ConfigSummaryControl.cs
+++ b/SourceCode/GPS/Forms/Config/ConfigSummaryControl.cs
@@ -54,7 +54,7 @@ namespace AgOpenGPS.Forms.Config
             lblToolOffset.Text = Distance.SmallDistanceString(mf.isMetric, ts.setVehicle_toolOffset);
             lblOverlap.Text = Distance.SmallDistanceString(mf.isMetric, ts.setVehicle_toolOverlap);
             lblLookahead.Text = ts.setVehicle_toolLookAheadOn.ToString() + " sec";
-            lblNudgeDistance.Text = Distance.VerySmallDistanceString(mf.isMetric, 0.01 * Properties.Settings.Default.setAS_snapDistance);
+            lblNudgeDistance.Text = Distance.VerySmallDistanceString(mf.isMetric, 0.01 * Properties.ToolSettings.Default.setAS_snapDistance);
             lblTramWidth.Text = Distance.MediumDistanceString(mf.isMetric, Properties.Settings.Default.setTram_tramWidth);
 
             // Buiten panels

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -1226,12 +1226,12 @@ namespace AgOpenGPS
 
         private void btnAdjRight_Click(object sender, EventArgs e)
         {
-            trk.NudgeTrack(Properties.Settings.Default.setAS_snapDistance * 0.01);
+            trk.NudgeTrack(Properties.ToolSettings.Default.setAS_snapDistance * 0.01);
         }
 
         private void btnAdjLeft_Click(object sender, EventArgs e)
         {
-            trk.NudgeTrack(-Properties.Settings.Default.setAS_snapDistance * 0.01);
+            trk.NudgeTrack(-Properties.ToolSettings.Default.setAS_snapDistance * 0.01);
         }
 
         #endregion

--- a/SourceCode/GPS/Forms/Field/FormAgShareDownloader.cs
+++ b/SourceCode/GPS/Forms/Field/FormAgShareDownloader.cs
@@ -141,7 +141,7 @@ namespace AgOpenGPS.Forms.Field
                 await gps.FileSaveEverythingBeforeClosingField();
             }
 
-            gps.FileOpenField(fieldFile);
+            await gps.FileOpenField(fieldFile);
             Close();
         }
 

--- a/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
@@ -494,7 +494,7 @@ namespace AgOpenGPS
                 }
 
                 //now open the newly cloned field
-                mf.FileOpenField(Path.Combine(directoryName, myFileName));
+                await mf.FileOpenField(Path.Combine(directoryName, myFileName));
             }
 
             DialogResult = DialogResult.OK;

--- a/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
@@ -272,6 +272,16 @@ namespace AgOpenGPS
             mf.pn.DefineLocalPlane(_origin, true);
 
             List<CBoundaryList> boundaries = importer.GetBoundaries();
+
+            // Calculate area for all boundaries first to enable sorting
+            foreach (var bnd in boundaries)
+            {
+                bnd.CalculateFenceArea(0); // Calculate area with temporary index
+            }
+
+            // Sort by area descending (largest first)
+            boundaries.Sort((a, b) => b.area.CompareTo(a.area));
+
             foreach (var bnd in boundaries)
             {
                 mf.bnd.bndList.Add(bnd);

--- a/SourceCode/GPS/Forms/Field/FormJob.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormJob.Designer.cs
@@ -45,6 +45,7 @@
             this.btnJobNew = new System.Windows.Forms.Button();
             this.lblResumeField = new System.Windows.Forms.Label();
             this.btnDeleteAB = new System.Windows.Forms.Button();
+            this.lblAgShareCloudLoad = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -378,8 +379,21 @@
             this.lblResumeField.Text = "Previous Field";
             this.lblResumeField.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
+            // lblAgShareCloudLoad
+            //
+            this.lblAgShareCloudLoad.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblAgShareCloudLoad.BackColor = System.Drawing.Color.Transparent;
+            this.lblAgShareCloudLoad.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblAgShareCloudLoad.ForeColor = System.Drawing.Color.SteelBlue;
+            this.lblAgShareCloudLoad.Location = new System.Drawing.Point(9, 480);
+            this.lblAgShareCloudLoad.Name = "lblAgShareCloudLoad";
+            this.lblAgShareCloudLoad.Size = new System.Drawing.Size(468, 20);
+            this.lblAgShareCloudLoad.TabIndex = 116;
+            this.lblAgShareCloudLoad.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblAgShareCloudLoad.Visible = false;
+            //
             // btnDeleteAB
-            // 
+            //
             this.btnDeleteAB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnDeleteAB.BackColor = System.Drawing.Color.Transparent;
             this.btnDeleteAB.DialogResult = System.Windows.Forms.DialogResult.Cancel;
@@ -404,6 +418,7 @@
             this.ControlBox = false;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.btnDeleteAB);
+            this.Controls.Add(this.lblAgShareCloudLoad);
             this.Controls.Add(this.lblResumeField);
             this.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
@@ -442,5 +457,6 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button btnJobAgShare;
         private System.Windows.Forms.Button btnAgShareBulkUpload;
+        private System.Windows.Forms.Label lblAgShareCloudLoad;
     }
 }

--- a/SourceCode/GPS/Forms/Field/FormJob.cs
+++ b/SourceCode/GPS/Forms/Field/FormJob.cs
@@ -33,6 +33,8 @@ namespace AgOpenGPS
             btnJobClose.Text = gStr.gsClose;
 
             this.Text = gStr.gsStartNewField;
+
+            lblAgShareCloudLoad.Text = "☁ " + gStr.gsAgShareAutoLoadActive;
         }
 
         private void FormJob_Load(object sender, EventArgs e)
@@ -80,6 +82,9 @@ namespace AgOpenGPS
                 ClientSize = new System.Drawing.Size(ClientSize.Width, ClientSize.Height - 75);
             }
 
+            lblAgShareCloudLoad.Visible = Properties.Settings.Default.AgShareEnabled
+                                       && Properties.Settings.Default.AgShareAutoLoad;
+
             mf.CloseTopMosts();
 
         }
@@ -95,10 +100,10 @@ namespace AgOpenGPS
             Close();
         }
 
-        private void btnJobResume_Click(object sender, EventArgs e)
+        private async void btnJobResume_Click(object sender, EventArgs e)
         {
             //open the Resume.txt and continue from last exit
-            mf.FileOpenField("Resume");
+            await mf.FileOpenField("Resume");
 
             Log.EventWriter("Job Form, Field Resume");
 
@@ -120,7 +125,7 @@ namespace AgOpenGPS
             {
                 if (form.ShowDialog(this) == DialogResult.Yes)
                 {
-                    mf.FileOpenField(mf.filePickerFileAndDirectory);
+                    await mf.FileOpenField(mf.filePickerFileAndDirectory);
                     Close();
                 }
             }
@@ -200,7 +205,7 @@ namespace AgOpenGPS
                         //returns full field.txt file dir name
                         if (form.ShowDialog(this) == DialogResult.Yes)
                         {
-                            mf.FileOpenField(mf.filePickerFileAndDirectory);
+                            await mf.FileOpenField(mf.filePickerFileAndDirectory);
                             Close();
                         }
                         else
@@ -212,7 +217,7 @@ namespace AgOpenGPS
                 else // 1 field found
                 {
                     mf.filePickerFileAndDirectory = Path.Combine(RegistrySettings.fieldsDirectory, infieldList, "Field.txt");
-                    mf.FileOpenField(mf.filePickerFileAndDirectory);
+                    await mf.FileOpenField(mf.filePickerFileAndDirectory);
                     Close();
                 }
             }
@@ -305,5 +310,6 @@ namespace AgOpenGPS
             DialogResult = DialogResult.Ignore;
             Close();
         }
+
     }
 }

--- a/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
@@ -49,9 +49,9 @@
             // textBoxApiKey
             // 
             this.textBoxApiKey.BackColor = System.Drawing.Color.White;
-            this.textBoxApiKey.Location = new System.Drawing.Point(122, 57);
+            this.textBoxApiKey.Location = new System.Drawing.Point(158, 57);
             this.textBoxApiKey.Name = "textBoxApiKey";
-            this.textBoxApiKey.Size = new System.Drawing.Size(462, 30);
+            this.textBoxApiKey.Size = new System.Drawing.Size(426, 30);
             this.textBoxApiKey.TabIndex = 0;
             // 
             // buttonTestConnection
@@ -78,24 +78,26 @@
             // 
             // labelApiKey
             // 
+            this.labelApiKey.AutoSize = true;
             this.labelApiKey.BackColor = System.Drawing.Color.Transparent;
             this.labelApiKey.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelApiKey.ForeColor = System.Drawing.Color.Black;
-            this.labelApiKey.Location = new System.Drawing.Point(16, 60);
+            this.labelApiKey.Location = new System.Drawing.Point(12, 59);
             this.labelApiKey.Name = "labelApiKey";
-            this.labelApiKey.Size = new System.Drawing.Size(100, 24);
+            this.labelApiKey.Size = new System.Drawing.Size(92, 23);
             this.labelApiKey.TabIndex = 5;
             this.labelApiKey.Text = "API Key:";
             this.labelApiKey.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label1
             // 
+            this.label1.AutoSize = true;
             this.label1.BackColor = System.Drawing.Color.Transparent;
             this.label1.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(16, 22);
+            this.label1.Location = new System.Drawing.Point(12, 21);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(100, 24);
+            this.label1.Size = new System.Drawing.Size(78, 23);
             this.label1.TabIndex = 6;
             this.label1.Text = "Server:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -105,9 +107,9 @@
             this.textBoxServer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxServer.BackColor = System.Drawing.Color.White;
-            this.textBoxServer.Location = new System.Drawing.Point(122, 19);
+            this.textBoxServer.Location = new System.Drawing.Point(158, 19);
             this.textBoxServer.Name = "textBoxServer";
-            this.textBoxServer.Size = new System.Drawing.Size(462, 30);
+            this.textBoxServer.Size = new System.Drawing.Size(426, 30);
             this.textBoxServer.TabIndex = 7;
             this.textBoxServer.Click += new System.EventHandler(this.textBoxServer_Click);
             // 

--- a/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
@@ -38,28 +38,27 @@
             this.linkRegister = new System.Windows.Forms.LinkLabel();
             this.label2 = new System.Windows.Forms.Label();
             this.btnDevelop = new System.Windows.Forms.Button();
-            this.btnAutoUpload = new System.Windows.Forms.Button();
             this.btnToggleUpload = new System.Windows.Forms.Button();
+            this.btnAutoUpload = new System.Windows.Forms.Button();
+            this.btnAutoLoad = new System.Windows.Forms.Button();
+            this.labelButtonsHint = new System.Windows.Forms.Label();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonSave = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // textBoxApiKey
             // 
-            this.textBoxApiKey.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxApiKey.BackColor = System.Drawing.Color.White;
-            this.textBoxApiKey.Location = new System.Drawing.Point(122, 59);
+            this.textBoxApiKey.Location = new System.Drawing.Point(122, 57);
             this.textBoxApiKey.Name = "textBoxApiKey";
-            this.textBoxApiKey.Size = new System.Drawing.Size(441, 30);
+            this.textBoxApiKey.Size = new System.Drawing.Size(462, 30);
             this.textBoxApiKey.TabIndex = 0;
             // 
             // buttonTestConnection
             // 
-            this.buttonTestConnection.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonTestConnection.Location = new System.Drawing.Point(343, 96);
+            this.buttonTestConnection.Location = new System.Drawing.Point(374, 93);
             this.buttonTestConnection.Name = "buttonTestConnection";
-            this.buttonTestConnection.Size = new System.Drawing.Size(220, 35);
+            this.buttonTestConnection.Size = new System.Drawing.Size(210, 35);
             this.buttonTestConnection.TabIndex = 1;
             this.buttonTestConnection.Text = "Test Connection";
             this.buttonTestConnection.UseVisualStyleBackColor = true;
@@ -67,11 +66,12 @@
             // 
             // labelStatus
             // 
-            this.labelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.labelStatus.ForeColor = System.Drawing.Color.DarkRed;
-            this.labelStatus.Location = new System.Drawing.Point(20, 141);
+            this.labelStatus.Location = new System.Drawing.Point(16, 140);
             this.labelStatus.Name = "labelStatus";
-            this.labelStatus.Size = new System.Drawing.Size(543, 25);
+            this.labelStatus.Size = new System.Drawing.Size(568, 24);
             this.labelStatus.TabIndex = 4;
             this.labelStatus.Text = "Enter Details Above and Tick Test Connection";
             this.labelStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -81,9 +81,9 @@
             this.labelApiKey.BackColor = System.Drawing.Color.Transparent;
             this.labelApiKey.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.labelApiKey.ForeColor = System.Drawing.Color.Black;
-            this.labelApiKey.Location = new System.Drawing.Point(16, 62);
+            this.labelApiKey.Location = new System.Drawing.Point(16, 60);
             this.labelApiKey.Name = "labelApiKey";
-            this.labelApiKey.Size = new System.Drawing.Size(100, 23);
+            this.labelApiKey.Size = new System.Drawing.Size(100, 24);
             this.labelApiKey.TabIndex = 5;
             this.labelApiKey.Text = "API Key:";
             this.labelApiKey.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -93,9 +93,9 @@
             this.label1.BackColor = System.Drawing.Color.Transparent;
             this.label1.Font = new System.Drawing.Font("Tahoma", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(16, 26);
+            this.label1.Location = new System.Drawing.Point(16, 22);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(100, 23);
+            this.label1.Size = new System.Drawing.Size(100, 24);
             this.label1.TabIndex = 6;
             this.label1.Text = "Server:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -105,18 +105,18 @@
             this.textBoxServer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxServer.BackColor = System.Drawing.Color.White;
-            this.textBoxServer.Location = new System.Drawing.Point(122, 23);
+            this.textBoxServer.Location = new System.Drawing.Point(122, 19);
             this.textBoxServer.Name = "textBoxServer";
-            this.textBoxServer.Size = new System.Drawing.Size(441, 30);
+            this.textBoxServer.Size = new System.Drawing.Size(462, 30);
             this.textBoxServer.TabIndex = 7;
             this.textBoxServer.Click += new System.EventHandler(this.textBoxServer_Click);
             // 
             // btnPaste
             // 
-            this.btnPaste.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnPaste.Location = new System.Drawing.Point(122, 96);
+            this.btnPaste.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnPaste.Location = new System.Drawing.Point(122, 95);
             this.btnPaste.Name = "btnPaste";
-            this.btnPaste.Size = new System.Drawing.Size(192, 35);
+            this.btnPaste.Size = new System.Drawing.Size(228, 34);
             this.btnPaste.TabIndex = 9;
             this.btnPaste.Text = "Paste from Clipboard";
             this.btnPaste.UseVisualStyleBackColor = true;
@@ -126,7 +126,7 @@
             // 
             this.linkRegister.AutoSize = true;
             this.linkRegister.LinkBehavior = System.Windows.Forms.LinkBehavior.AlwaysUnderline;
-            this.linkRegister.Location = new System.Drawing.Point(147, 341);
+            this.linkRegister.Location = new System.Drawing.Point(50, 380);
             this.linkRegister.Name = "linkRegister";
             this.linkRegister.Size = new System.Drawing.Size(280, 23);
             this.linkRegister.TabIndex = 10;
@@ -137,7 +137,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(158, 318);
+            this.label2.Location = new System.Drawing.Point(50, 358);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(256, 23);
             this.label2.TabIndex = 11;
@@ -148,19 +148,33 @@
             this.btnDevelop.BackColor = System.Drawing.Color.Transparent;
             this.btnDevelop.FlatAppearance.BorderSize = 0;
             this.btnDevelop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDevelop.Location = new System.Drawing.Point(12, 338);
+            this.btnDevelop.Location = new System.Drawing.Point(12, 378);
             this.btnDevelop.Name = "btnDevelop";
-            this.btnDevelop.Size = new System.Drawing.Size(22, 23);
+            this.btnDevelop.Size = new System.Drawing.Size(22, 22);
             this.btnDevelop.TabIndex = 12;
             this.btnDevelop.UseVisualStyleBackColor = false;
             this.btnDevelop.Click += new System.EventHandler(this.btnDevelop_Click);
+            // 
+            // btnToggleUpload
+            // 
+            this.btnToggleUpload.FlatAppearance.BorderSize = 0;
+            this.btnToggleUpload.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnToggleUpload.Image = global::AgOpenGPS.Properties.Resources.UploadOff;
+            this.btnToggleUpload.Location = new System.Drawing.Point(16, 172);
+            this.btnToggleUpload.Name = "btnToggleUpload";
+            this.btnToggleUpload.Size = new System.Drawing.Size(128, 128);
+            this.btnToggleUpload.TabIndex = 8;
+            this.btnToggleUpload.Text = "Activate";
+            this.btnToggleUpload.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.btnToggleUpload.UseVisualStyleBackColor = true;
+            this.btnToggleUpload.Click += new System.EventHandler(this.btnToggleUpload_Click);
             // 
             // btnAutoUpload
             // 
             this.btnAutoUpload.FlatAppearance.BorderSize = 0;
             this.btnAutoUpload.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnAutoUpload.Image = global::AgOpenGPS.Properties.Resources.AutoUploadOn;
-            this.btnAutoUpload.Location = new System.Drawing.Point(12, 173);
+            this.btnAutoUpload.Location = new System.Drawing.Point(158, 172);
             this.btnAutoUpload.Name = "btnAutoUpload";
             this.btnAutoUpload.Size = new System.Drawing.Size(128, 128);
             this.btnAutoUpload.TabIndex = 13;
@@ -169,19 +183,30 @@
             this.btnAutoUpload.UseVisualStyleBackColor = true;
             this.btnAutoUpload.Click += new System.EventHandler(this.btnAutoUpload_Click);
             // 
-            // btnToggleUpload
+            // btnAutoLoad
             // 
-            this.btnToggleUpload.FlatAppearance.BorderSize = 0;
-            this.btnToggleUpload.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnToggleUpload.Image = global::AgOpenGPS.Properties.Resources.UploadOff;
-            this.btnToggleUpload.Location = new System.Drawing.Point(224, 173);
-            this.btnToggleUpload.Name = "btnToggleUpload";
-            this.btnToggleUpload.Size = new System.Drawing.Size(128, 128);
-            this.btnToggleUpload.TabIndex = 8;
-            this.btnToggleUpload.Text = "Activate";
-            this.btnToggleUpload.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
-            this.btnToggleUpload.UseVisualStyleBackColor = true;
-            this.btnToggleUpload.Click += new System.EventHandler(this.btnToggleUpload_Click);
+            this.btnAutoLoad.FlatAppearance.BorderSize = 0;
+            this.btnAutoLoad.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnAutoLoad.Image = global::AgOpenGPS.Properties.Resources.DownloadAll;
+            this.btnAutoLoad.Location = new System.Drawing.Point(300, 172);
+            this.btnAutoLoad.Name = "btnAutoLoad";
+            this.btnAutoLoad.Size = new System.Drawing.Size(128, 128);
+            this.btnAutoLoad.TabIndex = 14;
+            this.btnAutoLoad.Text = "Local Only";
+            this.btnAutoLoad.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
+            this.btnAutoLoad.UseVisualStyleBackColor = true;
+            this.btnAutoLoad.Click += new System.EventHandler(this.btnAutoLoad_Click);
+            // 
+            // labelButtonsHint
+            // 
+            this.labelButtonsHint.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelButtonsHint.ForeColor = System.Drawing.Color.DimGray;
+            this.labelButtonsHint.Location = new System.Drawing.Point(16, 306);
+            this.labelButtonsHint.Name = "labelButtonsHint";
+            this.labelButtonsHint.Size = new System.Drawing.Size(412, 44);
+            this.labelButtonsHint.TabIndex = 15;
+            this.labelButtonsHint.Text = "Auto-Upload: upload field changes on close\r\nCloud Load: always download latest fr" +
+    "om AgShare on open";
             // 
             // buttonCancel
             // 
@@ -192,9 +217,9 @@
             this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonCancel.Image = global::AgOpenGPS.Properties.Resources.Cancel64;
             this.buttonCancel.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.buttonCancel.Location = new System.Drawing.Point(406, 209);
+            this.buttonCancel.Location = new System.Drawing.Point(424, 328);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(80, 92);
+            this.buttonCancel.Size = new System.Drawing.Size(80, 90);
             this.buttonCancel.TabIndex = 3;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -210,9 +235,9 @@
             this.buttonSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonSave.Image = global::AgOpenGPS.Properties.Resources.OK64;
             this.buttonSave.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.buttonSave.Location = new System.Drawing.Point(492, 209);
+            this.buttonSave.Location = new System.Drawing.Point(512, 328);
             this.buttonSave.Name = "buttonSave";
-            this.buttonSave.Size = new System.Drawing.Size(80, 92);
+            this.buttonSave.Size = new System.Drawing.Size(80, 90);
             this.buttonSave.TabIndex = 2;
             this.buttonSave.Text = "Save";
             this.buttonSave.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -224,24 +249,26 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.ClientSize = new System.Drawing.Size(584, 373);
+            this.ClientSize = new System.Drawing.Size(600, 430);
             this.ControlBox = false;
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.textBoxServer);
+            this.Controls.Add(this.labelApiKey);
+            this.Controls.Add(this.textBoxApiKey);
+            this.Controls.Add(this.btnPaste);
+            this.Controls.Add(this.buttonTestConnection);
+            this.Controls.Add(this.labelStatus);
+            this.Controls.Add(this.btnToggleUpload);
             this.Controls.Add(this.btnAutoUpload);
+            this.Controls.Add(this.btnAutoLoad);
+            this.Controls.Add(this.labelButtonsHint);
             this.Controls.Add(this.btnDevelop);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.linkRegister);
-            this.Controls.Add(this.btnPaste);
-            this.Controls.Add(this.btnToggleUpload);
-            this.Controls.Add(this.textBoxServer);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.labelApiKey);
-            this.Controls.Add(this.labelStatus);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonSave);
-            this.Controls.Add(this.buttonTestConnection);
-            this.Controls.Add(this.textBoxApiKey);
             this.Font = new System.Drawing.Font("Tahoma", 14.25F);
-            this.MinimumSize = new System.Drawing.Size(550, 340);
+            this.MinimumSize = new System.Drawing.Size(580, 410);
             this.Name = "FormAgShareSettings";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -268,5 +295,7 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button btnDevelop;
         private System.Windows.Forms.Button btnAutoUpload;
+        private System.Windows.Forms.Button btnAutoLoad;
+        private System.Windows.Forms.Label labelButtonsHint;
     }
 }

--- a/SourceCode/GPS/Forms/FormAgShareSettings.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using AgOpenGPS.Controls;
 using AgOpenGPS.Core.AgShare;
+using AgOpenGPS.Core.Translations;
 using AgOpenGPS.Properties;
 
 namespace AgOpenGPS
@@ -25,11 +26,23 @@ namespace AgOpenGPS
         // Load current settings and start clipboard monitoring
         private void FormAgShareSettings_Load(object sender, EventArgs e)
         {
+            // Translations
+            this.Text                    = gStr.gsAgShareSettings;
+            labelApiKey.Text             = gStr.gsAgShareApiKey + ":";
+            label1.Text                  = gStr.gsAgShareServer + ":";
+            buttonTestConnection.Text    = gStr.gsAgShareTestConnection;
+            btnPaste.Text                = gStr.gsAgSharePaste;
+            label2.Text                  = gStr.gsAgShareRegisterHere;
+            buttonCancel.Text            = gStr.gsCancel;
+            labelStatus.Text             = gStr.gsAgShareEnterDetails;
+            labelButtonsHint.Text        = gStr.gsAgShareButtonsHint;
+
             textBoxServer.Text = Settings.Default.AgShareServer;
             textBoxApiKey.Text = Settings.Default.AgShareApiKey;
 
             UpdateAgShareToggleButton();
             UpdateAgShareUploadButton();
+            UpdateAgShareAutoLoadButton();
 
             btnPaste.Enabled = Clipboard.ContainsText();
             clipboardCheckTimer = new Timer();
@@ -42,7 +55,7 @@ namespace AgOpenGPS
             textBoxServer.TextChanged += textBoxAnySetting_TextChanged;
 
             // Disable TextboxServer for now until it's released
-            textBoxServer.Enabled = false;
+            textBoxServer.Enabled = true;
         }
 
         // Dispose timer when form closes
@@ -68,7 +81,7 @@ namespace AgOpenGPS
         // Test connection with current input values
         private async void buttonTestConnection_Click(object sender, EventArgs e)
         {
-            labelStatus.Text = "Connecting...";
+            labelStatus.Text = gStr.gsAgShareConnecting;
             labelStatus.ForeColor = Color.Gray;
 
             var baseUrl = textBoxServer.Text;
@@ -78,7 +91,7 @@ namespace AgOpenGPS
 
             if (result.IsSuccessful)
             {
-                labelStatus.Text = "✔ Connection successful";
+                labelStatus.Text = "✔ " + gStr.gsAgShareConnectionOk;
                 labelStatus.ForeColor = Color.Green;
                 buttonSave.Enabled = true;
             }
@@ -95,7 +108,7 @@ namespace AgOpenGPS
             switch (error)
             {
                 case InvalidApiKeyError _:
-                    return "Invalid API key";
+                    return gStr.gsAgShareInvalidApiKey;
                 case StatusCodeError statusCodeError:
                     return $"Status {statusCodeError.StatusCode}: {statusCodeError.Body}";
                 case HttpRequestError httpRequestError:
@@ -114,7 +127,7 @@ namespace AgOpenGPS
             Settings.Default.AgShareApiKey = textBoxApiKey.Text;
             Settings.Default.Save();
 
-            labelStatus.Text = "✔ Settings saved";
+            labelStatus.Text = "✔ " + gStr.gsAgShareSaved;
             labelStatus.ForeColor = Color.Blue;
         }
 
@@ -130,12 +143,12 @@ namespace AgOpenGPS
             if (Settings.Default.AgShareEnabled)
             {
                 btnToggleUpload.Image = Properties.Resources.UploadOn;
-                btnToggleUpload.Text = "Activated";
+                btnToggleUpload.Text = gStr.gsAgShareActivated;
             }
             else
             {
                 btnToggleUpload.Image = Properties.Resources.UploadOff;
-                btnToggleUpload.Text = "Deactivated";
+                btnToggleUpload.Text = gStr.gsAgShareDeactivated;
                 buttonSave.Enabled = true;
             }
         }
@@ -188,6 +201,27 @@ namespace AgOpenGPS
             textBoxServer.Enabled = true;
         }
 
+        private void btnAutoLoad_Click(object sender, EventArgs e)
+        {
+            Settings.Default.AgShareAutoLoad = !Settings.Default.AgShareAutoLoad;
+            UpdateAgShareAutoLoadButton();
+            Settings.Default.Save();
+        }
+
+        private void UpdateAgShareAutoLoadButton()
+        {
+            if (Settings.Default.AgShareAutoLoad)
+            {
+                btnAutoLoad.Image = Properties.Resources.DownloadAndUse;
+                btnAutoLoad.Text = gStr.gsAgShareAutoLoad;
+            }
+            else
+            {
+                btnAutoLoad.Image = Properties.Resources.DownloadAll;
+                btnAutoLoad.Text = gStr.gsAgShareLocalOnly;
+            }
+        }
+
         private void btnAutoUpload_Click(object sender, EventArgs e)
         {
             Settings.Default.AgShareUploadActive = !Settings.Default.AgShareUploadActive;
@@ -197,12 +231,12 @@ namespace AgOpenGPS
         {
             if (Settings.Default.AgShareUploadActive)
             {
-                btnAutoUpload.Text = "Upload On";
+                btnAutoUpload.Text = gStr.gsAgShareUploadOn;
                 btnAutoUpload.Image = Resources.AutoUploadOn;
             }
             else
             {
-                btnAutoUpload.Text = "Upload Off";
+                btnAutoUpload.Text = gStr.gsAgShareUploadOff;
                 btnAutoUpload.Image = Resources.AutoUploadOff;
                 buttonSave.Enabled = true;
             }

--- a/SourceCode/GPS/Forms/FormAgShareSettings.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.cs
@@ -140,7 +140,9 @@ namespace AgOpenGPS
         // Update toggle button for upload-on/off
         private void UpdateAgShareToggleButton()
         {
-            if (Settings.Default.AgShareEnabled)
+            bool enabled = Settings.Default.AgShareEnabled;
+
+            if (enabled)
             {
                 btnToggleUpload.Image = Properties.Resources.UploadOn;
                 btnToggleUpload.Text = gStr.gsAgShareActivated;
@@ -151,6 +153,9 @@ namespace AgOpenGPS
                 btnToggleUpload.Text = gStr.gsAgShareDeactivated;
                 buttonSave.Enabled = true;
             }
+
+            btnAutoUpload.Enabled = enabled;
+            btnAutoLoad.Enabled = enabled;
         }
 
         // Toggle upload enabled state
@@ -206,6 +211,7 @@ namespace AgOpenGPS
             Settings.Default.AgShareAutoLoad = !Settings.Default.AgShareAutoLoad;
             UpdateAgShareAutoLoadButton();
             Settings.Default.Save();
+            buttonSave.Enabled = true;
         }
 
         private void UpdateAgShareAutoLoadButton()
@@ -226,7 +232,9 @@ namespace AgOpenGPS
         {
             Settings.Default.AgShareUploadActive = !Settings.Default.AgShareUploadActive;
             UpdateAgShareUploadButton();
+            buttonSave.Enabled = true;
         }
+
         private void UpdateAgShareUploadButton()
         {
             if (Settings.Default.AgShareUploadActive)
@@ -238,7 +246,6 @@ namespace AgOpenGPS
             {
                 btnAutoUpload.Text = gStr.gsAgShareUploadOff;
                 btnAutoUpload.Image = Resources.AutoUploadOff;
-                buttonSave.Enabled = true;
             }
         }
     }

--- a/SourceCode/GPS/Forms/FormAgShareSettings.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.cs
@@ -27,15 +27,15 @@ namespace AgOpenGPS
         private void FormAgShareSettings_Load(object sender, EventArgs e)
         {
             // Translations
-            this.Text                    = gStr.gsAgShareSettings;
-            labelApiKey.Text             = gStr.gsAgShareApiKey + ":";
-            label1.Text                  = gStr.gsAgShareServer + ":";
-            buttonTestConnection.Text    = gStr.gsAgShareTestConnection;
-            btnPaste.Text                = gStr.gsAgSharePaste;
-            label2.Text                  = gStr.gsAgShareRegisterHere;
-            buttonCancel.Text            = gStr.gsCancel;
-            labelStatus.Text             = gStr.gsAgShareEnterDetails;
-            labelButtonsHint.Text        = gStr.gsAgShareButtonsHint;
+            this.Text = gStr.gsAgShareSettings;
+            labelApiKey.Text = gStr.gsAgShareApiKey + ":";
+            label1.Text = gStr.gsAgShareServer + ":";
+            buttonTestConnection.Text = gStr.gsAgShareTestConnection;
+            btnPaste.Text = gStr.gsAgSharePaste;
+            label2.Text = gStr.gsAgShareRegisterHere;
+            buttonCancel.Text = gStr.gsCancel;
+            labelStatus.Text = gStr.gsAgShareEnterDetails;
+            labelButtonsHint.Text = gStr.gsAgShareButtonsHint;
 
             textBoxServer.Text = Settings.Default.AgShareServer;
             textBoxApiKey.Text = Settings.Default.AgShareApiKey;

--- a/SourceCode/GPS/Forms/FormEventViewer.cs
+++ b/SourceCode/GPS/Forms/FormEventViewer.cs
@@ -19,26 +19,7 @@ namespace AgOpenGPS
 
         private void FormEventViewer_Load(object sender, EventArgs e)
         {
-            try
-            {
-                using (StreamReader sr = File.OpenText(filename))
-                {
-                    //rtbLogViewer.Text = String.Empty;
-                    while (!sr.EndOfStream)
-                    {
-                        rtbLogViewer.AppendText(sr.ReadLine() + "\r");
-                    }
-
-                }
-            }
-            catch (Exception ex)
-            {
-                rtbLogViewer.AppendText("Catch ->  error loading logfile" + ex.ToString());
-            }
-
-            rtbLogViewer.AppendText(" **** Current Session Below ***** \r\n\r\n");
-
-            rtbLogViewer.AppendText(Log.sbEvents.ToString());
+            LoadLog();
         }
 
         private void btnExit_Click(object sender, EventArgs e)
@@ -48,29 +29,26 @@ namespace AgOpenGPS
 
         private void btnRefresh_Click(object sender, EventArgs e)
         {
-            rtbLogViewer.Clear();
-            rtbLogViewer.HideSelection = false;
+            LoadLog();
+        }
+
+        private void LoadLog()
+        {
+            string fileContent = "";
             try
             {
-                using (StreamReader sr = File.OpenText(filename))
-                {
-                    //rtbLogViewer.Text = String.Empty;
-                    while (!sr.EndOfStream)
-                    {
-                        rtbLogViewer.AppendText(sr.ReadLine() + "\r");
-                    }
-
-                }
+                fileContent = File.ReadAllText(filename);
             }
             catch (Exception ex)
             {
-                rtbLogViewer.AppendText("Catch ->  error loading logfile" + ex.ToString());
+                fileContent = "Catch -> error loading logfile" + ex.ToString();
             }
 
-            rtbLogViewer.AppendText(" **** Current Session Below ***** \r\n\r\n");
-
-            rtbLogViewer.AppendText(Log.sbEvents.ToString());
-
+            rtbLogViewer.SuspendLayout();
+            rtbLogViewer.Text = fileContent
+                + "\r\n **** Current Session Below *****\r\n\r\n"
+                + Log.sbEvents.ToString();
+            rtbLogViewer.ResumeLayout();
         }
     }
 }

--- a/SourceCode/GPS/Forms/FormEventViewer.cs
+++ b/SourceCode/GPS/Forms/FormEventViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Windows.Forms;
 using AgLibrary.Logging;
 
@@ -7,19 +8,31 @@ namespace AgOpenGPS
 {
     public partial class FormEventViewer : Form
     {
-        //class variables
-        string filename;
+        private readonly string _filename;
+        private long _filePosition = 0;
+        private int _sessionLength = 0;
+        private Timer _refreshTimer;
 
-        public FormEventViewer(string _filename)
+        public FormEventViewer(string filename)
         {
-            //get copy of the calling main form
             InitializeComponent();
-            filename = _filename;
+            _filename = filename;
         }
 
         private void FormEventViewer_Load(object sender, EventArgs e)
         {
             LoadLog();
+
+            _refreshTimer = new Timer { Interval = 1000 };
+            _refreshTimer.Tick += (s, ev) => AppendNewContent();
+            _refreshTimer.Start();
+        }
+
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            _refreshTimer?.Stop();
+            _refreshTimer?.Dispose();
+            base.OnFormClosed(e);
         }
 
         private void btnExit_Click(object sender, EventArgs e)
@@ -32,23 +45,74 @@ namespace AgOpenGPS
             LoadLog();
         }
 
+        // Full reload — used on open and manual refresh
         private void LoadLog()
         {
             string fileContent = "";
             try
             {
-                fileContent = File.ReadAllText(filename);
+                fileContent = File.ReadAllText(_filename);
+                _filePosition = new FileInfo(_filename).Length;
             }
             catch (Exception ex)
             {
-                fileContent = "Catch -> error loading logfile" + ex.ToString();
+                fileContent = "Catch -> error loading logfile: " + ex.Message;
+                _filePosition = 0;
             }
+
+            _sessionLength = Log.sbEvents.Length;
 
             rtbLogViewer.SuspendLayout();
             rtbLogViewer.Text = fileContent
                 + "\r\n **** Current Session Below *****\r\n\r\n"
                 + Log.sbEvents.ToString();
+            ScrollToBottom();
             rtbLogViewer.ResumeLayout();
+        }
+
+        // Appends only new content since the last read — called by timer
+        private void AppendNewContent()
+        {
+            bool hasNew = false;
+
+            try
+            {
+                long currentSize = new FileInfo(_filename).Length;
+                if (currentSize > _filePosition)
+                {
+                    using (var fs = new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
+                        fs.Seek(_filePosition, SeekOrigin.Begin);
+                        using (var sr = new StreamReader(fs, Encoding.UTF8))
+                        {
+                            string newContent = sr.ReadToEnd();
+                            if (!string.IsNullOrEmpty(newContent))
+                            {
+                                rtbLogViewer.AppendText(newContent);
+                                hasNew = true;
+                            }
+                        }
+                        _filePosition = currentSize;
+                    }
+                }
+            }
+            catch { }
+
+            int currentSessionLength = Log.sbEvents.Length;
+            if (currentSessionLength > _sessionLength)
+            {
+                rtbLogViewer.AppendText(Log.sbEvents.ToString().Substring(_sessionLength));
+                _sessionLength = currentSessionLength;
+                hasNew = true;
+            }
+
+            if (hasNew) ScrollToBottom();
+        }
+
+        private void ScrollToBottom()
+        {
+            rtbLogViewer.SelectionStart = rtbLogViewer.Text.Length;
+            rtbLogViewer.ScrollToCaret();
         }
     }
 }

--- a/SourceCode/GPS/Forms/Guidance/FormNudge.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormNudge.cs
@@ -28,15 +28,15 @@ namespace AgOpenGPS
             if (mf.isMetric)
             {
                 nudSnapDistance.DecimalPlaces = 0;
-                nudSnapDistance.Value = (int)((double)Properties.Settings.Default.setAS_snapDistance);
+                nudSnapDistance.Value = (int)((double)Properties.ToolSettings.Default.setAS_snapDistance);
             }
             else
             {
                 nudSnapDistance.DecimalPlaces = 1;
-                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.Settings.Default.setAS_snapDistance * mf.cm2CmOrIn), 1);
+                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.ToolSettings.Default.setAS_snapDistance * mf.cm2CmOrIn), 1);
             }
 
-            snapAdj = Properties.Settings.Default.setAS_snapDistance * 0.01;
+            snapAdj = Properties.ToolSettings.Default.setAS_snapDistance * 0.01;
 
             Location = Properties.Settings.Default.setWindow_formNudgeLocation;
             UpdateMoveLabel();
@@ -84,8 +84,8 @@ namespace AgOpenGPS
         {
             ((NudlessNumericUpDown)sender).ShowKeypad(this);
             snapAdj = (double)nudSnapDistance.Value * mf.inchOrCm2m;
-            Properties.Settings.Default.setAS_snapDistance = snapAdj * 100;
-            Properties.Settings.Default.Save();
+            Properties.ToolSettings.Default.setAS_snapDistance = snapAdj * 100;
+            Properties.ToolSettings.Default.Save();
             mf.Activate();
         }
 

--- a/SourceCode/GPS/Forms/Guidance/FormRefNudge.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormRefNudge.cs
@@ -30,15 +30,15 @@ namespace AgOpenGPS
             if (mf.isMetric)
             {
                 nudSnapDistance.DecimalPlaces = 0;
-                nudSnapDistance.Value = (int)((double)Properties.Settings.Default.setAS_snapDistanceRef);
+                nudSnapDistance.Value = (int)((double)Properties.ToolSettings.Default.setAS_snapDistanceRef);
             }
             else
             {
                 nudSnapDistance.DecimalPlaces = 1;
-                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.Settings.Default.setAS_snapDistanceRef * mf.cm2CmOrIn), 1);
+                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.ToolSettings.Default.setAS_snapDistanceRef * mf.cm2CmOrIn), 1);
             }
 
-            snapAdj = Properties.Settings.Default.setAS_snapDistanceRef * 0.01;
+            snapAdj = Properties.ToolSettings.Default.setAS_snapDistanceRef * 0.01;
 
             foreach (var item in mf.trk.gArr)
             {
@@ -66,8 +66,8 @@ namespace AgOpenGPS
         {
             ((NudlessNumericUpDown)sender).ShowKeypad(this);
             snapAdj = (double)nudSnapDistance.Value * mf.inchOrCm2m;
-            Properties.Settings.Default.setAS_snapDistanceRef = snapAdj * 100;
-            Properties.Settings.Default.Save();
+            Properties.ToolSettings.Default.setAS_snapDistanceRef = snapAdj * 100;
+            Properties.ToolSettings.Default.Save();
             mf.Activate();
         }
 

--- a/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
+++ b/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
@@ -391,7 +391,7 @@ namespace AgOpenGPS.Forms.Profiles
 
             // Save current profiles before switching so unsaved changes are not lost
             if (vehicleChanged) VehicleSettings.Default.Save();
-            if (toolChanged)    ToolSettings.Default.Save();
+            if (toolChanged) ToolSettings.Default.Save();
 
             if (vehicleChanged)
             {

--- a/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
+++ b/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
@@ -389,6 +389,10 @@ namespace AgOpenGPS.Forms.Profiles
             bool vehicleChanged = _selectedVehicle != null && _selectedVehicle != RegistrySettings.vehicleProfileName;
             bool toolChanged = _selectedTool != null && _selectedTool != RegistrySettings.toolProfileName;
 
+            // Save current profiles before switching so unsaved changes are not lost
+            if (vehicleChanged) VehicleSettings.Default.Save();
+            if (toolChanged)    ToolSettings.Default.Save();
+
             if (vehicleChanged)
             {
                 var result = VehicleSettings.Default.Load(_selectedVehicle);

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -37,7 +38,7 @@ namespace AgOpenGPS
         }
 
         // Open a field with required precheck and per-file loaders.
-        public void FileOpenField(string openType)
+        public async Task FileOpenField(string openType)
         {
             if (isJobStarted)
             {
@@ -71,6 +72,9 @@ namespace AgOpenGPS
             }
 
             if (fileAndDirectory == "Cancel") return;
+
+            // If AgShare is active and this field has a cloud ID, fetch the latest version first
+            await TryLoadFromAgShareAsync(fileAndDirectory);
 
             // Set current field directory
             currentFieldDirectory = new DirectoryInfo(Path.GetDirectoryName(fileAndDirectory)).Name;
@@ -956,6 +960,30 @@ namespace AgOpenGPS
                 result = default(T);
                 return false;
             }
+        }
+
+        // Downloads the latest cloud version of a field if AgShare is enabled and agshare.txt exists.
+        // Overwrites local files so FileOpenField loads the cloud version. Falls back silently on failure.
+        private async Task TryLoadFromAgShareAsync(string fieldFilePath)
+        {
+            if (!Properties.Settings.Default.AgShareEnabled) return;
+            if (!Properties.Settings.Default.AgShareAutoLoad) return;
+
+            string fieldDir = Path.GetDirectoryName(fieldFilePath);
+            string agshareFile = Path.Combine(fieldDir, "agshare.txt");
+
+            if (!File.Exists(agshareFile)) return;
+
+            string idText = File.ReadAllText(agshareFile).Trim();
+            if (!Guid.TryParse(idText, out Guid fieldId)) return;
+
+            var downloader = new AgShareDownloader(agShareClient);
+            bool success = await downloader.DownloadAndSaveAsync(fieldId);
+
+            if (success)
+                TimedMessageBox(3000, gStr.gsAgShareFieldLoaded, Path.GetFileName(fieldDir));
+            else
+                FormDialog.Show("AgShare", gStr.gsAgShareLoadFailed, DialogSeverity.Warning);
         }
 
         // Runs an action (no return); logs + user message on failure.

--- a/SourceCode/GPS/Forms/Settings/FormAllSettings.cs
+++ b/SourceCode/GPS/Forms/Settings/FormAllSettings.cs
@@ -210,6 +210,8 @@ namespace AgOpenGPS
             AddRow(mid, "Headland Sect. Ctrl", tsDefault.setHeadland_isSectionControlled, ts.setHeadland_isSectionControlled);
 
             AddHeader(mid, "── Guidance (per Tool)");
+            AddRow(mid, "Snap Distance", tsDefault.setAS_snapDistance, ts.setAS_snapDistance);
+            AddRow(mid, "Snap Distance Ref", tsDefault.setAS_snapDistanceRef, ts.setAS_snapDistanceRef);
             AddRow(mid, "DeadZone Dist", tsDefault.setAS_deadZoneDistance, ts.setAS_deadZoneDistance);
             AddRow(mid, "DeadZone Hdg", tsDefault.setAS_deadZoneHeading, ts.setAS_deadZoneHeading);
             AddRow(mid, "DeadZone Delay", tsDefault.setAS_deadZoneDelay, ts.setAS_deadZoneDelay);
@@ -267,8 +269,6 @@ namespace AgOpenGPS
 
             mid.Rows.Clear();
             AddHeader(mid, "── AutoSteer");
-            AddRow(mid, "Snap Distance", esDefault.setAS_snapDistance, es.setAS_snapDistance);
-            AddRow(mid, "Snap Distance Ref", esDefault.setAS_snapDistanceRef, es.setAS_snapDistanceRef);
             AddRow(mid, "Guidance Lookahead", esDefault.setAS_guidanceLookAheadTime, es.setAS_guidanceLookAheadTime);
             AddRow(mid, "AutoSteer Auto On", esDefault.setAS_isAutoSteerAutoOn, es.setAS_isAutoSteerAutoOn);
             AddRow(mid, "Constant Contour", esDefault.setAS_isConstantContourOn, es.setAS_isConstantContourOn);

--- a/SourceCode/GPS/Forms/Settings/FormSteer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSteer.cs
@@ -740,12 +740,12 @@ namespace AgOpenGPS
             if (mf.isMetric)
             {
                 nudSnapDistance.DecimalPlaces = 0;
-                nudSnapDistance.Value = (int)((double)Properties.Settings.Default.setAS_snapDistance * mf.cm2CmOrIn);
+                nudSnapDistance.Value = (int)((double)Properties.ToolSettings.Default.setAS_snapDistance * mf.cm2CmOrIn);
             }
             else
             {
                 nudSnapDistance.DecimalPlaces = 1;
-                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.Settings.Default.setAS_snapDistance * mf.cm2CmOrIn), 1, MidpointRounding.AwayFromZero);
+                nudSnapDistance.Value = (decimal)Math.Round(((double)Properties.ToolSettings.Default.setAS_snapDistance * mf.cm2CmOrIn), 1, MidpointRounding.AwayFromZero);
             }
 
             nudGuidanceLookAhead.Value = (decimal)Properties.Settings.Default.setAS_guidanceLookAheadTime;
@@ -785,8 +785,8 @@ namespace AgOpenGPS
         {
             if (((NudlessNumericUpDown)sender).ShowKeypad(this))
             {
-                Properties.Settings.Default.setAS_snapDistance = ((double)nudSnapDistance.Value * mf.inOrCm2Cm);
-                mf.ABLine.snapDistance = Properties.Settings.Default.setAS_snapDistance;
+                Properties.ToolSettings.Default.setAS_snapDistance = ((double)nudSnapDistance.Value * mf.inOrCm2Cm);
+                mf.ABLine.snapDistance = Properties.ToolSettings.Default.setAS_snapDistance;
             }
         }
 
@@ -1251,7 +1251,7 @@ namespace AgOpenGPS
                 Properties.VehicleSettings.Default.setAS_functionSpeedLimit = 12;
                 Properties.Settings.Default.setDisplay_lightbarCmPerPixel = 5;
                 Properties.Settings.Default.setDisplay_lineWidth = 2;
-                Properties.Settings.Default.setAS_snapDistance = 20;
+                Properties.ToolSettings.Default.setAS_snapDistance = 20;
                 Properties.Settings.Default.setAS_guidanceLookAheadTime = 1.5;
                 Properties.Settings.Default.setAS_uTurnCompensation = 1;
 

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -287,7 +287,7 @@ namespace AgOpenGPS
                             if (data.Length < 6) break;
                             if (((data[5] & 1) == 1)) //mask bit #0 set and command bit #0 nudge line to the 0 = left 1 = right
                             {
-                                double dist = Properties.Settings.Default.setAS_snapDistance * 0.01;
+                                double dist = Properties.ToolSettings.Default.setAS_snapDistance * 0.01;
                                 if ((data[6] & 1) != 1) { trk.NudgeTrack(-dist); }
                                 if ((data[6] & 1) == 1) { trk.NudgeTrack(dist); }
                             }
@@ -592,14 +592,14 @@ namespace AgOpenGPS
             if ((char)keyData == hotkeys[7]) // nudge track left
             {
                 if (trk.idx > -1)
-                    trk.NudgeTrack((double)Properties.Settings.Default.setAS_snapDistance * -0.01);
+                    trk.NudgeTrack((double)Properties.ToolSettings.Default.setAS_snapDistance * -0.01);
                 return true;
             }
 
             if ((char)keyData == hotkeys[8]) // nudge track right
             {
                 if (trk.idx > -1)
-                    trk.NudgeTrack((double)Properties.Settings.Default.setAS_snapDistance * 0.01);
+                    trk.NudgeTrack((double)Properties.ToolSettings.Default.setAS_snapDistance * 0.01);
                 return true;
             }
 

--- a/SourceCode/GPS/Properties/RegistrySettings.cs
+++ b/SourceCode/GPS/Properties/RegistrySettings.cs
@@ -129,8 +129,7 @@ namespace AgOpenGPS
             //make sure directories exist and are in right place if not default workingDir
             CreateDirectories();
 
-            //keep below 500 kb
-            Log.CheckLogSize(Path.Combine(logsDirectory, "AgOpenGPS_Events_Log.txt"), 1000000);
+            Log.CheckLogSize(Path.Combine(logsDirectory, "AgOpenGPS_Events_Log.txt"));
 
             // Load Environment settings
             Properties.Settings.Default.Load();

--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -115,8 +115,6 @@ namespace AgOpenGPS.Properties
         public int bndToolSmooth = 1;
 
         // ===== AUTOSTEER SETTINGS =====
-        public double setAS_snapDistance = 20.0;
-        public double setAS_snapDistanceRef = 5;
         public bool setAS_isAutoSteerAutoOn = false;
         public double setAS_guidanceLookAheadTime = 1.5;
         public bool setAS_isConstantContourOn = false;
@@ -313,8 +311,6 @@ namespace AgOpenGPS.Properties
             dest.bndToolSmooth = source.bndToolSmooth;
 
             // AutoSteer settings (verplaatst van Vehicle)
-            dest.setAS_snapDistance = source.setAS_snapDistance;
-            dest.setAS_snapDistanceRef = source.setAS_snapDistanceRef;
             dest.setAS_isAutoSteerAutoOn = source.setAS_isAutoSteerAutoOn;
             dest.setAS_guidanceLookAheadTime = source.setAS_guidanceLookAheadTime;
             dest.setAS_isConstantContourOn = source.setAS_isConstantContourOn;

--- a/SourceCode/GPS/Properties/Settings.cs
+++ b/SourceCode/GPS/Properties/Settings.cs
@@ -150,6 +150,7 @@ namespace AgOpenGPS.Properties
         public bool PublicField = false;
         public bool AgShareEnabled = false;
         public bool AgShareUploadActive = false;
+        public bool AgShareAutoLoad = false;
 
         // ===== UDP SETTINGS =====
         public int SetGPS_udpWatchMsec = 50;
@@ -347,6 +348,7 @@ namespace AgOpenGPS.Properties
             dest.PublicField = source.PublicField;
             dest.AgShareEnabled = source.AgShareEnabled;
             dest.AgShareUploadActive = source.AgShareUploadActive;
+            dest.AgShareAutoLoad = source.AgShareAutoLoad;
 
             // UDP settings
             dest.SetGPS_udpWatchMsec = source.SetGPS_udpWatchMsec;

--- a/SourceCode/GPS/Properties/SettingsLegacy.cs
+++ b/SourceCode/GPS/Properties/SettingsLegacy.cs
@@ -27,8 +27,6 @@ namespace AgOpenGPS.Properties
         public byte setAS_highSteerPWM = 180;
         public byte setAS_lowSteerPWM = 30;
         public int setAS_wasOffset = 3;
-        public double setAS_snapDistance = 20.0;
-        public double setAS_snapDistanceRef = 5;
         public bool setAS_isAutoSteerAutoOn = false;
         public double setAS_guidanceLookAheadTime = 1.5;
         public bool setAS_isConstantContourOn = false;

--- a/SourceCode/GPS/Properties/SettingsLegacy.cs
+++ b/SourceCode/GPS/Properties/SettingsLegacy.cs
@@ -286,6 +286,7 @@ namespace AgOpenGPS.Properties
         public bool PublicField = false;
         public bool AgShareEnabled = false;
         public bool AgShareUploadActive = false;
+        public bool AgShareAutoLoad = false;
 
         // UDP settings
         public int SetGPS_udpWatchMsec = 50;

--- a/SourceCode/GPS/Properties/ToolSettings.cs
+++ b/SourceCode/GPS/Properties/ToolSettings.cs
@@ -85,6 +85,10 @@ namespace AgOpenGPS.Properties
         public int setAS_deadZoneHeading = 10;
         public int setAS_deadZoneDelay = 5;
 
+        // Nudge snap distances
+        public double setAS_snapDistance = 20.0;
+        public double setAS_snapDistanceRef = 5.0;
+
         // Headland
         public bool setHeadland_isSectionControlled = true;
 

--- a/SourceCode/GPS/Protocols/ISOBUS/ISO11783_TaskFile.cs
+++ b/SourceCode/GPS/Protocols/ISOBUS/ISO11783_TaskFile.cs
@@ -163,11 +163,11 @@ namespace AgOpenGPS.Protocols.ISOBUS
 
                             var guidancePattern = new ISOGuidancePattern
                             {
+                                GuidancePatternId = guidanceGroup.GuidanceGroupId.Replace("GGP", "GPN"),
                                 GuidancePatternPropagationDirection = ISOGuidancePatternPropagationDirection.Bothdirections,
                                 GuidancePatternExtension = ISOGuidancePatternExtension.Frombothfirstandlastpoint,
                                 GuidancePatternGNSSMethod = ISOGuidancePatternGNSSMethod.Desktopgenerateddata
                             };
-                            isoxml.IdTable.AddObjectAndAssignIdIfNone(guidancePattern);
 
                             ISOLineString lineString = CreateLineString(track, localPlane, version);
 

--- a/SourceCode/GPS/Protocols/ISOBUS/ISO11783_TaskFile.cs
+++ b/SourceCode/GPS/Protocols/ISOBUS/ISO11783_TaskFile.cs
@@ -163,11 +163,11 @@ namespace AgOpenGPS.Protocols.ISOBUS
 
                             var guidancePattern = new ISOGuidancePattern
                             {
-                                GuidancePatternId = guidanceGroup.GuidanceGroupId,
                                 GuidancePatternPropagationDirection = ISOGuidancePatternPropagationDirection.Bothdirections,
                                 GuidancePatternExtension = ISOGuidancePatternExtension.Frombothfirstandlastpoint,
                                 GuidancePatternGNSSMethod = ISOGuidancePatternGNSSMethod.Desktopgenerateddata
                             };
+                            isoxml.IdTable.AddObjectAndAssignIdIfNone(guidancePattern);
 
                             ISOLineString lineString = CreateLineString(track, localPlane, version);
 

--- a/SourceCode/Updater/AgOpenGPS.Updater.csproj
+++ b/SourceCode/Updater/AgOpenGPS.Updater.csproj
@@ -30,7 +30,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SourceCode/Updater/Forms/FormUpdate.Designer.cs
+++ b/SourceCode/Updater/Forms/FormUpdate.Designer.cs
@@ -76,12 +76,12 @@ namespace AgOpenGPS.Updater.Forms
             //
             this.lblGitHubStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblGitHubStatus.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(255)))), ((int)(((byte)(10)))));
             this.lblGitHubStatus.Location = new System.Drawing.Point(630, 35);
             this.lblGitHubStatus.Name = "lblGitHubStatus";
             this.lblGitHubStatus.Size = new System.Drawing.Size(110, 40);
             this.lblGitHubStatus.TabIndex = 1;
-            this.lblGitHubStatus.Text = "🔒 Anonymous";
+            this.lblGitHubStatus.Text = "🔐 Official";
             this.lblGitHubStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             //
             // panelMain

--- a/SourceCode/Updater/Forms/FormUpdate.cs
+++ b/SourceCode/Updater/Forms/FormUpdate.cs
@@ -89,9 +89,6 @@ namespace AgOpenGPS.Updater.Forms
             // Display current version
             lblCurrentVersion.Text = $"Current Version: {_currentVersion}";
 
-            // Update GitHub status indicator
-            //UpdateGitHubStatus();
-
             // Auto-detect local update
             bool foundLocal = CheckForLocalUpdate();
 
@@ -128,13 +125,6 @@ namespace AgOpenGPS.Updater.Forms
             lblSourceInfo.Visible = true;
 
             return found;
-        }
-
-        private void UpdateGitHubStatus()
-        {
-            lblGitHubStatus.Text = "🔐 Official";
-            lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(100, 255, 100); // Bright green
-            lblGitHubStatus.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
         }
 
         private void UpdateSourceUI()

--- a/SourceCode/Updater/Forms/FormUpdate.cs
+++ b/SourceCode/Updater/Forms/FormUpdate.cs
@@ -18,7 +18,6 @@ namespace AgOpenGPS.Updater.Forms
         private string _currentVersion;
         private _updateSource currentSource;
         private string _installPath;
-        private readonly string _gitHubToken;
         private ReleaseInfo _availableUpdate;
         private string _localUpdatePath;
         private string _localUpdateVersion;
@@ -29,14 +28,13 @@ namespace AgOpenGPS.Updater.Forms
 
         private enum _updateSource { Web, Local }
 
-        public FormUpdate(string currentVersion = null, string installPath = null, string gitHubToken = null)
+        public FormUpdate(string currentVersion = null, string installPath = null)
         {
             InitializeComponent();
 
             _updateService = new UpdateService();
             _currentVersion = currentVersion ?? UpdateService.GetCurrentVersion();
             _installPath = installPath ?? UpdateService.GetCurrentApplicationPath();
-            _gitHubToken = gitHubToken;
             currentSource = _updateSource.Web;
 
             // Handle command line arguments
@@ -92,7 +90,7 @@ namespace AgOpenGPS.Updater.Forms
             lblCurrentVersion.Text = $"Current Version: {_currentVersion}";
 
             // Update GitHub status indicator
-            UpdateGitHubStatus();
+            //UpdateGitHubStatus();
 
             // Auto-detect local update
             bool foundLocal = CheckForLocalUpdate();
@@ -134,40 +132,9 @@ namespace AgOpenGPS.Updater.Forms
 
         private void UpdateGitHubStatus()
         {
-            // Check if we have a GitHub token (from command line or hardcoded)
-            bool hasToken = !string.IsNullOrEmpty(_gitHubToken) ||
-                HasHardcodedGitHubToken();
-
-            if (hasToken)
-            {
-                lblGitHubStatus.Text = "🔐 Official";
-                lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(100, 255, 100); // Bright green
-                lblGitHubStatus.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            }
-            else
-            {
-                lblGitHubStatus.Text = "🔓 Anonymous";
-                lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(180, 180, 180); // Gray
-                lblGitHubStatus.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            }
-        }
-
-        private bool HasHardcodedGitHubToken()
-        {
-            try
-            {
-                // Check if GithubReleaseService has a hardcoded token
-                using (var service = new GithubReleaseService())
-                {
-                    // The service uses hardcoded token if no token is passed and one exists
-                    // We can check this by seeing if it adds an Authorization header
-                    return service.HasAuthToken();
-                }
-            }
-            catch
-            {
-                return false;
-            }
+            lblGitHubStatus.Text = "🔐 Official";
+            lblGitHubStatus.ForeColor = System.Drawing.Color.FromArgb(100, 255, 100); // Bright green
+            lblGitHubStatus.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
         }
 
         private void UpdateSourceUI()
@@ -370,7 +337,7 @@ namespace AgOpenGPS.Updater.Forms
                     SetStatus("Checking GitHub releases...");
                     bool includePrerelease = chkIncludePrerelease.Checked;
                     var (hasUpdate, releaseInfo, message) = await _updateService.CheckForUpdate(
-                        _currentVersion, includePrerelease, _gitHubToken);
+                        _currentVersion, includePrerelease);
 
                     _availableUpdate = releaseInfo;
 
@@ -510,7 +477,7 @@ namespace AgOpenGPS.Updater.Forms
                     });
 
                     var (downloaded, dlPath, downloadMsg) = await _updateService.DownloadUpdate(
-                        _availableUpdate, tempDir, progress, _gitHubToken);
+                        _availableUpdate, tempDir, progress);
 
                     token.ThrowIfCancellationRequested();
 

--- a/SourceCode/Updater/Program.cs
+++ b/SourceCode/Updater/Program.cs
@@ -15,13 +15,16 @@ namespace AgOpenGPS.Updater
         [STAThread]
         private static void Main()
         {
+            if (!System.Diagnostics.Debugger.IsAttached)
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
             // Parse command line arguments
             string currentVersion = null;
             string installPath = null;
-            string gitHubToken = null;
             bool showFirmwareUpdate = false;
 
             var args = Environment.GetCommandLineArgs();
@@ -37,10 +40,6 @@ namespace AgOpenGPS.Updater
                 {
                     installPath = args[++i];
                 }
-                else if (arg.Equals("--github-token", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
-                {
-                    gitHubToken = args[++i];
-                }
                 else if (arg.Equals("--firmware", StringComparison.OrdinalIgnoreCase))
                 {
                     showFirmwareUpdate = true;
@@ -54,7 +53,7 @@ namespace AgOpenGPS.Updater
             }
             else
             {
-                Application.Run(new FormUpdate(currentVersion, installPath, gitHubToken));
+                Application.Run(new FormUpdate(currentVersion, installPath));
             }
         }
     }

--- a/SourceCode/Updater/Services/GithubReleaseService.cs
+++ b/SourceCode/Updater/Services/GithubReleaseService.cs
@@ -22,7 +22,6 @@ namespace AgOpenGPS.Updater.Services
         private readonly HttpClient _httpClient;
         private readonly string _owner;
         private readonly string _repository;
-        private readonly string _authToken;
 
         public GithubReleaseService(string owner = null, string repository = null)
         {
@@ -320,11 +319,6 @@ namespace AgOpenGPS.Updater.Services
         /// <summary>
         /// Checks if this service has an authentication token.
         /// </summary>
-        public bool HasAuthToken()
-        {
-            return !string.IsNullOrEmpty(_authToken);
-        }
-
         public void Dispose()
         {
             _httpClient?.Dispose();

--- a/SourceCode/Updater/Services/GithubReleaseService.cs
+++ b/SourceCode/Updater/Services/GithubReleaseService.cs
@@ -19,20 +19,16 @@ namespace AgOpenGPS.Updater.Services
         private const string DefaultRepository = "AgOpenGPS";
         private const string GithubApiUrl = "https://api.github.com";
 
-        // GitHub Personal Access Token for updater (read-only, increases rate limit to 5000/hr)
-        private const string GitHubToken = "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";
-
         private readonly HttpClient _httpClient;
         private readonly string _owner;
         private readonly string _repository;
         private readonly string _authToken;
 
-        public GithubReleaseService(string owner = null, string repository = null, string authToken = null)
+        public GithubReleaseService(string owner = null, string repository = null)
         {
             _owner = owner ?? DefaultOwner;
             _repository = repository ?? DefaultRepository;
             // Use provided token or fall back to default read-only token
-            _authToken = authToken ?? GitHubToken;
 
             _httpClient = new HttpClient
             {
@@ -44,10 +40,6 @@ namespace AgOpenGPS.Updater.Services
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("AgOpenGPS-Updater", "1.0"));
 
-            if (!string.IsNullOrEmpty(_authToken))
-            {
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", _authToken);
-            }
         }
 
         /// <summary>

--- a/SourceCode/Updater/Services/UpdateService.cs
+++ b/SourceCode/Updater/Services/UpdateService.cs
@@ -22,11 +22,11 @@ namespace AgOpenGPS.Updater.Services
         /// Checks for updates and returns the release info if an update is available.
         /// </summary>
         public async Task<(bool HasUpdate, ReleaseInfo ReleaseInfo, string Message)> CheckForUpdate(
-            string currentVersion, bool includePrerelease = false, string gitHubToken = null)
+            string currentVersion, bool includePrerelease = false)
         {
             try
             {
-                using (var githubService = new GithubReleaseService(authToken: gitHubToken))
+                using (var githubService = new GithubReleaseService())
                 {
                     var updateInfo = await githubService.CheckForUpdate(currentVersion, includePrerelease);
 
@@ -52,7 +52,7 @@ namespace AgOpenGPS.Updater.Services
         /// Downloads an update release to the specified path.
         /// </summary>
         public async Task<(bool Success, string DownloadPath, string Message)> DownloadUpdate(
-            ReleaseInfo release, string targetDirectory, IProgress<double> progress = null, string gitHubToken = null)
+            ReleaseInfo release, string targetDirectory, IProgress<double> progress = null)
         {
             try
             {
@@ -77,7 +77,7 @@ namespace AgOpenGPS.Updater.Services
 
                 string downloadPath = Path.Combine(targetDirectory, Path.GetFileName(asset.Name));
 
-                using (var githubService = new GithubReleaseService(authToken: gitHubToken))
+                using (var githubService = new GithubReleaseService())
                 {
                     await githubService.DownloadAsset(asset.BrowserDownloadUrl, downloadPath, progress);
                 }


### PR DESCRIPTION
## Summary

Hotpatch with AgShare improvements, small settings fixes and maintenance.

## AgShare
  - **Auto cloud load**: when AgShare is active and a field has a cloud ID,
    the latest version is automatically downloaded before the field is opened
    (Open, Resume, Drive In). Controlled by a new per-user toggle in the
    AgShare settings form.
  - **FormAgShareSettings** redesigned with a cleaner 3-zone layout; all UI
    strings moved to the translations resource.
  - Translations for all new AgShare strings added for **DE, NL, HU, CS, FR**.
  - Auto-Upload and Cloud Load buttons are now correctly disabled when
    AgShare is not activated.

## Settings
  - `setAS_snapDistance` and `setAS_snapDistanceRef` (nudge step size) moved
    from Environment to **Tool profile** — makes more sense as a per-tool value.
  - Current vehicle/tool profiles are now **saved before switching** to a
    different profile in FormLoadVehicleTool, preventing loss of unsaved changes.

## Log Viewer
  - Fixed slow load caused by line-by-line `AppendText` redraws — now loads
    in one shot.
  - Viewer now **auto-updates in realtime** (1 s interval, appends only new
    lines, no flicker).
  - Scrolls to the **bottom** on open and after new entries arrive.
  - Log file is now **trimmed to the last 100 lines** on startup instead of
    growing indefinitely.
## Updater
  - Removed expired GitHub API token dependency from the updater — the token
    was causing 401 errors and requires ongoing maintenance. Rate limiting
    is not an issue in practice for release checks.

## Other
  - Fixed MSB3270 architecture mismatch warning in test project (x64).