### PR TITLE
Bugfixes for 6.8.4

### DIFF
--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.el.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.el.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.grc.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.grc.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
+++ b/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
@@ -197,10 +197,13 @@ namespace AgOpenGPS
             BoundaryFiles.Save(fieldDir, field.Boundaries);
             TrackFiles.Save(fieldDir, field.Tracks);
 
-            // Empty placeholder files
-            FlagsFiles.Save(fieldDir, new List<CFlag>());
-            HeadlandFiles.Save(fieldDir, new List<CBoundaryList>());
-            ContourFiles.CreateFile(fieldDir);
+            // These files are local user data - only create if they don't exist yet
+            if (!File.Exists(Path.Combine(fieldDir, "Flags.txt")))
+                FlagsFiles.Save(fieldDir, new List<CFlag>());
+            if (!File.Exists(Path.Combine(fieldDir, "Headland.txt")))
+                HeadlandFiles.Save(fieldDir, new List<CBoundaryList>());
+            if (!File.Exists(Path.Combine(fieldDir, "Contour.txt")))
+                ContourFiles.CreateFile(fieldDir);
             // Sections.txt is always local - never created or overwritten by AgShare download
         }
     }

--- a/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
+++ b/SourceCode/GPS/Classes/AgShare/AgShareDownloader.cs
@@ -201,7 +201,7 @@ namespace AgOpenGPS
             FlagsFiles.Save(fieldDir, new List<CFlag>());
             HeadlandFiles.Save(fieldDir, new List<CBoundaryList>());
             ContourFiles.CreateFile(fieldDir);
-            SectionsFiles.CreateEmpty(fieldDir);
+            // Sections.txt is always local - never created or overwritten by AgShare download
         }
     }
 

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -78,6 +78,13 @@ namespace AgOpenGPS
 
         //how far should the distance between points on the uTurn be
         private double pointSpacing;
+
+        // Saved state before YouTurnTrigger, used to restore on mid-turn cancel
+        private int savedCurvePathsAway, savedABLinePathsAway;
+        private bool savedCurveHeadingSameWay, savedABLineHeadingSameWay;
+        private bool savedIsTurnLeft;
+        private int savedRowSkipsWidth, savedTurnSkips;
+        private bool savedPreviousBigSkip;
         #endregion
 
         //constructor
@@ -2415,6 +2422,16 @@ namespace AgOpenGPS
 
             if (!isGoingStraightThrough)
             {
+                // Save state so we can restore if user cancels mid-turn
+                savedCurvePathsAway = mf.curve.howManyPathsAway;
+                savedABLinePathsAway = mf.ABLine.howManyPathsAway;
+                savedCurveHeadingSameWay = mf.curve.isHeadingSameWay;
+                savedABLineHeadingSameWay = mf.ABLine.isHeadingSameWay;
+                savedIsTurnLeft = isTurnLeft;
+                savedRowSkipsWidth = rowSkipsWidth;
+                savedTurnSkips = turnSkips;
+                savedPreviousBigSkip = previousBigSkip;
+
                 mf.curve.howManyPathsAway += (isTurnLeft ^ mf.curve.isHeadingSameWay) ? rowSkipsWidth : -rowSkipsWidth;
                 mf.curve.isHeadingSameWay = !mf.curve.isHeadingSameWay;
 
@@ -2435,6 +2452,21 @@ namespace AgOpenGPS
                 }
                 else isTurnLeft = !isTurnLeft;
             }
+        }
+
+        // Restores path state to before the trigger when user cancels a turn in progress
+        public void RestorePreTriggerState()
+        {
+            if (!isYouTurnTriggered || isGoingStraightThrough) return;
+
+            mf.curve.howManyPathsAway = savedCurvePathsAway;
+            mf.curve.isHeadingSameWay = savedCurveHeadingSameWay;
+            mf.ABLine.howManyPathsAway = savedABLinePathsAway;
+            mf.ABLine.isHeadingSameWay = savedABLineHeadingSameWay;
+            isTurnLeft = savedIsTurnLeft;
+            rowSkipsWidth = savedRowSkipsWidth;
+            turnSkips = savedTurnSkips;
+            previousBigSkip = savedPreviousBigSkip;
         }
 
         //Normal copmpletion of youturn

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -250,6 +250,10 @@ namespace AgOpenGPS
                 //yt.Set_Alternate_skips();
 
                 btnAutoYouTurn.Image = Properties.Resources.YouTurnNo;
+
+                // If a turn was already triggered, restore the original path before resetting
+                yt.RestorePreTriggerState();
+
                 yt.ResetYouTurn();
 
                 //new direction so reset where to put turn diagnostic

--- a/SourceCode/GPS/Forms/Field/FormJob.cs
+++ b/SourceCode/GPS/Forms/Field/FormJob.cs
@@ -198,7 +198,7 @@ namespace AgOpenGPS
                                     // Convert to miles if not metric
                                     Distance distanceObj = new Distance(distance * 1000); // Distance expects meters
                                     double displayDistance = mf.isMetric ? distanceObj.InKilometers : distanceObj.InMiles;
-                                    distanceList += displayDistance.ToString("F3");
+                                    distanceList += displayDistance.ToString("F3", System.Globalization.CultureInfo.InvariantCulture);
                                 }
                             }
                         }


### PR DESCRIPTION
This fixes some bugs which were found in 6.8.4.
- Fix Drive-in Form Distance table showing wrong values in other languages then English
- Fix AgShare download deleting local Sections file
- Fix AgShare download deleting local Flags, headland and contour files
- Fix Uturn Cancel when uturn is started and user turns off Uturn, the turn will be made no matter what cause the next pass is already selected and locked.

Added Greek Translations