### PR TITLE
Fix a typo in Bulgarian translation

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.bg.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.bg.resx
@@ -399,7 +399,7 @@
         <value>Директорията съществува</value>
     </data>
     <data name="gsDisagree">
-        <value>Не съм съгласен</value>
+        <value>Отказвам</value>
     </data>
     <data name="gsDiscourseForum">
         <value>Дискурсен форум</value>


### PR DESCRIPTION
Changed one word to a shorter one.