### PR TITLE
Improves boundary recording and simulator lockout

### DIFF
--- a/SourceCode/GPS/Classes/AgShare/Helpers/FieldParser.cs
+++ b/SourceCode/GPS/Classes/AgShare/Helpers/FieldParser.cs
@@ -45,7 +45,11 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                 Origin = origin
             };
 
-            var converter = new GeoConverter(origin.Latitude, origin.Longitude);
+            // Use LocalPlane.ConvertWgs84ToGeoCoord: it is the exact analytic inverse of the
+            // uploader's LocalPlane.ConvertGeoCoordToWgs84 (both evaluate metersPerDegreeLon at
+            // the point's own latitude). The old GeoConverter evaluated it at the origin latitude,
+            // which introduced a systematic east-axis shear on the upload->download round trip.
+            var converter = new LocalPlane(origin, new SharedFieldProperties());
 
             // Parse boundaries directly to CBoundaryList
             if (dto.Boundaries != null)
@@ -68,7 +72,7 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                             continue;
                         }
 
-                        var local = converter.ToLocal(wgs.Latitude, wgs.Longitude);
+                        var local = converter.ConvertWgs84ToGeoCoord(wgs);
                         bnd.fenceLine.Add(new vec3(local.Easting, local.Northing, 0.0));
                     }
 
@@ -104,8 +108,8 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                         continue;
                     }
 
-                    var vA = converter.ToLocal(wgsA.Latitude, wgsA.Longitude);
-                    var vB = converter.ToLocal(wgsB.Latitude, wgsB.Longitude);
+                    var vA = converter.ConvertWgs84ToGeoCoord(wgsA);
+                    var vB = converter.ConvertWgs84ToGeoCoord(wgsB);
                     var ptA = new vec3(vA.Easting, vA.Northing, 0);
                     var ptB = new vec3(vB.Easting, vB.Northing, 0);
                     bool isCurve = ab.Coords.Count > 2;
@@ -134,7 +138,7 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                             var wgs = new Wgs84(p.Latitude, p.Longitude);
                             if (!wgs.IsValid) continue;
 
-                            var local = converter.ToLocal(wgs.Latitude, wgs.Longitude);
+                            var local = converter.ConvertWgs84ToGeoCoord(wgs);
                             localPts.Add(new vec3(local.Easting, local.Northing, 0));
                         }
 

--- a/SourceCode/GPS/Classes/CFenceLine.cs
+++ b/SourceCode/GPS/Classes/CFenceLine.cs
@@ -156,7 +156,6 @@ namespace AgOpenGPS
         //obvious
         public bool CalculateFenceArea(int idx, bool cleanIntersections = true)
         {
-            Debug.WriteLine("CalculateFenceArea is Called");
             if (cleanIntersections) RemoveSelfIntersections();
             int ptCount = fenceLine.Count;
             if (ptCount < 3) return false; // Need at least 3 points for a valid boundary

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -1648,6 +1648,13 @@ namespace AgOpenGPS
         }
         private void simulatorOnToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            // Once SIM has been disabled this session, it stays disabled until app restart.
+            if (isSimDisabledLocked)
+            {
+                simulatorOnToolStripMenuItem.Checked = false;
+                simulatorOnToolStripMenuItem.Enabled = false;
+                return;
+            }
             if (isJobStarted)
             {
                 TimedMessageBox(2000, gStr.gsFieldIsOpen, gStr.gsCloseFieldFirst);
@@ -2299,6 +2306,14 @@ namespace AgOpenGPS
         double lastSimGuidanceAngle = 0;
         private void timerSim_Tick(object sender, EventArgs e)
         {
+            // Hard lock: if SIM was ever disabled in this session, kill the timer and bail.
+            // Prevents rogue sim ticks from overwriting pn.fix with sim coords while live GNSS is active.
+            if (isSimDisabledLocked)
+            {
+                timerSim.Enabled = false;
+                return;
+            }
+
             if (recPath.isDrivingRecordedPath || isBtnAutoSteerOn && (guidanceLineDistanceOff != 32000))
             {
                 if (vehicle.isInDeadZone)

--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -259,8 +259,8 @@ namespace AgOpenGPS
                     lblCurrentField.Text = "\u25B6" + " " + lblCurrentField.Text;
                 }
 
-                //fix
-                if (timerSim.Enabled && pn.fixQuality++ > 5) pn.fixQuality = 2;
+                //fix - only cycle fake quality while SIM is genuinely the active source
+                if (timerSim.Enabled && !isSimDisabledLocked && pn.fixQuality++ > 5) pn.fixQuality = 2;
 
                 fileSaveAlwaysCounter += 3;
             }

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -14,6 +14,10 @@ namespace AgOpenGPS
         //very first fix to setup grid etc
         public bool isFirstFixPositionSet = false, isGPSPositionInitialized = false, isFirstHeadingSet = false,
             isReverse = false, isSteerInReverse = true, isSuperSlow = false;
+
+        // Sticky lock: once SIM is disabled in this session (either by live fix arriving or by user),
+        // it can never be re-enabled until the app is restarted. Sim uit = Sim uit.
+        public bool isSimDisabledLocked = false;
         public double startGPSHeading = 0;
 
         //string to record fixes for elevation maps

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -351,6 +351,9 @@ namespace AgOpenGPS
             panelSim.Visible = false;
             timerSim.Enabled = false;
             simulatorOnToolStripMenuItem.Checked = false;
+            // Lock SIM off for the rest of this session — no runtime path may re-enable.
+            isSimDisabledLocked = true;
+            simulatorOnToolStripMenuItem.Enabled = false;
             Properties.Settings.Default.setMenu_isSimulatorOn = simulatorOnToolStripMenuItem.Checked;
             Properties.Settings.Default.Save();
             return;


### PR DESCRIPTION
Addresses artifacts in boundary recording and enhances simulator stability.

**Boundary Recording Improvements:**
- Prevents boundary overlap artifacts when an operator drives past the start point.
- Introduces `TrimDrivenOvershoot` to intelligently remove excess path by:
    - Stripping trailing points that loop straight back to the start.
    - Resolving angled overshoots by finding intersections and retaining the enclosed loop.
- Enhances `RemoveSelfIntersections` to prevent discarding valid boundaries if the cleanup process results in a disproportionately small or degenerate polygon.

**Simulator Safety & Lockout:**
- Fixes simulator coordinates from potentially leaking into live GNSS fixes, which could cause erratic position jumps.
- Implements a "sticky lock" (`isSimDisabledLocked`) that permanently disables the simulator for the remainder of the session once it's turned off (either manually or by the system).
- Ensures the simulator cannot be accidentally re-enabled and that its timer and fix quality spoofing mechanisms are completely halted when locked off, preventing interference with live data.