### PR TITLE
ISOBUS TC conflicts with Section painting

### DIFF
--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -1282,7 +1282,9 @@ namespace AgOpenGPS
                 mc.CheckWorkAndSteerSwitch();
 
             // Check ISOBUS for actual section states
-            if (isobus.IsAlive())
+            // Only override if TC has active clients with section control capability (numberOfSections > 0)
+            // For 0-section implements, let AOG control sections normally
+            if (isobus.IsAlive() && isobus.HasActiveClients)
             {
                 for (int j = 0; j < tool.numOfSections; j++)
                 {


### PR DESCRIPTION
When we have TC running we want the ISOBUS Ready button to appear. But without any implement connected AgOpenGPS should paint the areas how it would normally do.