### PR TITLE
Bugfixes and Improvements (IMPORTANT for AgShare USERS!)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,6 @@ AgOpenGPS is a GPS-guidance steering system for agriculture in C# WinForms (.NET
 | [Classes](docs/classes.md) | Core classes and their responsibilities |
 | [PGN Protocol](docs/pgn-protocol.md) | PGN message format and communication |
 
-## Current Work
-
-**Branch**: `NewSettings` - Settings split into Vehicle/Tool/Environment
-
-See [Settings documentation](docs/settings.md) for details.
-
 ## Project Overview
 
 ```
@@ -39,7 +33,7 @@ SourceCode/
 
 ## User Preferences
 
-- **Language**: Dutch speaker
+- **Language**: English
 - **Comments**: All code comments must be in **English**
 - **Style**: Practical working code > perfect architecture
 - **Priority**: Get it working in the field

--- a/SourceCode/AgIO/Source/Forms/FormLoop.cs
+++ b/SourceCode/AgIO/Source/Forms/FormLoop.cs
@@ -79,6 +79,21 @@ namespace AgIO
         //First run
         private void FormLoop_Load(object sender, EventArgs e)
         {
+            if (RegistrySettings.profileLoadResult == AgLibrary.Settings.LoadResult.Failed)
+            {
+                TimedMessageBox(10000,
+                    "Profile Load Warning",
+                    "AgIO profile could not be fully loaded (file may be corrupt).\r\n" +
+                    "Current session is using defaults for missing/invalid values.");
+            }
+
+            if (RegistrySettings.profileLoadedFromBackup)
+            {
+                TimedMessageBox(10000,
+                    "Profile Recovery",
+                    "AgIO profile was recovered from .last backup because the main file was unreadable.");
+            }
+
             if (Settings.Default.setDisplay_StartMinimized)
             {
                 this.WindowState = FormWindowState.Minimized;
@@ -305,7 +320,14 @@ namespace AgIO
             Settings.Default.setPort_wasMachineModuleConnected = wasMachineModuleConnectedLastRun;
             Settings.Default.setPort_wasRtcmConnected = wasRtcmConnectedLastRun;
 
-            Settings.Default.Save();
+            if (RegistrySettings.profileLoadResult == AgLibrary.Settings.LoadResult.Ok)
+            {
+                Settings.Default.Save();
+            }
+            else
+            {
+                Log.EventWriter($"AgIO profile save skipped: profile load state is {RegistrySettings.profileLoadResult}");
+            }
 
             isobusForm.StopAogTaskControllerProcess();
 

--- a/SourceCode/AgIO/Source/Properties/RegistrySettings.cs
+++ b/SourceCode/AgIO/Source/Properties/RegistrySettings.cs
@@ -1,5 +1,6 @@
 ﻿using AgIO.Properties;
 using AgLibrary.Logging;
+using AgLibrary.Settings;
 using Microsoft.Win32;
 using System;
 using System.Configuration;
@@ -29,6 +30,8 @@ namespace AgIO
         public static string profileDirectory;
         public static string logsDirectory;
         public static string profileName = "";
+        public static LoadResult profileLoadResult = LoadResult.MissingFile;
+        public static bool profileLoadedFromBackup = false;
 
         public static void Load()
         {
@@ -73,7 +76,11 @@ namespace AgIO
 
             Log.CheckLogSize(Path.Combine(logsDirectory, "AgIO_Events_Log.txt"));
 
-            Properties.Settings.Default.Load();
+            profileLoadResult = Properties.Settings.Default.Load();
+            if (profileLoadResult != LoadResult.Ok)
+            {
+                Log.EventWriter($"AgIO profile load failed: '{profileName}' ({profileLoadResult})");
+            }
         }
 
         public static void Save(string name, string value)

--- a/SourceCode/AgIO/Source/Properties/Settings.cs
+++ b/SourceCode/AgIO/Source/Properties/Settings.cs
@@ -82,6 +82,23 @@ namespace AgIO.Properties
         {
             string path = Path.Combine(RegistrySettings.profileDirectory, RegistrySettings.profileName + ".XML");
             var result = XmlSettingsHandler.LoadXMLFile(path, this);
+            bool loadedFromBackup = false;
+
+            // Fallback to last known good backup when current profile is missing/corrupt.
+            if (result == LoadResult.Failed || result == LoadResult.MissingFile)
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                if (File.Exists(backupPath))
+                {
+                    var backupResult = XmlSettingsHandler.LoadXMLFile(backupPath, this);
+                    if (backupResult == LoadResult.Ok)
+                    {
+                        result = LoadResult.Ok;
+                        loadedFromBackup = true;
+                    }
+                }
+            }
+
             if (result == LoadResult.MissingFile)
             {
                 if (RegistrySettings.profileName != "")
@@ -95,6 +112,9 @@ namespace AgIO.Properties
                 }
             }
 
+            RegistrySettings.profileLoadResult = result;
+            RegistrySettings.profileLoadedFromBackup = loadedFromBackup;
+
             return result;
         }
 
@@ -103,7 +123,18 @@ namespace AgIO.Properties
             string path = Path.Combine(RegistrySettings.profileDirectory, RegistrySettings.profileName + ".XML");
 
             if (RegistrySettings.profileName != "")
+            {
+                // Keep a last-known-good copy before writing, unless this profile was
+                // recovered from .last (primary .XML was unreadable).
+                if (File.Exists(path) && !RegistrySettings.profileLoadedFromBackup)
+                {
+                    string backupPath = Path.ChangeExtension(path, ".last");
+                    File.Copy(path, backupPath, true);
+                }
+
                 XmlSettingsHandler.SaveXMLFile(path, this);
+                RegistrySettings.profileLoadedFromBackup = false;
+            }
             else
             {
                 Log.EventWriter("Default Profile Not saved to Profiles");

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.nl.resx
@@ -262,7 +262,7 @@ De volgorde waarin u ze indrukt, is de volgorde waarin ze van onder naar boven i
     <value>Autosteer Configuratie</value>
   </data>
   <data name="gsAutoSwitchDualFixSpeed" xml:space="preserve">
-    <value>Dual&lt;&gt;Fix</value>
+    <value>Schakelsnelheid</value>
   </data>
   <data name="gsBackground" xml:space="preserve">
     <value>Achtergrond</value>
@@ -1506,5 +1506,80 @@ Laad via het Config-paneel &amp; menu linksboven.</value>
   </data>
   <data name="gsRename" xml:space="preserve">
     <value>Hernoem</value>
+  </data>
+  <data name="gsCm" xml:space="preserve">
+    <value>cm</value>
+  </data>
+  <data name="gsDiscourseForum" xml:space="preserve">
+    <value>Discourse Forum</value>
+  </data>
+  <data name="gsPixel" xml:space="preserve">
+    <value>Pixel</value>
+  </data>
+  <data name="gsYouTubeTutorials" xml:space="preserve">
+    <value>Youtube uitlegvideo's</value>
+  </data>
+  <data name="gsAckermann" xml:space="preserve">
+    <value>Ackermann</value>
+  </data>
+  <data name="gsCurve" xml:space="preserve">
+    <value>Curve</value>
+  </data>
+  <data name="gsDiameter" xml:space="preserve">
+    <value>Diameter</value>
+  </data>
+  <data name="gsDirect" xml:space="preserve">
+    <value>Direct</value>
+  </data>
+  <data name="gsEasyDriveInfo" xml:space="preserve">
+    <value>Snelle start met GPS begeleiding. Stel werkende breedte en hitch lengte in en maak dan een AB lijn of curve. Er wordt niets opgeslagen.</value>
+  </data>
+  <data name="gsGrid" xml:space="preserve">
+    <value>Raster</value>
+  </data>
+  <data name="gsHelp" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="gsKeyboard" xml:space="preserve">
+    <value>Toetsenbord</value>
+  </data>
+  <data name="gsLatLon" xml:space="preserve">
+    <value>Breedte+Lengte</value>
+  </data>
+  <data name="gsNext" xml:space="preserve">
+    <value>Volgende</value>
+  </data>
+  <data name="gsStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="gsWebCam" xml:space="preserve">
+    <value>WebCam</value>
+  </data>
+  <data name="gsWest" xml:space="preserve">
+    <value>West</value>
+  </data>
+  <data name="gsWizards" xml:space="preserve">
+    <value>Installatiehulpen</value>
+  </data>
+  <data name="gsWizard" xml:space="preserve">
+    <value>Installatiehulp</value>
+  </data>
+  <data name="gsZone" xml:space="preserve">
+    <value>Zone</value>
+  </data>
+  <data name="gsZones" xml:space="preserve">
+    <value>Zones</value>
+  </data>
+  <data name="gsZoomIn" xml:space="preserve">
+    <value>Inzoomen</value>
+  </data>
+  <data name="gsTractor" xml:space="preserve">
+    <value>Tractor</value>
+  </data>
+  <data name="gsTBT" xml:space="preserve">
+    <value>TBT</value>
+  </data>
+  <data name="gsAPlus" xml:space="preserve">
+    <value>A+</value>
   </data>
 </root>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ta.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ta.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.ta.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.ta.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -58,4 +58,1490 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="gsABDraw" xml:space="preserve">
+    <value>ஏபி வரையவும்</value>
+  </data>
+  <data name="gsABDrawHint" xml:space="preserve">
+    <value>தொடங்குவதற்கு எல்லையில் 2 புள்ளிகளைக் சொடுக்கு செய்யவும்</value>
+  </data>
+  <data name="gsABline" xml:space="preserve">
+    <value>ஏபி லைன்</value>
+  </data>
+  <data name="gsADConverter" xml:space="preserve">
+    <value>AD மாற்றி</value>
+  </data>
+  <data name="gsAPlus" xml:space="preserve">
+    <value>A+</value>
+  </data>
+  <data name="gsAckermann" xml:space="preserve">
+    <value>அக்கர்மேன்</value>
+  </data>
+  <data name="gsAcquire" xml:space="preserve">
+    <value>கையகப்படுத்து</value>
+  </data>
+  <data name="gsAcquireFactor" xml:space="preserve">
+    <value>காரணியைப் பெறுங்கள்</value>
+  </data>
+  <data name="gsActionHasBeenCancelled" xml:space="preserve">
+    <value>நடவடிக்கை ரத்து செய்யப்பட்டுள்ளது</value>
+  </data>
+  <data name="gsActive" xml:space="preserve">
+    <value>செயல்படுத்து</value>
+  </data>
+  <data name="gsActual" xml:space="preserve">
+    <value>உண்மையான</value>
+  </data>
+  <data name="gsAdvancedTramLines" xml:space="preserve">
+    <value>மேம்பட்ட டிராம்லைன்களை உருவாக்கவும்</value>
+  </data>
+  <data name="gsAgShareDownloader" xml:space="preserve">
+    <value>AgShare இலிருந்து புலங்களைப் பதிவிறக்கவும்</value>
+  </data>
+  <data name="gsAgShareActivate" xml:space="preserve">
+    <value>செயல்படுத்து</value>
+  </data>
+  <data name="gsAgShareActivated" xml:space="preserve">
+    <value>செயல்படுத்தப்பட்டது</value>
+  </data>
+  <data name="gsAgShareApiKey" xml:space="preserve">
+    <value>பநிஇ விசை</value>
+  </data>
+  <data name="gsAgShareAutoLoad" xml:space="preserve">
+    <value>முகில் சுமை</value>
+  </data>
+  <data name="gsAgShareAutoUpload" xml:space="preserve">
+    <value>தானாக பதிவேற்றம்</value>
+  </data>
+  <data name="gsAgShareButtonsHint" xml:space="preserve">
+    <value>தானியங்கு-பதிவேற்றம்: நெருங்கியவுடன் பதிவேற்ற புலத்தில் மாற்றங்கள் 
+முகில் லோட்: எப்போதும் திறந்திருக்கும் AgShare இலிருந்து சமீபத்தியவற்றைப் பதிவிறக்கவும்</value>
+  </data>
+  <data name="gsAgShareConnecting" xml:space="preserve">
+    <value>இணைக்கிறது...</value>
+  </data>
+  <data name="gsAgShareConnectionOk" xml:space="preserve">
+    <value>இணைப்பு வெற்றிகரமாக உள்ளது</value>
+  </data>
+  <data name="gsAgShareDeactivated" xml:space="preserve">
+    <value>செயலிழக்கப்பட்டது</value>
+  </data>
+  <data name="gsAgShareEnterDetails" xml:space="preserve">
+    <value>சேவையகம் மற்றும் பநிஇ விசையை உள்ளிட்டு, இணைப்பைச் சோதிக்கவும்</value>
+  </data>
+  <data name="gsAgShareInvalidApiKey" xml:space="preserve">
+    <value>தவறான பநிஇ விசை</value>
+  </data>
+  <data name="gsAgShareLocalOnly" xml:space="preserve">
+    <value>உள்ளக மட்டும்</value>
+  </data>
+  <data name="gsAgSharePaste" xml:space="preserve">
+    <value>கிளிப்போர்டில் இருந்து ஒட்டவும்</value>
+  </data>
+  <data name="gsAgShareRegisterHere" xml:space="preserve">
+    <value>AgShare ஐப் பயன்படுத்த இங்கே பதிவு செய்யவும்</value>
+  </data>
+  <data name="gsAgShareSaved" xml:space="preserve">
+    <value>அமைப்புகள் சேமிக்கப்பட்டன</value>
+  </data>
+  <data name="gsAgShareServer" xml:space="preserve">
+    <value>சேவையகம்</value>
+  </data>
+  <data name="gsAgShareSettings" xml:space="preserve">
+    <value>AgShare அமைப்புகள்</value>
+  </data>
+  <data name="gsAgShareTestConnection" xml:space="preserve">
+    <value>சோதனை இணைப்பு</value>
+  </data>
+  <data name="gsAgShareUploadOff" xml:space="preserve">
+    <value>பதிவேற்றம் முடக்கப்பட்டுள்ளது</value>
+  </data>
+  <data name="gsAgShareUploadOn" xml:space="preserve">
+    <value>பதிவேற்றம் ஆன்</value>
+  </data>
+  <data name="gsAgShareAutoLoadActive" xml:space="preserve">
+    <value>மேகத்திலிருந்து புலங்கள் தானாக ஏற்றப்படும்</value>
+  </data>
+  <data name="gsAgShareFieldLoaded" xml:space="preserve">
+    <value>AgShare இலிருந்து புலம் ஏற்றப்பட்டது</value>
+  </data>
+  <data name="gsAgShareLoadFailed" xml:space="preserve">
+    <value>உள்ளக பதிப்பைப் பயன்படுத்தி, கிளவுடிலிருந்து புலத்தை ஏற்ற முடியவில்லை.</value>
+  </data>
+  <data name="gsAgree" xml:space="preserve">
+    <value>ஒப்புக்கொள்கிறேன்</value>
+  </data>
+  <data name="gsAgressiveness" xml:space="preserve">
+    <value>வன்கவர்வு</value>
+  </data>
+  <data name="gsAllSettings" xml:space="preserve">
+    <value>அனைத்து அமைப்புகளையும் பார்க்கவும்</value>
+  </data>
+  <data name="gsAlpha" xml:space="preserve">
+    <value>அகர</value>
+  </data>
+  <data name="gsAntennaHeight" xml:space="preserve">
+    <value>ஆண்டெனா உயரம்</value>
+  </data>
+  <data name="gsAntennaOffset" xml:space="preserve">
+    <value>ஆண்டெனா ஆஃப்செட்</value>
+  </data>
+  <data name="gsApplied" xml:space="preserve">
+    <value>விண்ணப்பிக்கப்பட்டது</value>
+  </data>
+  <data name="gsArea" xml:space="preserve">
+    <value>பகுதி</value>
+  </data>
+  <data name="gsArrangeText" xml:space="preserve">
+    <value>பட்டியலில் (வலது பக்கம்) தோன்ற விரும்பும் இடது பக்கத்தில் உள்ள பொத்தான்களைத் தொடவும். 
+
+நீங்கள் அவற்றைத் தள்ளும் வரிசையானது பட்டியலில் கீழே இருந்து மேலே தோன்றும் வரிசையாக இருக்கும்.</value>
+  </data>
+  <data name="gsAttachmentStyle" xml:space="preserve">
+    <value>இணைப்பு நடை</value>
+  </data>
+  <data name="gsAuto" xml:space="preserve">
+    <value>தானி</value>
+  </data>
+  <data name="gsAutoOffAgIO" xml:space="preserve">
+    <value>ஆட்டோ ஆஃப் AgIO</value>
+  </data>
+  <data name="gsAutoStartAgIO" xml:space="preserve">
+    <value>ஆட்டோ ச்டார்ட் AgIO</value>
+  </data>
+  <data name="gsAutoSteer" xml:space="preserve">
+    <value>ஆட்டோ ச்டியர்</value>
+  </data>
+  <data name="gsAutoSteerConfiguration" xml:space="preserve">
+    <value>தானி Steer உள்ளமைவு</value>
+  </data>
+  <data name="gsAutoSteerPort" xml:space="preserve">
+    <value>ஆட்டோச்டீர் துறைமுகம்</value>
+  </data>
+  <data name="gsAutoSwitchDualFix" xml:space="preserve">
+    <value>தானியங்கு இரட்டை &lt;&gt; சரி</value>
+  </data>
+  <data name="gsAutoSwitchDualFixSpeed" xml:space="preserve">
+    <value>ச்விட்ச் விரைவு</value>
+  </data>
+  <data name="gsBackground" xml:space="preserve">
+    <value>பின்னணி</value>
+  </data>
+  <data name="gsBasedOnField" xml:space="preserve">
+    <value>புலத்தை அடிப்படையாகக் கொண்டது</value>
+  </data>
+  <data name="gsBottomMenu" xml:space="preserve">
+    <value>கீழ் பட்டியல்</value>
+  </data>
+  <data name="gsBoundary" xml:space="preserve">
+    <value>எல்லை</value>
+  </data>
+  <data name="gsBoundaryLineFilesAreCorrupt" xml:space="preserve">
+    <value>எல்லைக் கோடுகள் சிதைந்த கோப்பு</value>
+  </data>
+  <data name="gsBrightness" xml:space="preserve">
+    <value>ஒளி</value>
+  </data>
+  <data name="gsBuild" xml:space="preserve">
+    <value>உருவாக்கு</value>
+  </data>
+  <data name="gsBuildAround" xml:space="preserve">
+    <value>சுற்றி கட்டவும்</value>
+  </data>
+  <data name="gsButFieldIsLoaded" xml:space="preserve">
+    <value>ஆனால் புலம் ஏற்றப்பட்டது</value>
+  </data>
+  <data name="gsButton" xml:space="preserve">
+    <value>பொத்தான்</value>
+  </data>
+  <data name="gsButtonDescription" xml:space="preserve">
+    <value>புச் ஆன். புச் ஆஃப்</value>
+  </data>
+  <data name="gsButtonPicker" xml:space="preserve">
+    <value>பட்டன் எடுப்பவர்</value>
+  </data>
+  <data name="gsCameraBehavior" xml:space="preserve">
+    <value>கேமரா நடத்தை</value>
+  </data>
+  <data name="gsCancel" xml:space="preserve">
+    <value>ரத்துசெய்</value>
+  </data>
+  <data name="gsCenter" xml:space="preserve">
+    <value>நடுவண்</value>
+  </data>
+  <data name="gsCentimeters" xml:space="preserve">
+    <value>சென்டிமீட்டர்</value>
+  </data>
+  <data name="gsCharts" xml:space="preserve">
+    <value>விளக்கப்படங்கள்</value>
+  </data>
+  <data name="gsCheckForUpdates" xml:space="preserve">
+    <value>புதுப்பிப்புகளை சரிபார்க்கவும்</value>
+  </data>
+  <data name="gsChoose" xml:space="preserve">
+    <value>தேர்வு செய்யவும்</value>
+  </data>
+  <data name="gsChooseADifferentField" xml:space="preserve">
+    <value>வேறு துறையைத் தேர்வு செய்யவும்</value>
+  </data>
+  <data name="gsChooseADifferentName" xml:space="preserve">
+    <value>வேறு பெயரைத் தேர்ந்தெடுக்கவும்</value>
+  </data>
+  <data name="gsChooseBuildDifferentone" xml:space="preserve">
+    <value>வேறு ஒன்றைத் தேர்ந்தெடுக்கவும் அல்லது உருவாக்கவும்</value>
+  </data>
+  <data name="gsClipLine" xml:space="preserve">
+    <value>கிளிப் லைன்</value>
+  </data>
+  <data name="gsClose" xml:space="preserve">
+    <value>மூடு</value>
+  </data>
+  <data name="gsCloseAllWindowsFirst" xml:space="preserve">
+    <value>மூடு அனைத்தும் சாளரங்கள் First</value>
+  </data>
+  <data name="gsCloseFieldFirst" xml:space="preserve">
+    <value>முதலில் களத்தை மூடு</value>
+  </data>
+  <data name="gsCm" xml:space="preserve">
+    <value>செ.மீ</value>
+  </data>
+  <data name="gsColorPicker" xml:space="preserve">
+    <value>கலர் பிக்கர்</value>
+  </data>
+  <data name="gsColors" xml:space="preserve">
+    <value>நிறங்கள்</value>
+  </data>
+  <data name="gsCompletelyDeleteBoundary" xml:space="preserve">
+    <value>எல்லையை முழுமையாக நீக்கு</value>
+  </data>
+  <data name="gsConfiguration" xml:space="preserve">
+    <value>உள்ளமைவு</value>
+  </data>
+  <data name="gsContourFileIsCorrupt" xml:space="preserve">
+    <value>காண்டூர் கோப்பு சிதைந்துள்ளது</value>
+  </data>
+  <data name="gsContourOn" xml:space="preserve">
+    <value>காண்டூர் ஆன்</value>
+  </data>
+  <data name="gsCopyFrom" xml:space="preserve">
+    <value>இருந்து நகல்</value>
+  </data>
+  <data name="gsCouldntGenerateValidPath" xml:space="preserve">
+    <value>சரியான பாதை இல்லை</value>
+  </data>
+  <data name="gsCountsPerDegree" xml:space="preserve">
+    <value>ஒரு பட்டத்திற்கு எண்ணிக்கை</value>
+  </data>
+  <data name="gsCoverage" xml:space="preserve">
+    <value>கவரேச்</value>
+  </data>
+  <data name="gsCreate" xml:space="preserve">
+    <value>உருவாக்கு</value>
+  </data>
+  <data name="gsCreateABoundaryFirst" xml:space="preserve">
+    <value>முதலில் ஒரு எல்லையை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCreateNewField" xml:space="preserve">
+    <value>புதிய புலத்தை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCreateNewFromIsoXML" xml:space="preserve">
+    <value>ISO-XML இலிருந்து புதிய புலத்தை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCreateNewProfile" xml:space="preserve">
+    <value>புதிய சுயவிவரத்தை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCurrent" xml:space="preserve">
+    <value>மின்னோட்ட்ம், ஓட்டம்</value>
+  </data>
+  <data name="gsCurrentTurnSensor" xml:space="preserve">
+    <value>தற்போதைய டர்ன் சென்சார்</value>
+  </data>
+  <data name="gsCurve" xml:space="preserve">
+    <value>வளைவு</value>
+  </data>
+  <data name="gsCurveLineFileIsCorrupt" xml:space="preserve">
+    <value>வளைவு கோடு கோப்பு சிதைந்துள்ளது</value>
+  </data>
+  <data name="gsCurveNotOn" xml:space="preserve">
+    <value>வளைவு இயக்கத்தில் இல்லை</value>
+  </data>
+  <data name="gsDay" xml:space="preserve">
+    <value>நாள்</value>
+  </data>
+  <data name="gsDeadzone" xml:space="preserve">
+    <value>டெட்சோன்</value>
+  </data>
+  <data name="gsDefault" xml:space="preserve">
+    <value>இயல்புநிலை</value>
+  </data>
+  <data name="gsDegree" xml:space="preserve">
+    <value>பட்டம்</value>
+  </data>
+  <data name="gsDelete" xml:space="preserve">
+    <value>நீக்கு</value>
+  </data>
+  <data name="gsDeleteAllContoursAndSections" xml:space="preserve">
+    <value>அனைத்து பிரிவுகள் மற்றும் வரையறைகளை நீக்கு</value>
+  </data>
+  <data name="gsDeleteAppliedArea" xml:space="preserve">
+    <value>பயன்படுத்தப்பட்ட பகுதியை நீக்கு</value>
+  </data>
+  <data name="gsDeleteContourPaths" xml:space="preserve">
+    <value>விளிம்பு பாதைகளை நீக்கு</value>
+  </data>
+  <data name="gsDeleteField" xml:space="preserve">
+    <value>புலத்தை நீக்கு</value>
+  </data>
+  <data name="gsDeleteForSure" xml:space="preserve">
+    <value>நிச்சயமாக நீக்க விரும்புகிறீர்களா?</value>
+  </data>
+  <data name="gsDiameter" xml:space="preserve">
+    <value>விட்டம்</value>
+  </data>
+  <data name="gsDirect" xml:space="preserve">
+    <value>நேரடி</value>
+  </data>
+  <data name="gsDirectionMarkers" xml:space="preserve">
+    <value>திசை குறிப்பான்கள்</value>
+  </data>
+  <data name="gsDirectories" xml:space="preserve">
+    <value>கோப்பகங்கள்</value>
+  </data>
+  <data name="gsDirectoryExists" xml:space="preserve">
+    <value>அடைவு உள்ளது</value>
+  </data>
+  <data name="gsDisagree" xml:space="preserve">
+    <value>உடன்படவில்லை</value>
+  </data>
+  <data name="gsDiscourseForum" xml:space="preserve">
+    <value>சொற்பொழிவு மன்றம்</value>
+  </data>
+  <data name="gsDisplay" xml:space="preserve">
+    <value>காட்சி</value>
+  </data>
+  <data name="gsDistance" xml:space="preserve">
+    <value>தூரம்</value>
+  </data>
+  <data name="gsDistanceToFlag" xml:space="preserve">
+    <value>கொடிக்கான தூரம்</value>
+  </data>
+  <data name="gsDownloadAll" xml:space="preserve">
+    <value>அனைத்தையும் பெறுங்கள்</value>
+  </data>
+  <data name="gsDownloading" xml:space="preserve">
+    <value>பதிவிறக்குகிறது</value>
+  </data>
+  <data name="gsDriveIn" xml:space="preserve">
+    <value>உள்ளே ஓட்டு</value>
+  </data>
+  <data name="gsDriveThru" xml:space="preserve">
+    <value>இயக்கி த்ரூ</value>
+  </data>
+  <data name="gsDriving" xml:space="preserve">
+    <value>ஓட்டுதல்</value>
+  </data>
+  <data name="gsDualAntennaSetting" xml:space="preserve">
+    <value>இரட்டை ஆண்டெனா அமைப்புகள்</value>
+  </data>
+  <data name="gsDualpositionAntennaRight" xml:space="preserve">
+    <value>இரட்டை நிலை ஆண்டெனா வலது பக்கத்தில் உள்ளது</value>
+  </data>
+  <data name="gsEasyDriveInfo" xml:space="preserve">
+    <value>சிபிஎச் வழிகாட்டுதலுடன் விரைவாகத் தொடங்குங்கள். வேலை செய்யும் அகலம் மற்றும் இட்ச் நீளத்தை அமைத்து, பின்னர் AB கோடு அல்லது வளைவை உருவாக்கவும். வட்டில் எதுவும் சேமிக்கப்படவில்லை.</value>
+  </data>
+  <data name="gsEast" xml:space="preserve">
+    <value>கிழக்கு</value>
+  </data>
+  <data name="gsEditABLine" xml:space="preserve">
+    <value>AB வரியைத் திருத்தவும்</value>
+  </data>
+  <data name="gsEditColor" xml:space="preserve">
+    <value>வண்ணத்தைத் திருத்து</value>
+  </data>
+  <data name="gsEditFieldName" xml:space="preserve">
+    <value>புலத்தின் பெயரைத் திருத்தவும்</value>
+  </data>
+  <data name="gsElevationlog" xml:space="preserve">
+    <value>உயரப் பதிவு</value>
+  </data>
+  <data name="gsEmptyProfile" xml:space="preserve">
+    <value>வெற்று சுயவிவரம்</value>
+  </data>
+  <data name="gsEnable" xml:space="preserve">
+    <value>இயக்கு</value>
+  </data>
+  <data name="gsEncoderCounts" xml:space="preserve">
+    <value>எண்ணுகிறது</value>
+  </data>
+  <data name="gsEnterCoordinatesForSimulator" xml:space="preserve">
+    <value>சிமுலேட்டருக்கான ஆயங்களை உள்ளிடவும்</value>
+  </data>
+  <data name="gsEnterFieldName" xml:space="preserve">
+    <value>புலத்தின் பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsEnterName" xml:space="preserve">
+    <value>பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsEnterRecordName" xml:space="preserve">
+    <value>பதிவின் பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsEnterSimCoords" xml:space="preserve">
+    <value>சிம் கோர்டுகளை உள்ளிடவும்</value>
+  </data>
+  <data name="gsError" xml:space="preserve">
+    <value>பிழை</value>
+  </data>
+  <data name="gsErrorreadingKML" xml:space="preserve">
+    <value>KML ஐப் படிப்பதில் பிழை</value>
+  </data>
+  <data name="gsExit" xml:space="preserve">
+    <value>வெளியேறு</value>
+  </data>
+  <data name="gsExitToWindows" xml:space="preserve">
+    <value>சாளரங்களில் இருந்து வெளியேறவும்</value>
+  </data>
+  <data name="gsExtraGuideLines" xml:space="preserve">
+    <value>கூடுதல் வழிகாட்டுதல்கள்</value>
+  </data>
+  <data name="gsFactor" xml:space="preserve">
+    <value>காரணி</value>
+  </data>
+  <data name="gsFast" xml:space="preserve">
+    <value>வேகமாக</value>
+  </data>
+  <data name="gsField" xml:space="preserve">
+    <value>புலம்</value>
+  </data>
+  <data name="gsFieldFileIsCorrupt" xml:space="preserve">
+    <value>புல கோப்பு சிதைந்துள்ளது</value>
+  </data>
+  <data name="gsFieldIsOpen" xml:space="preserve">
+    <value>களம் திறந்துள்ளது</value>
+  </data>
+  <data name="gsFieldMenu" xml:space="preserve">
+    <value>புல பட்டியல்</value>
+  </data>
+  <data name="gsFieldNotOpen" xml:space="preserve">
+    <value>களம் திறக்கப்படவில்லை</value>
+  </data>
+  <data name="gsFieldPicker" xml:space="preserve">
+    <value>கோப்பை ஏற்றவும்</value>
+  </data>
+  <data name="gsFieldTexture" xml:space="preserve">
+    <value>புல அமைப்பு</value>
+  </data>
+  <data name="gsFileError" xml:space="preserve">
+    <value>கோப்பு பிழை</value>
+  </data>
+  <data name="gsFix2Fix" xml:space="preserve">
+    <value>ஃபிக்ச் டு ஃபிக்ச் டிச்டன்ச்</value>
+  </data>
+  <data name="gsFixAlarm" xml:space="preserve">
+    <value>RTK ஃபிக்ச் அலாரம்</value>
+  </data>
+  <data name="gsFixAlarmStop" xml:space="preserve">
+    <value>அலாரம் ஆட்டோச்டீரை நிறுத்துகிறது</value>
+  </data>
+  <data name="gsFlagByLatLon" xml:space="preserve">
+    <value>லாட் லோனால் கொடி</value>
+  </data>
+  <data name="gsFlagFileIsCorrupt" xml:space="preserve">
+    <value>கொடி கோப்பு சிதைந்துள்ளது</value>
+  </data>
+  <data name="gsFlags" xml:space="preserve">
+    <value>கொடிகளை உருவாக்கவும்</value>
+  </data>
+  <data name="gsForNow" xml:space="preserve">
+    <value>இப்போதைக்கு</value>
+  </data>
+  <data name="gsForceOverwrite" xml:space="preserve">
+    <value>கட்டாயமாக மேலெழுதவும்</value>
+  </data>
+  <data name="gsFormFlag" xml:space="preserve">
+    <value>கொடிகள்</value>
+  </data>
+  <data name="gsFromExisting" xml:space="preserve">
+    <value>இருப்பதில் இருந்து</value>
+  </data>
+  <data name="gsFromKml" xml:space="preserve">
+    <value>KML இலிருந்து</value>
+  </data>
+  <data name="gsGap" xml:space="preserve">
+    <value>இடைவெளி</value>
+  </data>
+  <data name="gsGetSelected" xml:space="preserve">
+    <value>தேர்ந்தெடுக்கவும்</value>
+  </data>
+  <data name="gsGpsStep" xml:space="preserve">
+    <value>குறைந்தபட்ச சிபிஎச் படி</value>
+  </data>
+  <data name="gsGrid" xml:space="preserve">
+    <value>வலைவாய்</value>
+  </data>
+  <data name="gsGuidanceStopped" xml:space="preserve">
+    <value>வழிகாட்டுதல் நிறுத்தப்பட்டது</value>
+  </data>
+  <data name="gsHardwareMessages" xml:space="preserve">
+    <value>வன்பொருள் செய்திகள்</value>
+  </data>
+  <data name="gsHeading" xml:space="preserve">
+    <value>தலைப்பு</value>
+  </data>
+  <data name="gsHeadingChart" xml:space="preserve">
+    <value>தலைப்பு விளக்கப்படம்</value>
+  </data>
+  <data name="gsHeadingOffset" xml:space="preserve">
+    <value>தலைப்பு ஆஃப்செட்</value>
+  </data>
+  <data name="gsHeadland" xml:space="preserve">
+    <value>தலைப்பகுதி</value>
+  </data>
+  <data name="gsHeadlandForm" xml:space="preserve">
+    <value>எட்லேண்டை உருவாக்கி திருத்தவும்</value>
+  </data>
+  <data name="gsHelp" xml:space="preserve">
+    <value>உதவி</value>
+  </data>
+  <data name="gsHitchLength" xml:space="preserve">
+    <value>இட்ச் நீளம்</value>
+  </data>
+  <data name="gsHold" xml:space="preserve">
+    <value>பிடி</value>
+  </data>
+  <data name="gsHydraulicLift" xml:space="preserve">
+    <value>ஐட்ராலிக் லிஃப்ட்</value>
+  </data>
+  <data name="gsHydraulicLiftConfig" xml:space="preserve">
+    <value>ஐட்ராலிக் லிஃப்ட் கட்டமைப்பு</value>
+  </data>
+  <data name="gsHydraulicLiftLookAhead" xml:space="preserve">
+    <value>முன்னே பார்</value>
+  </data>
+  <data name="gsIMUAxis" xml:space="preserve">
+    <value>IMU அச்சு இடமாற்று</value>
+  </data>
+  <data name="gsIfWrongDirectionTapVehicle" xml:space="preserve">
+    <value>தவறான திசையில் வாகனத்தைத் தட்டவும்</value>
+  </data>
+  <data name="gsImage" xml:space="preserve">
+    <value>படம் இல்லை</value>
+  </data>
+  <data name="gsImuFusion" xml:space="preserve">
+    <value>இணைவு</value>
+  </data>
+  <data name="gsInches" xml:space="preserve">
+    <value>அங்குலம்</value>
+  </data>
+  <data name="gsInner" xml:space="preserve">
+    <value>உள்</value>
+  </data>
+  <data name="gsIntegral" xml:space="preserve">
+    <value>தொகையீட்டு</value>
+  </data>
+  <data name="gsIntegralInfo" xml:space="preserve">
+    <value>குறுக்கு பாதை பிழையை குறைக்க இது மெதுவாக திசைமாற்றி கோணத்தை அதிகரிக்கும்</value>
+  </data>
+  <data name="gsInvertHydraulicRelays" xml:space="preserve">
+    <value>தலைகீழ் ரிலே</value>
+  </data>
+  <data name="gsInvertMotor" xml:space="preserve">
+    <value>மின்னோடி திசையை மாற்றவும்</value>
+  </data>
+  <data name="gsInvertRelays" xml:space="preserve">
+    <value>தலைகீழ் ரிலேக்கள்</value>
+  </data>
+  <data name="gsInvertRoll" xml:space="preserve">
+    <value>தலைகீழ் ரோல்</value>
+  </data>
+  <data name="gsInvertWas" xml:space="preserve">
+    <value>தலைகீழாக இருந்தது</value>
+  </data>
+  <data name="gsKmH" xml:space="preserve">
+    <value>கிமீ/ம</value>
+  </data>
+  <data name="gsKeyboard" xml:space="preserve">
+    <value>விசைப்பலகை</value>
+  </data>
+  <data name="gsLanguage" xml:space="preserve">
+    <value>மொழி</value>
+  </data>
+  <data name="gsLatLon" xml:space="preserve">
+    <value>லேட்+லாங்</value>
+  </data>
+  <data name="gsLateral" xml:space="preserve">
+    <value>பக்கவாட்டு</value>
+  </data>
+  <data name="gsLatitude" xml:space="preserve">
+    <value>அகலாங்கு</value>
+  </data>
+  <data name="gsLeft" xml:space="preserve">
+    <value>இடது</value>
+  </data>
+  <data name="gsLess" xml:space="preserve">
+    <value>குறைவாக</value>
+  </data>
+  <data name="gsLightbar" xml:space="preserve">
+    <value>லைட்பார்</value>
+  </data>
+  <data name="gsLineSmooth" xml:space="preserve">
+    <value>வரி மென்மையானது</value>
+  </data>
+  <data name="gsLineWidth" xml:space="preserve">
+    <value>வரி அகலம்</value>
+  </data>
+  <data name="gsLoad" xml:space="preserve">
+    <value>ஏற்றவும்</value>
+  </data>
+  <data name="gsLoadProfile" xml:space="preserve">
+    <value>சுயவிவரத்தை ஏற்றவும்</value>
+  </data>
+  <data name="gsLongtitude" xml:space="preserve">
+    <value>தீர்க்கரேகை</value>
+  </data>
+  <data name="gsLookAhead" xml:space="preserve">
+    <value>முன்னே பார்</value>
+  </data>
+  <data name="gsLookAheadTiming" xml:space="preserve">
+    <value>முன்னோக்கி நேர அமைப்புகளைப் பாருங்கள்</value>
+  </data>
+  <data name="gsLowerTime" xml:space="preserve">
+    <value>குறைந்த நேரம்</value>
+  </data>
+  <data name="gsMPH" xml:space="preserve">
+    <value>mph</value>
+  </data>
+  <data name="gsMachinePort" xml:space="preserve">
+    <value>இயந்திர துறைமுகம்</value>
+  </data>
+  <data name="gsManual" xml:space="preserve">
+    <value>கையேடு</value>
+  </data>
+  <data name="gsManualTurns" xml:space="preserve">
+    <value>கைமுறை திருப்பங்கள்</value>
+  </data>
+  <data name="gsMapForBackground" xml:space="preserve">
+    <value>Bing வரைபடத்தை பின்னணியாகச் சேர்க்கவும்</value>
+  </data>
+  <data name="gsMaxLimit" xml:space="preserve">
+    <value>அதிகபட்ச வரம்பு</value>
+  </data>
+  <data name="gsMaxSpeed" xml:space="preserve">
+    <value>அதிகபட்ச விரைவு</value>
+  </data>
+  <data name="gsMaxSteerAngle" xml:space="preserve">
+    <value>மேக்ச் ச்டீயர் ஆங்கிள்</value>
+  </data>
+  <data name="gsMeters" xml:space="preserve">
+    <value>மீட்டர்கள்</value>
+  </data>
+  <data name="gsMinSpeed" xml:space="preserve">
+    <value>குறைந்தபட்ச விரைவு</value>
+  </data>
+  <data name="gsMinToMove" xml:space="preserve">
+    <value>நகர்த்துவதற்கு குறைந்தபட்சம்</value>
+  </data>
+  <data name="gsMissingABLinesFile" xml:space="preserve">
+    <value>ABLInes கோப்பு காணவில்லை</value>
+  </data>
+  <data name="gsMissingBoundaryFile" xml:space="preserve">
+    <value>எல்லைக் கோப்பு காணவில்லை</value>
+  </data>
+  <data name="gsMissingContourFile" xml:space="preserve">
+    <value>கான்டூர் கோப்பு இல்லை</value>
+  </data>
+  <data name="gsMissingFlagsFile" xml:space="preserve">
+    <value>கொடி கோப்பு காணவில்லை</value>
+  </data>
+  <data name="gsMissingSectionFile" xml:space="preserve">
+    <value>பிரிவு கோப்பு காணவில்லை</value>
+  </data>
+  <data name="gsMode" xml:space="preserve">
+    <value>பயன்முறை</value>
+  </data>
+  <data name="gsMore" xml:space="preserve">
+    <value>மேலும்</value>
+  </data>
+  <data name="gsMotorDriver" xml:space="preserve">
+    <value>மின்னோடி டிரைவர் வகை</value>
+  </data>
+  <data name="gsMultiColorSections" xml:space="preserve">
+    <value>பல வண்ணம்</value>
+  </data>
+  <data name="gsN_East" xml:space="preserve">
+    <value>வகிழக்கு</value>
+  </data>
+  <data name="gsN_West" xml:space="preserve">
+    <value>வடமேற்கு</value>
+  </data>
+  <data name="gsName" xml:space="preserve">
+    <value>பெயர்</value>
+  </data>
+  <data name="gsNew" xml:space="preserve">
+    <value>புதிய</value>
+  </data>
+  <data name="gsNewFromDefault" xml:space="preserve">
+    <value>இயல்புநிலையிலிருந்து புதியது</value>
+  </data>
+  <data name="gsNext" xml:space="preserve">
+    <value>அடுத்தது</value>
+  </data>
+  <data name="gsNextGuidanceLine" xml:space="preserve">
+    <value>அடுத்த வழிகாட்டுதல் வரி</value>
+  </data>
+  <data name="gsNight" xml:space="preserve">
+    <value>இரவு</value>
+  </data>
+  <data name="gsNoABLineActive" xml:space="preserve">
+    <value>ஏபிலைன் செயலில் இல்லை</value>
+  </data>
+  <data name="gsNoBoundary" xml:space="preserve">
+    <value>இல்லை Boundary</value>
+  </data>
+  <data name="gsNoFieldsFound" xml:space="preserve">
+    <value>புலங்கள் எதுவும் கிடைக்கவில்லை</value>
+  </data>
+  <data name="gsNoGuidanceLines" xml:space="preserve">
+    <value>வழிகாட்டுதல் கோடுகள் இல்லை</value>
+  </data>
+  <data name="gsNone" xml:space="preserve">
+    <value>எதுவுமில்லை</value>
+  </data>
+  <data name="gsNorth" xml:space="preserve">
+    <value>வடக்கு</value>
+  </data>
+  <data name="gsNothingDeleted" xml:space="preserve">
+    <value>எதுவும் நீக்கப்படவில்லை</value>
+  </data>
+  <data name="gsNudge" xml:space="preserve">
+    <value>நட்ச்</value>
+  </data>
+  <data name="gsNudgeDistance" xml:space="preserve">
+    <value>தூரத்தை அசைக்கவும்</value>
+  </data>
+  <data name="gsNudgeRefTrack" xml:space="preserve">
+    <value>குறிப்பு தடத்தை நகர்த்தவும்</value>
+  </data>
+  <data name="gsOff" xml:space="preserve">
+    <value>அணை</value>
+  </data>
+  <data name="gsOffset" xml:space="preserve">
+    <value>ஆஃப்செட்</value>
+  </data>
+  <data name="gsOffsetFix" xml:space="preserve">
+    <value>ஆஃப்செட் ஃபிக்ச்</value>
+  </data>
+  <data name="gsOn" xml:space="preserve">
+    <value>அன்று</value>
+  </data>
+  <data name="gsOnDelay" xml:space="preserve">
+    <value>நேரந்தவறுகை</value>
+  </data>
+  <data name="gsOpacity" xml:space="preserve">
+    <value>ஒளிபுகாநிலை</value>
+  </data>
+  <data name="gsOpen" xml:space="preserve">
+    <value>திற</value>
+  </data>
+  <data name="gsOuter" xml:space="preserve">
+    <value>வெளி</value>
+  </data>
+  <data name="gsOverlap" xml:space="preserve">
+    <value>ஒன்றுடன் ஒன்று</value>
+  </data>
+  <data name="gsOverride" xml:space="preserve">
+    <value>மேலெழுது</value>
+  </data>
+  <data name="gsOvershootReduction" xml:space="preserve">
+    <value>ஓவர்சூட் குறைப்பு</value>
+  </data>
+  <data name="gsPasses" xml:space="preserve">
+    <value>கடந்து செல்கிறது</value>
+  </data>
+  <data name="gsPastEndOfCurve" xml:space="preserve">
+    <value>வளைவின் கடைசி முடிவு</value>
+  </data>
+  <data name="gsPause" xml:space="preserve">
+    <value>இடைநிறுத்தம்</value>
+  </data>
+  <data name="gsPivot" xml:space="preserve">
+    <value>பிவோட்</value>
+  </data>
+  <data name="gsPivotDistance" xml:space="preserve">
+    <value>பிவோட் தூரம்</value>
+  </data>
+  <data name="gsPixel" xml:space="preserve">
+    <value>படப்புள்ளி</value>
+  </data>
+  <data name="gsPlantPop" xml:space="preserve">
+    <value>தாவர பாப்</value>
+  </data>
+  <data name="gsPleaseEnterABLine" xml:space="preserve">
+    <value>தயவுசெய்து ABLine ஐ உள்ளிடவும்</value>
+  </data>
+  <data name="gsPleaseWait" xml:space="preserve">
+    <value>தயவுசெய்து காத்திருங்கள்</value>
+  </data>
+  <data name="gsPoint" xml:space="preserve">
+    <value>புள்ளியம்</value>
+  </data>
+  <data name="gsPoints" xml:space="preserve">
+    <value>பிரிவகம்</value>
+  </data>
+  <data name="gsPointsToProcess" xml:space="preserve">
+    <value>செயல்முறைக்கான புள்ளிகள்</value>
+  </data>
+  <data name="gsPolygons" xml:space="preserve">
+    <value>பலகோணங்கள்</value>
+  </data>
+  <data name="gsPowerLoss" xml:space="preserve">
+    <value>ஆற்றல் இழப்பு பணிநிறுத்தம்</value>
+  </data>
+  <data name="gsPresetColor" xml:space="preserve">
+    <value>முன்னமைக்கப்பட்ட வண்ணத்தைத் தேர்ந்தெடுக்கவும்</value>
+  </data>
+  <data name="gsPressureTurnSensor" xml:space="preserve">
+    <value>அழுத்தம் திருப்பு சென்சார்</value>
+  </data>
+  <data name="gsPreview" xml:space="preserve">
+    <value>முன்னோட்டம்</value>
+  </data>
+  <data name="gsProblemMakingPath" xml:space="preserve">
+    <value>சிக்கல் செய்யும் பாதை</value>
+  </data>
+  <data name="gsProfile" xml:space="preserve">
+    <value>சூழல்</value>
+  </data>
+  <data name="gsProfileMenuHint" xml:space="preserve">
+    <value>வண்டி, கருவி மற்றும் சுற்றுச்சூழல் அமைப்புகள் இப்போது தனி சுயவிவரங்களாக சேமிக்கப்படுகின்றன. 
+கட்டமைப்பு பேனல் &amp; மேல் இடது மெனுவிலிருந்து ஏற்றவும்.</value>
+  </data>
+  <data name="gsProgramWillExitPleaseRestart" xml:space="preserve">
+    <value>நிரல் வெளியேறும் தயவுசெய்து மீண்டும் தொடங்கவும்</value>
+  </data>
+  <data name="gsProportionalGain" xml:space="preserve">
+    <value>விகிதாசார ஆதாயம்</value>
+  </data>
+  <data name="gsQuickAB" xml:space="preserve">
+    <value>விரைவு ஏபி லைன் கிரியேட்டர்</value>
+  </data>
+  <data name="gsRaiseTime" xml:space="preserve">
+    <value>நேரத்தை உயர்த்தவும்</value>
+  </data>
+  <data name="gsRate" xml:space="preserve">
+    <value>மதிப்பிடவும்</value>
+  </data>
+  <data name="gsReallyResetEverything" xml:space="preserve">
+    <value>உண்மையில் எல்லாவற்றையும் மீட்டமைக்கவா?</value>
+  </data>
+  <data name="gsRecord" xml:space="preserve">
+    <value>பதிவு</value>
+  </data>
+  <data name="gsRecordedPathFileIsCorrupt" xml:space="preserve">
+    <value>பதிவுசெய்யப்பட்ட பாதை கோப்பு சிதைந்துள்ளது</value>
+  </data>
+  <data name="gsRecordedPathMenu" xml:space="preserve">
+    <value>பதிவு செய்யப்பட்ட பாதை</value>
+  </data>
+  <data name="gsRecordedPathPicker" xml:space="preserve">
+    <value>பதிவு பாதை சுமை</value>
+  </data>
+  <data name="gsRemain" xml:space="preserve">
+    <value>எஞ்சியிரு</value>
+  </data>
+  <data name="gsRemoveOffset" xml:space="preserve">
+    <value>ஆஃப்செட்டை அகற்று</value>
+  </data>
+  <data name="gsReset" xml:space="preserve">
+    <value>மீட்டமை</value>
+  </data>
+  <data name="gsResetAll" xml:space="preserve">
+    <value>அனைத்தையும் மீட்டமைக்கவும்</value>
+  </data>
+  <data name="gsResetAllForSure" xml:space="preserve">
+    <value>அனைத்தையும் நிச்சயமாக மீட்டமைக்கவா?</value>
+  </data>
+  <data name="gsResume" xml:space="preserve">
+    <value>ரெச்யூம்</value>
+  </data>
+  <data name="gsReverseDistance" xml:space="preserve">
+    <value>தலைகீழ் தூரம்</value>
+  </data>
+  <data name="gsReverseSteer" xml:space="preserve">
+    <value>தலைகீழ் கண்டறிதல்</value>
+  </data>
+  <data name="gsRight" xml:space="preserve">
+    <value>வலது</value>
+  </data>
+  <data name="gsRightMenu" xml:space="preserve">
+    <value>வலது பட்டியல்</value>
+  </data>
+  <data name="gsRollFilter" xml:space="preserve">
+    <value>ரோல் வடிகட்டி</value>
+  </data>
+  <data name="gsS_East" xml:space="preserve">
+    <value>SE</value>
+  </data>
+  <data name="gsS_West" xml:space="preserve">
+    <value>SW</value>
+  </data>
+  <data name="gsSaveAllDone" xml:space="preserve">
+    <value>அனைத்தும் முடிந்தது. இப்போது மூடுகிறது..</value>
+  </data>
+  <data name="gsSaveAndReturn" xml:space="preserve">
+    <value>சேமித்து திரும்பவும்</value>
+  </data>
+  <data name="gsSaveBeerTime" xml:space="preserve">
+    <value>அடுத்த முறை சந்திப்போம்!</value>
+  </data>
+  <data name="gsSaveField" xml:space="preserve">
+    <value>சேமிப்பு புலம்</value>
+  </data>
+  <data name="gsSaveFieldSavedLocal" xml:space="preserve">
+    <value>புலம் உள்நாட்டில் சேமிக்கப்பட்டது.</value>
+  </data>
+  <data name="gsSaveFinalizeShutdown" xml:space="preserve">
+    <value>பணிநிறுத்தத்தை முடிக்கிறது</value>
+  </data>
+  <data name="gsSaveSettings" xml:space="preserve">
+    <value>அமைப்புகளைச் சேமிக்கிறது</value>
+  </data>
+  <data name="gsSaveEnvironmentSettings" xml:space="preserve">
+    <value>சுற்றுச்சூழல் அமைப்புகள்</value>
+  </data>
+  <data name="gsSaveEnvironmentSettingsSaved" xml:space="preserve">
+    <value>சுற்றுச்சூழல் அமைப்புகள் சேமிக்கப்பட்டன.</value>
+  </data>
+  <data name="gsSaveSettingsSaved" xml:space="preserve">
+    <value>அமைப்புகள் சேமிக்கப்பட்டன.</value>
+  </data>
+  <data name="gsSaveVehicleSettings" xml:space="preserve">
+    <value>வாகன அமைப்புகள்</value>
+  </data>
+  <data name="gsSaveVehicleSettingsSaved" xml:space="preserve">
+    <value>வாகன அமைப்புகள் சேமிக்கப்பட்டன.</value>
+  </data>
+  <data name="gsSaveToolSettings" xml:space="preserve">
+    <value>கருவி அமைப்புகள்</value>
+  </data>
+  <data name="gsSaveToolSettingsSaved" xml:space="preserve">
+    <value>கருவி அமைப்புகள் சேமிக்கப்பட்டன.</value>
+  </data>
+  <data name="gsSaveUploadCompleted" xml:space="preserve">
+    <value>பதிவேற்றம் முடிந்தது.</value>
+  </data>
+  <data name="gsSaveUploadFailed" xml:space="preserve">
+    <value>பதிவேற்றம் தோல்வியடைந்தது.</value>
+  </data>
+  <data name="gsSaveUploadToAgshare" xml:space="preserve">
+    <value>AgShare இல் புலத்தைப் பதிவேற்றுகிறது</value>
+  </data>
+  <data name="gsScreenButtons" xml:space="preserve">
+    <value>திரை பொத்தான்கள்</value>
+  </data>
+  <data name="gsSectionColorsSet" xml:space="preserve">
+    <value>பிரிவு வண்ணங்களை அமைக்கவும்</value>
+  </data>
+  <data name="gsSectionLines" xml:space="preserve">
+    <value>பிரிவு கோடுகள்</value>
+  </data>
+  <data name="gsSections" xml:space="preserve">
+    <value>பிரிவுகள்</value>
+  </data>
+  <data name="gsSelectButtons" xml:space="preserve">
+    <value>பொத்தான்களைத் தேர்ந்தெடுக்கவும்</value>
+  </data>
+  <data name="gsSelectPreset" xml:space="preserve">
+    <value>முன்னமைக்கப்பட்ட வண்ணத்தைத் தேர்ந்தெடுக்கவும்</value>
+  </data>
+  <data name="gsSendAndSave" xml:space="preserve">
+    <value>அனுப்பு + சேமி</value>
+  </data>
+  <data name="gsSentToMachineModule" xml:space="preserve">
+    <value>இயந்திர தொகுதிக்கு அனுப்பப்பட்டது</value>
+  </data>
+  <data name="gsSetPoint" xml:space="preserve">
+    <value>செட்பாயிண்ட்</value>
+  </data>
+  <data name="gsShiftGPSPosition" xml:space="preserve">
+    <value>சிபிஎச் நிலையை மாற்றவும்</value>
+  </data>
+  <data name="gsShutdown" xml:space="preserve">
+    <value>பணிநிறுத்தம்</value>
+  </data>
+  <data name="gsShutdownIn" xml:space="preserve">
+    <value>பணிநிறுத்தம்</value>
+  </data>
+  <data name="gsSideHillComp" xml:space="preserve">
+    <value>சைட் இல் ஒரு டிகிரி இழப்பீடு</value>
+  </data>
+  <data name="gsSimpleTramLines" xml:space="preserve">
+    <value>எளிய டிராம்களை உருவாக்குபவர்</value>
+  </data>
+  <data name="gsSimulatorOn" xml:space="preserve">
+    <value>சிமுலேட்டர் ஆன்</value>
+  </data>
+  <data name="gsSingleAntennaSetting" xml:space="preserve">
+    <value>ஒற்றை ஆண்டெனா அமைப்புகள்</value>
+  </data>
+  <data name="gsSlow" xml:space="preserve">
+    <value>மெதுவாக</value>
+  </data>
+  <data name="gsSlowDownBelow" xml:space="preserve">
+    <value>கீழே மெதுவாக</value>
+  </data>
+  <data name="gsSmooth" xml:space="preserve">
+    <value>மென்மையானது</value>
+  </data>
+  <data name="gsSmoothABCurve" xml:space="preserve">
+    <value>மென்மையான ஏபி வளைவு</value>
+  </data>
+  <data name="gsSort" xml:space="preserve">
+    <value>வரிசைப்படுத்து</value>
+  </data>
+  <data name="gsSound" xml:space="preserve">
+    <value>ஒலிகள்</value>
+  </data>
+  <data name="gsSouth" xml:space="preserve">
+    <value>தெற்கு</value>
+  </data>
+  <data name="gsSpacing" xml:space="preserve">
+    <value>இடைவெளி</value>
+  </data>
+  <data name="gsSpeedFactor" xml:space="preserve">
+    <value>வேக காரணி</value>
+  </data>
+  <data name="gsSpeedo" xml:space="preserve">
+    <value>ச்பீடோ</value>
+  </data>
+  <data name="gsStart" xml:space="preserve">
+    <value>தொடங்கு</value>
+  </data>
+  <data name="gsStartDeleteABoundary" xml:space="preserve">
+    <value>ஒரு எல்லையைத் தொடங்கவும் அல்லது நீக்கவும்</value>
+  </data>
+  <data name="gsStartFullscreen" xml:space="preserve">
+    <value>முழுத்திரையைத் தொடங்கவும்</value>
+  </data>
+  <data name="gsStartNewField" xml:space="preserve">
+    <value>புதிய களத்தைத் தொடங்கவும்</value>
+  </data>
+  <data name="gsStatus" xml:space="preserve">
+    <value>நிலை</value>
+  </data>
+  <data name="gsSteerAngle" xml:space="preserve">
+    <value>திசைமாற்றி கோணம்</value>
+  </data>
+  <data name="gsSteerBar" xml:space="preserve">
+    <value>ச்டீயரிங் பார்</value>
+  </data>
+  <data name="gsSteerChart" xml:space="preserve">
+    <value>திசைமாற்றி விளக்கப்படங்கள்</value>
+  </data>
+  <data name="gsSteerEnable" xml:space="preserve">
+    <value>வெளிப்புற இயக்கு</value>
+  </data>
+  <data name="gsSteerInReverse" xml:space="preserve">
+    <value>தலைகீழாக இருக்கும் போது திசை திருப்பவும்</value>
+  </data>
+  <data name="gsSteerResponse" xml:space="preserve">
+    <value>பதிலைத் திசை திருப்பவும்</value>
+  </data>
+  <data name="gsSteerSwitch" xml:space="preserve">
+    <value>திசைமாற்றி சுவிட்ச்</value>
+  </data>
+  <data name="gsSteerWizard" xml:space="preserve">
+    <value>ஓட்டும் வழிகாட்டி</value>
+  </data>
+  <data name="gsStopRecordPauseBoundary" xml:space="preserve">
+    <value>நிறுத்து பதிவு இடைநிறுத்த எல்லை</value>
+  </data>
+  <data name="gsSvennArrow" xml:space="preserve">
+    <value>ச்வென் அம்பு</value>
+  </data>
+  <data name="gsSwitch" xml:space="preserve">
+    <value>ஆளி, நிலைமாறி</value>
+  </data>
+  <data name="gsSwitchDescription" xml:space="preserve">
+    <value>புச் ஆன், ரிலீச் ஆஃப்</value>
+  </data>
+  <data name="gsTerms" xml:space="preserve">
+    <value>AgOpenGPS என்பது வழிகாட்டுதல் அமைப்புகள், சிபிஎச் வாக்கியங்கள் மற்றும் இயந்திரக் கட்டுப்பாட்டின் தத்துவார்த்த பயன்பாடு பற்றி அறிய கண்டிப்பாக கல்வி மென்பொருள் ஆகும். 
+
+எந்த சூழ்நிலையிலும் உண்மையான உபகரணங்களில் இதைப் பயன்படுத்த முடியாது. இயந்திர வழிகாட்டுதலைப் பாதுகாப்பாக அனுபவிக்க மாணவர் அனுமதிக்க சிமுலேட்டர் வழங்கப்படுகிறது. 
+
+மென்பொருளில் பாதுகாப்பு அமைப்புகள் எதுவும் இல்லை மற்றும் எதுவும் குறிப்பிடப்படவில்லை. 
+
+சொந்த ஆபத்தில் பயன்படுத்தவும்.</value>
+  </data>
+  <data name="gsTermsConditions" xml:space="preserve">
+    <value>விதிமுறைகள் மற்றும் நிபந்தனைகள்</value>
+  </data>
+  <data name="gsToFile" xml:space="preserve">
+    <value>கோப்புக்கு</value>
+  </data>
+  <data name="gsTooFast" xml:space="preserve">
+    <value>மிக வேகமாக</value>
+  </data>
+  <data name="gsToolLeft" xml:space="preserve">
+    <value>கருவி இடது</value>
+  </data>
+  <data name="gsToolOffset" xml:space="preserve">
+    <value>கருவி ஆஃப்செட் திசை</value>
+  </data>
+  <data name="gsToolRight" xml:space="preserve">
+    <value>கருவி சரி</value>
+  </data>
+  <data name="gsToolsMenu" xml:space="preserve">
+    <value>கருவிகள் பட்டியல்</value>
+  </data>
+  <data name="gsTotal" xml:space="preserve">
+    <value>மொத்தம்</value>
+  </data>
+  <data name="gsTrack" xml:space="preserve">
+    <value>மின்தடம்</value>
+  </data>
+  <data name="gsTracks" xml:space="preserve">
+    <value>தடங்கள்</value>
+  </data>
+  <data name="gsTramLines" xml:space="preserve">
+    <value>டிராம் கோடுகள்</value>
+  </data>
+  <data name="gsTramWidth" xml:space="preserve">
+    <value>டிராம் அகலம்</value>
+  </data>
+  <data name="gsTurnABCurveOn" xml:space="preserve">
+    <value>ஏபி வளைவை இயக்கவும்</value>
+  </data>
+  <data name="gsTurnOffDelay" xml:space="preserve">
+    <value>தாமதத்தை முடக்கு</value>
+  </data>
+  <data name="gsTurnOffRecordedPath" xml:space="preserve">
+    <value>ரெக்-பாத்தை அணைக்கவும்</value>
+  </data>
+  <data name="gsTurnOnContourOrMakeABLine" xml:space="preserve">
+    <value>மேக் ஏபி லைனின் விளிம்பை இயக்கவும்</value>
+  </data>
+  <data name="gsTurnSensor" xml:space="preserve">
+    <value>சென்சார் திருப்பு</value>
+  </data>
+  <data name="gsUnits" xml:space="preserve">
+    <value>அலகுகள்</value>
+  </data>
+  <data name="gsUseSelected" xml:space="preserve">
+    <value>தேர்ந்தெடுக்கப்பட்டதைப் பயன்படுத்தவும்</value>
+  </data>
+  <data name="gsUserNo" xml:space="preserve">
+    <value>பயனர்</value>
+  </data>
+  <data name="gsUturn" xml:space="preserve">
+    <value>யு-டர்ன்</value>
+  </data>
+  <data name="gsUturnCompensation" xml:space="preserve">
+    <value>யு-டர்ன் இழப்பீடு</value>
+  </data>
+  <data name="gsUturnExtension" xml:space="preserve">
+    <value>நீட்டிப்பு நீளத்தை 2 அல்லது 3x ஆரம் அமைக்கவும்</value>
+  </data>
+  <data name="gsUturnSmooth" xml:space="preserve">
+    <value>ச்மூத்திங் 3-4x ஆரம் அமைக்கவும்</value>
+  </data>
+  <data name="gsVehiclegroupbox" xml:space="preserve">
+    <value>வாகன வகை</value>
+  </data>
+  <data name="gsVersion" xml:space="preserve">
+    <value>பதிப்பு</value>
+  </data>
+  <data name="gsWasZero" xml:space="preserve">
+    <value>பூச்சியமாக இருந்தது</value>
+  </data>
+  <data name="gsSmartWAS" xml:space="preserve">
+    <value>அறிவுள்ள இருந்தது</value>
+  </data>
+  <data name="gsSmartWASHelp" xml:space="preserve">
+    <value>வண்டி ஓட்டும் போது வழிகாட்டுதல் திசைமாற்றி கோணங்களை பகுப்பாய்வு செய்வதன் மூலம் பூச்சியத்தை தானாக அளவீடு செய்கிறது. ஆட்டோச்டீரை இயக்கி, பாதையில் சீராக ஓட்டவும்.</value>
+  </data>
+  <data name="gsWebCam" xml:space="preserve">
+    <value>வெப்கேம்</value>
+  </data>
+  <data name="gsWest" xml:space="preserve">
+    <value>மேற்கு</value>
+  </data>
+  <data name="gsWheelbase" xml:space="preserve">
+    <value>வீல்பேச்</value>
+  </data>
+  <data name="gsWidth" xml:space="preserve">
+    <value>அகலம்</value>
+  </data>
+  <data name="gsWindowsStillOpen" xml:space="preserve">
+    <value>சாளரங்கள் இன்னும் திறந்திருக்கும்</value>
+  </data>
+  <data name="gsWizard" xml:space="preserve">
+    <value>மந்திரவாதி</value>
+  </data>
+  <data name="gsWizards" xml:space="preserve">
+    <value>மந்திரவாதிகள்</value>
+  </data>
+  <data name="gsWorkSwitch" xml:space="preserve">
+    <value>வேலை மாறுதல்</value>
+  </data>
+  <data name="gsWorkWidth" xml:space="preserve">
+    <value>அகலம்</value>
+  </data>
+  <data name="gsWorked" xml:space="preserve">
+    <value>பணியாற்றினார்</value>
+  </data>
+  <data name="gsXTEChart" xml:space="preserve">
+    <value>XTE ஆர்ட்</value>
+  </data>
+  <data name="gsYouTubeTutorials" xml:space="preserve">
+    <value>YouTube பயிற்சிகள்</value>
+  </data>
+  <data name="gsZeroRoll" xml:space="preserve">
+    <value>சீரோ ரோல்</value>
+  </data>
+  <data name="gsZone" xml:space="preserve">
+    <value>மண்டலம்</value>
+  </data>
+  <data name="gsZones" xml:space="preserve">
+    <value>மண்டலங்கள்</value>
+  </data>
+  <data name="gsZoomIn" xml:space="preserve">
+    <value>பெரிதாக்கு</value>
+  </data>
+  <data name="gsCurrentVehicle" xml:space="preserve">
+    <value>தற்போதைய வண்டி</value>
+  </data>
+  <data name="gsCurrentTool" xml:space="preserve">
+    <value>தற்போதைய கருவி</value>
+  </data>
+  <data name="gsSelected" xml:space="preserve">
+    <value>தேர்ந்தெடுக்கப்பட்டது</value>
+  </data>
+  <data name="gsAntennaPivot" xml:space="preserve">
+    <value>ஆண்டெனா பிவோட்</value>
+  </data>
+  <data name="gsTrackWidth" xml:space="preserve">
+    <value>தட அகலம்</value>
+  </data>
+  <data name="gsAttach" xml:space="preserve">
+    <value>இணைக்கவும்</value>
+  </data>
+  <data name="gsTrailingHitch" xml:space="preserve">
+    <value>டிரெயிலிங் இட்ச்</value>
+  </data>
+  <data name="gsType" xml:space="preserve">
+    <value>வகை</value>
+  </data>
+  <data name="gsHitch" xml:space="preserve">
+    <value>இட்ச்</value>
+  </data>
+  <data name="gsVehicle" xml:space="preserve">
+    <value>வண்டி</value>
+  </data>
+  <data name="gsTool" xml:space="preserve">
+    <value>கருவி</value>
+  </data>
+  <data name="gsTractor" xml:space="preserve">
+    <value>டிராக்டர்</value>
+  </data>
+  <data name="gsHarvester" xml:space="preserve">
+    <value>அறுவடை செய்பவர்</value>
+  </data>
+  <data name="gsArticulated" xml:space="preserve">
+    <value>வெளிப்படுத்தப்பட்டது</value>
+  </data>
+  <data name="gsFront" xml:space="preserve">
+    <value>முன்</value>
+  </data>
+  <data name="gsTBT" xml:space="preserve">
+    <value>TBT</value>
+  </data>
+  <data name="gsRearFixed" xml:space="preserve">
+    <value>பின்புறம் சரி செய்யப்பட்டது</value>
+  </data>
+  <data name="gsTrailing" xml:space="preserve">
+    <value>பின்தொடர்தல்</value>
+  </data>
+  <data name="gsVehicleInUse" xml:space="preserve">
+    <value>பயன்பாட்டில் உள்ள வண்டி</value>
+  </data>
+  <data name="gsCannotDeleteActiveVehicle" xml:space="preserve">
+    <value>செயலில் உள்ள வாகனத்தை நீக்க முடியாது</value>
+  </data>
+  <data name="gsDeleteVehicleConfirm" xml:space="preserve">
+    <value>வாகனத்தை நீக்கு</value>
+  </data>
+  <data name="gsRenameVehicle" xml:space="preserve">
+    <value>வாகனத்தின் பெயரை மாற்றவும்</value>
+  </data>
+  <data name="gsEnterNewVehicleName" xml:space="preserve">
+    <value>புதிய வாகனத்தின் பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsVehicleExists" xml:space="preserve">
+    <value>வண்டி ஏற்கனவே உள்ளது</value>
+  </data>
+  <data name="gsToolInUse" xml:space="preserve">
+    <value>பயன்பாட்டில் உள்ள கருவி</value>
+  </data>
+  <data name="gsCannotDeleteActiveTool" xml:space="preserve">
+    <value>செயலில் உள்ள கருவியை நீக்க முடியாது</value>
+  </data>
+  <data name="gsDeleteToolConfirm" xml:space="preserve">
+    <value>நீக்கு கருவி</value>
+  </data>
+  <data name="gsRenameTool" xml:space="preserve">
+    <value>கருவியை மறுபெயரிடவும்</value>
+  </data>
+  <data name="gsEnterNewToolName" xml:space="preserve">
+    <value>புதிய கருவி பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsToolExists" xml:space="preserve">
+    <value>கருவி ஏற்கனவே உள்ளது</value>
+  </data>
+  <data name="gsErrorLoadingVehicle" xml:space="preserve">
+    <value>வாகனத்தை ஏற்றுவதில் பிழை</value>
+  </data>
+  <data name="gsErrorLoadingTool" xml:space="preserve">
+    <value>கருவியை ஏற்றுவதில் பிழை</value>
+  </data>
+  <data name="gsFileResult" xml:space="preserve">
+    <value>முடிவு</value>
+  </data>
+  <data name="gsNewVehicle" xml:space="preserve">
+    <value>புதிய வண்டி</value>
+  </data>
+  <data name="gsEnterVehicleName" xml:space="preserve">
+    <value>வாகனத்தின் பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsNewTool" xml:space="preserve">
+    <value>புதிய கருவி</value>
+  </data>
+  <data name="gsEnterToolName" xml:space="preserve">
+    <value>கருவியின் பெயரை உள்ளிடவும்</value>
+  </data>
+  <data name="gsCreateDefaultVehicle" xml:space="preserve">
+    <value>இயல்புநிலை வாகனத்தை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCreateDefaultVehicleConfirm" xml:space="preserve">
+    <value>தொழிற்சாலை அமைப்புகளுடன் 'இயல்புநிலை' வாகன சுயவிவரத்தை உருவாக்கவா?</value>
+  </data>
+  <data name="gsOverwrite" xml:space="preserve">
+    <value>மேலெழுதவும்</value>
+  </data>
+  <data name="gsProfileExistsOverwrite" xml:space="preserve">
+    <value>சுயவிவரம் ஏற்கனவே உள்ளது. மேலெழுதவும்</value>
+  </data>
+  <data name="gsCreateDefaultTool" xml:space="preserve">
+    <value>இயல்புநிலை கருவியை உருவாக்கவும்</value>
+  </data>
+  <data name="gsCreateDefaultToolConfirm" xml:space="preserve">
+    <value>தொழிற்சாலை அமைப்புகளுடன் 'இயல்புநிலை' கருவி சுயவிவரத்தை உருவாக்கவா?</value>
+  </data>
+  <data name="gsDefaultVehicleLoaded" xml:space="preserve">
+    <value>இயல்புநிலை வண்டி ஏற்றப்பட்டது</value>
+  </data>
+  <data name="gsDefaultToolLoaded" xml:space="preserve">
+    <value>இயல்புநிலை கருவி ஏற்றப்பட்டது</value>
+  </data>
+  <data name="gsConvertOldProfiles" xml:space="preserve">
+    <value>பழைய சுயவிவரங்களை மாற்றவும்</value>
+  </data>
+  <data name="gsVehicleTool" xml:space="preserve">
+    <value>வண்டி / கருவி</value>
+  </data>
+  <data name="gsConvertOldProfilesTitle" xml:space="preserve">
+    <value>பழைய சுயவிவர கோப்புகளை புதிய வடிவத்திற்கு மாற்றவும்</value>
+  </data>
+  <data name="gsConvertProfilesExplanation" xml:space="preserve">
+    <value>பழைய சுயவிவரங்கள் ஒரே கோப்பில் அனைத்து அமைப்புகளையும் கொண்டிருந்தன. புதிய வடிவம் வண்டி, கருவி மற்றும் சுற்றுச்சூழல் ஆகியவற்றைப் பிரிக்கிறது. நீங்கள் பிரித்தெடுக்க விரும்புவதைத் தேர்ந்தெடுக்கவும்.</value>
+  </data>
+  <data name="gsConvertStep1" xml:space="preserve">
+    <value>படி 1</value>
+  </data>
+  <data name="gsConvertStep2" xml:space="preserve">
+    <value>படி 2</value>
+  </data>
+  <data name="gsVehicleProfileName" xml:space="preserve">
+    <value>வாகன சுயவிவரப் பெயர்</value>
+  </data>
+  <data name="gsToolProfileName" xml:space="preserve">
+    <value>கருவி சுயவிவரப் பெயர்</value>
+  </data>
+  <data name="gsImportVehicle" xml:space="preserve">
+    <value>இறக்குமதி வண்டி</value>
+  </data>
+  <data name="gsImportTool" xml:space="preserve">
+    <value>இறக்குமதி கருவி</value>
+  </data>
+  <data name="gsNoImport" xml:space="preserve">
+    <value>இறக்குமதி இல்லை</value>
+  </data>
+  <data name="gsNoOldFormatFiles" xml:space="preserve">
+    <value>பழைய வடிவமைப்பு கோப்புகள் எதுவும் இல்லை.</value>
+  </data>
+  <data name="gsOldFiles" xml:space="preserve">
+    <value>பழைய கோப்புகள்</value>
+  </data>
+  <data name="gsOldFilesStatus" xml:space="preserve">
+    <value>பழைய கோப்பு(கள்): மாற்றப்பட்டது, மாற்றுவதற்கு</value>
+  </data>
+  <data name="gsConverted" xml:space="preserve">
+    <value>மாற்றப்பட்டது</value>
+  </data>
+  <data name="gsToConvert" xml:space="preserve">
+    <value>மாற்ற வேண்டும்</value>
+  </data>
+  <data name="gsConvertTitle" xml:space="preserve">
+    <value>மாற்றவும்</value>
+  </data>
+  <data name="gsConvertConfirm" xml:space="preserve">
+    <value>மாற்றத்தை உறுதிப்படுத்தவும்</value>
+  </data>
+  <data name="gsConvertConfirmMsg" xml:space="preserve">
+    <value>'{0}' ஐ மாற்று: {1} {2}</value>
+  </data>
+  <data name="gsConvertFrom" xml:space="preserve">
+    <value>மாற்றவும்</value>
+  </data>
+  <data name="gsConvertVehicleLine" xml:space="preserve">
+    <value>வண்டி</value>
+  </data>
+  <data name="gsConvertToolLine" xml:space="preserve">
+    <value>கருவி</value>
+  </data>
+  <data name="gsConversionComplete" xml:space="preserve">
+    <value>மாற்றம் முடிந்தது</value>
+  </data>
+  <data name="gsConvertedSuccess" xml:space="preserve">
+    <value>வெற்றிகரமாக மாற்றப்பட்டது</value>
+  </data>
+  <data name="gsEnvironmentMigratedLoaded" xml:space="preserve">
+    <value>சுற்றுச்சூழல் அமைப்புகள் இறக்குமதி செய்யப்பட்டு ஏற்றப்பட்டன.</value>
+  </data>
+  <data name="gsConversionErrors" xml:space="preserve">
+    <value>மாற்று பிழைகள்</value>
+  </data>
+  <data name="gsConversionErrorMsg" xml:space="preserve">
+    <value>பிழைகள் ஏற்பட்டன</value>
+  </data>
+  <data name="gsLoadVehicleTool" xml:space="preserve">
+    <value>ஏற்றும் வாகனம்/கருவி</value>
+  </data>
+  <data name="gsExists" xml:space="preserve">
+    <value>உள்ளது</value>
+  </data>
+  <data name="gsFileName" xml:space="preserve">
+    <value>கோப்பு பெயர்</value>
+  </data>
+  <data name="gsRename" xml:space="preserve">
+    <value>மறுபெயரிடவும்</value>
+  </data>
+  <data name="gsVehicleAlreadyExists" xml:space="preserve">
+    <value>வண்டி ஏற்கனவே உள்ளது</value>
+  </data>
+  <data name="gsToolAlreadyExists" xml:space="preserve">
+    <value>கருவி ஏற்கனவே உள்ளது</value>
+  </data>
+  <data name="v_AboutIntro" xml:space="preserve">
+    <value>https://www.youtube.com/watch?v=iN2cZ8avHag</value>
+  </data>
 </root>

--- a/SourceCode/AgOpenGPS.Core/Translations/gStr.vi.resx
+++ b/SourceCode/AgOpenGPS.Core/Translations/gStr.vi.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SourceCode/GPS/Classes/AgShare/Helpers/FieldParser.cs
+++ b/SourceCode/GPS/Classes/AgShare/Helpers/FieldParser.cs
@@ -45,7 +45,11 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                 Origin = origin
             };
 
-            var converter = new GeoConverter(origin.Latitude, origin.Longitude);
+            // Use LocalPlane.ConvertWgs84ToGeoCoord: it is the exact analytic inverse of the
+            // uploader's LocalPlane.ConvertGeoCoordToWgs84 (both evaluate metersPerDegreeLon at
+            // the point's own latitude). The old GeoConverter evaluated it at the origin latitude,
+            // which introduced a systematic east-axis shear on the upload->download round trip.
+            var converter = new LocalPlane(origin, new SharedFieldProperties());
 
             // Parse boundaries directly to CBoundaryList
             if (dto.Boundaries != null)
@@ -68,7 +72,7 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                             continue;
                         }
 
-                        var local = converter.ToLocal(wgs.Latitude, wgs.Longitude);
+                        var local = converter.ConvertWgs84ToGeoCoord(wgs);
                         bnd.fenceLine.Add(new vec3(local.Easting, local.Northing, 0.0));
                     }
 
@@ -104,8 +108,8 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                         continue;
                     }
 
-                    var vA = converter.ToLocal(wgsA.Latitude, wgsA.Longitude);
-                    var vB = converter.ToLocal(wgsB.Latitude, wgsB.Longitude);
+                    var vA = converter.ConvertWgs84ToGeoCoord(wgsA);
+                    var vB = converter.ConvertWgs84ToGeoCoord(wgsB);
                     var ptA = new vec3(vA.Easting, vA.Northing, 0);
                     var ptB = new vec3(vB.Easting, vB.Northing, 0);
                     bool isCurve = ab.Coords.Count > 2;
@@ -134,7 +138,7 @@ namespace AgOpenGPS.Classes.AgShare.Helpers
                             var wgs = new Wgs84(p.Latitude, p.Longitude);
                             if (!wgs.IsValid) continue;
 
-                            var local = converter.ToLocal(wgs.Latitude, wgs.Longitude);
+                            var local = converter.ConvertWgs84ToGeoCoord(wgs);
                             localPts.Add(new vec3(local.Easting, local.Northing, 0));
                         }
 

--- a/SourceCode/GPS/Classes/CFenceLine.cs
+++ b/SourceCode/GPS/Classes/CFenceLine.cs
@@ -156,7 +156,6 @@ namespace AgOpenGPS
         //obvious
         public bool CalculateFenceArea(int idx, bool cleanIntersections = true)
         {
-            Debug.WriteLine("CalculateFenceArea is Called");
             if (cleanIntersections) RemoveSelfIntersections();
             int ptCount = fenceLine.Count;
             if (ptCount < 3) return false; // Need at least 3 points for a valid boundary

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -2067,9 +2067,11 @@ namespace AgOpenGPS
                         //clear the section lists
                         for (int j = 0; j < triStrip.Count; j++)
                         {
-                            //clean out the lists
+                            //clean out the lists and reset drawing state
                             triStrip[j].patchList?.Clear();
                             triStrip[j].triangleList?.Clear();
+                            triStrip[j].isDrawing = false;  // Reset drawing state to prevent ISOBUS race condition
+                            triStrip[j].numTriangles = 0;
                         }
                         patchSaveList?.Clear();
 

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -1648,6 +1648,13 @@ namespace AgOpenGPS
         }
         private void simulatorOnToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            // Once SIM has been disabled this session, it stays disabled until app restart.
+            if (isSimDisabledLocked)
+            {
+                simulatorOnToolStripMenuItem.Checked = false;
+                simulatorOnToolStripMenuItem.Enabled = false;
+                return;
+            }
             if (isJobStarted)
             {
                 TimedMessageBox(2000, gStr.gsFieldIsOpen, gStr.gsCloseFieldFirst);
@@ -2301,6 +2308,14 @@ namespace AgOpenGPS
         double lastSimGuidanceAngle = 0;
         private void timerSim_Tick(object sender, EventArgs e)
         {
+            // Hard lock: if SIM was ever disabled in this session, kill the timer and bail.
+            // Prevents rogue sim ticks from overwriting pn.fix with sim coords while live GNSS is active.
+            if (isSimDisabledLocked)
+            {
+                timerSim.Enabled = false;
+                return;
+            }
+
             if (recPath.isDrivingRecordedPath || isBtnAutoSteerOn && (guidanceLineDistanceOff != 32000))
             {
                 if (vehicle.isInDeadZone)

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -1286,9 +1286,11 @@ namespace AgOpenGPS
             //clear the section lists
             for (int j = 0; j < triStrip.Count; j++)
             {
-                //clean out the lists
+                //clean out the lists and reset drawing state
                 triStrip[j].patchList?.Clear();
                 triStrip[j].triangleList?.Clear();
+                triStrip[j].isDrawing = false;  // Reset drawing state
+                triStrip[j].numTriangles = 0;
             }
 
             triStrip?.Clear();

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -537,6 +537,46 @@ namespace AgOpenGPS
 
             hotkeys = Properties.Settings.Default.setKey_hotkeys.ToCharArray();
 
+            if (RegistrySettings.vehicleProfileLoadResult == AgLibrary.Settings.LoadResult.Failed ||
+                RegistrySettings.toolProfileLoadResult == AgLibrary.Settings.LoadResult.Failed)
+            {
+                string vehicleMsg = RegistrySettings.vehicleProfileLoadResult == AgLibrary.Settings.LoadResult.Failed
+                    ? $"Vehicle '{RegistrySettings.vehicleProfileName}'"
+                    : null;
+                string toolMsg = RegistrySettings.toolProfileLoadResult == AgLibrary.Settings.LoadResult.Failed
+                    ? $"Tool '{RegistrySettings.toolProfileName}'"
+                    : null;
+
+                string corrupted = vehicleMsg != null && toolMsg != null
+                    ? vehicleMsg + " and " + toolMsg
+                    : vehicleMsg ?? toolMsg;
+
+                TimedMessageBox(
+                    10000,
+                    "Profile Load Warning",
+                    corrupted + " profile could not be fully loaded (file may be corrupt).\r\n" +
+                    "Current session is using defaults for missing/invalid values.");
+            }
+
+            if (RegistrySettings.vehicleProfileLoadedFromBackup || RegistrySettings.toolProfileLoadedFromBackup)
+            {
+                string vehicleMsg = RegistrySettings.vehicleProfileLoadedFromBackup
+                    ? $"Vehicle '{RegistrySettings.vehicleProfileName}'"
+                    : null;
+                string toolMsg = RegistrySettings.toolProfileLoadedFromBackup
+                    ? $"Tool '{RegistrySettings.toolProfileName}'"
+                    : null;
+
+                string recovered = vehicleMsg != null && toolMsg != null
+                    ? vehicleMsg + " and " + toolMsg
+                    : vehicleMsg ?? toolMsg;
+
+                TimedMessageBox(
+                    10000,
+                    "Profile Recovery",
+                    recovered + " profile was recovered from .last backup because the main file was unreadable.");
+            }
+
             // Check if any profile is missing (registry empty OR file doesn't exist)
             bool missingVehicle = string.IsNullOrEmpty(RegistrySettings.vehicleProfileName) ||
                                    !File.Exists(Path.Combine(RegistrySettings.vehiclesDirectory, RegistrySettings.vehicleProfileName + ".xml"));
@@ -769,9 +809,17 @@ namespace AgOpenGPS
                     try
                     {
                         // Save Vehicle Settings
-                        Properties.VehicleSettings.Default.Save();
-                        await Task.Delay(100);
-                        savingForm.UpdateStep("Vehicle", gStr.gsSaveVehicleSettingsSaved, SavingStepState.Done);
+                        if (RegistrySettings.vehicleProfileLoadResult == AgLibrary.Settings.LoadResult.Ok)
+                        {
+                            Properties.VehicleSettings.Default.Save();
+                            await Task.Delay(100);
+                            savingForm.UpdateStep("Vehicle", gStr.gsSaveVehicleSettingsSaved, SavingStepState.Done);
+                        }
+                        else
+                        {
+                            Log.EventWriter($"Vehicle settings save skipped: profile load state is {RegistrySettings.vehicleProfileLoadResult}");
+                            savingForm.UpdateStep("Vehicle", "Vehicle settings save skipped (profile not loaded)", SavingStepState.Failed);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -782,9 +830,17 @@ namespace AgOpenGPS
                     try
                     {
                         // Save Tool Settings
-                        Properties.ToolSettings.Default.Save();
-                        await Task.Delay(100);
-                        savingForm.UpdateStep("Tool", gStr.gsSaveToolSettingsSaved, SavingStepState.Done);
+                        if (RegistrySettings.toolProfileLoadResult == AgLibrary.Settings.LoadResult.Ok)
+                        {
+                            Properties.ToolSettings.Default.Save();
+                            await Task.Delay(100);
+                            savingForm.UpdateStep("Tool", gStr.gsSaveToolSettingsSaved, SavingStepState.Done);
+                        }
+                        else
+                        {
+                            Log.EventWriter($"Tool settings save skipped: profile load state is {RegistrySettings.toolProfileLoadResult}");
+                            savingForm.UpdateStep("Tool", "Tool settings save skipped (profile not loaded)", SavingStepState.Failed);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -259,8 +259,8 @@ namespace AgOpenGPS
                     lblCurrentField.Text = "\u25B6" + " " + lblCurrentField.Text;
                 }
 
-                //fix
-                if (timerSim.Enabled && pn.fixQuality++ > 5) pn.fixQuality = 2;
+                //fix - only cycle fake quality while SIM is genuinely the active source
+                if (timerSim.Enabled && !isSimDisabledLocked && pn.fixQuality++ > 5) pn.fixQuality = 2;
 
                 fileSaveAlwaysCounter += 3;
             }

--- a/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -1282,7 +1282,9 @@ namespace AgOpenGPS
                 mc.CheckWorkAndSteerSwitch();
 
             // Check ISOBUS for actual section states
-            if (isobus.IsAlive())
+            // Only override if TC has active clients with section control capability (numberOfSections > 0)
+            // For 0-section implements, let AOG control sections normally
+            if (isobus.IsAlive() && isobus.HasActiveClients)
             {
                 for (int j = 0; j < tool.numOfSections; j++)
                 {

--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -14,6 +14,10 @@ namespace AgOpenGPS
         //very first fix to setup grid etc
         public bool isFirstFixPositionSet = false, isGPSPositionInitialized = false, isFirstHeadingSet = false,
             isReverse = false, isSteerInReverse = true, isSuperSlow = false;
+
+        // Sticky lock: once SIM is disabled in this session (either by live fix arriving or by user),
+        // it can never be re-enabled until the app is restarted. Sim uit = Sim uit.
+        public bool isSimDisabledLocked = false;
         public double startGPSHeading = 0;
 
         //string to record fixes for elevation maps

--- a/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
+++ b/SourceCode/GPS/Forms/Profiles/FormLoadVehicleTool.cs
@@ -67,10 +67,12 @@ namespace AgOpenGPS.Forms.Profiles
         private void UpdateCurrentLabels()
         {
             lblCurrentVehicle.Text = !string.IsNullOrEmpty(RegistrySettings.vehicleProfileName)
-                ? gStr.gsCurrentVehicle + ": " + RegistrySettings.vehicleProfileName
+                ? gStr.gsCurrentVehicle + ": " + RegistrySettings.vehicleProfileName +
+                  (RegistrySettings.vehicleProfileLoadResult == LoadResult.Ok ? "" : " (load failed)")
                 : gStr.gsCurrentVehicle + ": " + gStr.gsNone;
             lblCurrentTool.Text = !string.IsNullOrEmpty(RegistrySettings.toolProfileName)
-                ? gStr.gsCurrentTool + ": " + RegistrySettings.toolProfileName
+                ? gStr.gsCurrentTool + ": " + RegistrySettings.toolProfileName +
+                  (RegistrySettings.toolProfileLoadResult == LoadResult.Ok ? "" : " (load failed)")
                 : gStr.gsCurrentTool + ": " + gStr.gsNone;
         }
 

--- a/SourceCode/GPS/Forms/UDPComm.Designer.cs
+++ b/SourceCode/GPS/Forms/UDPComm.Designer.cs
@@ -351,6 +351,9 @@ namespace AgOpenGPS
             panelSim.Visible = false;
             timerSim.Enabled = false;
             simulatorOnToolStripMenuItem.Checked = false;
+            // Lock SIM off for the rest of this session — no runtime path may re-enable.
+            isSimDisabledLocked = true;
+            simulatorOnToolStripMenuItem.Enabled = false;
             Properties.Settings.Default.setMenu_isSimulatorOn = simulatorOnToolStripMenuItem.Checked;
             Properties.Settings.Default.Save();
             return;

--- a/SourceCode/GPS/IO/SectionFiles.cs
+++ b/SourceCode/GPS/IO/SectionFiles.cs
@@ -32,6 +32,15 @@ namespace AgOpenGPS.IO
                     var patch = FileIoUtils.ReadVec3Block(reader, verts);
                     if (patch.Count > 0)
                     {
+                        // Ensure patch has odd vertex count (first vertex is RGB color, rest are coordinates)
+                        // If even, it means the color vertex is missing, so prepend a default color
+                        if (patch.Count % 2 == 0)
+                        {
+                            // The first line was likely a coordinate misinterpreted as color
+                            // Insert default color at the beginning
+                            var colorVec = new vec3(27, 151, 160); // Default teal color
+                            patch.Insert(0, colorVec);
+                        }
                         result.Add(patch);
                     }
                 }

--- a/SourceCode/GPS/Properties/RegistrySettings.cs
+++ b/SourceCode/GPS/Properties/RegistrySettings.cs
@@ -1,4 +1,5 @@
 ﻿using AgLibrary.Logging;
+using AgLibrary.Settings;
 using AgOpenGPS.Forms;
 using Microsoft.Win32;
 using System;
@@ -41,6 +42,11 @@ namespace AgOpenGPS
         public static string baseDirectory;
         public static string fieldsDirectory;
         public static string environmentDirectory;
+
+        public static LoadResult vehicleProfileLoadResult = LoadResult.MissingFile;
+        public static LoadResult toolProfileLoadResult = LoadResult.MissingFile;
+        public static bool vehicleProfileLoadedFromBackup = false;
+        public static bool toolProfileLoadedFromBackup = false;
 
         // Indicates if migration from legacy single profile is needed
         public static bool NeedsMigration { get; private set; }
@@ -137,14 +143,24 @@ namespace AgOpenGPS
             // Load Vehicle settings if vehicleProfileName is set
             if (!string.IsNullOrEmpty(vehicleProfileName))
             {
-                Properties.VehicleSettings.Default.Load(vehicleProfileName);
+                vehicleProfileLoadResult = Properties.VehicleSettings.Default.Load(vehicleProfileName);
+                if (vehicleProfileLoadResult != LoadResult.Ok)
+                {
+                    Log.EventWriter($"Vehicle profile load failed: {vehicleProfileName} ({vehicleProfileLoadResult})");
+                }
             }
+            else vehicleProfileLoadResult = LoadResult.MissingFile;
 
             // Load Tool settings if toolProfileName is set
             if (!string.IsNullOrEmpty(toolProfileName))
             {
-                Properties.ToolSettings.Default.Load(toolProfileName);
+                toolProfileLoadResult = Properties.ToolSettings.Default.Load(toolProfileName);
+                if (toolProfileLoadResult != LoadResult.Ok)
+                {
+                    Log.EventWriter($"Tool profile load failed: {toolProfileName} ({toolProfileLoadResult})");
+                }
             }
+            else toolProfileLoadResult = LoadResult.MissingFile;
         }
 
         public static void Save(string name, string value)

--- a/SourceCode/GPS/Properties/ToolSettings.cs
+++ b/SourceCode/GPS/Properties/ToolSettings.cs
@@ -126,6 +126,23 @@ namespace AgOpenGPS.Properties
         {
             string path = Path.Combine(RegistrySettings.toolsDirectory, toolFileName + ".xml");
             var result = XmlSettingsHandler.LoadXMLFile(path, this);
+            bool loadedFromBackup = false;
+
+            // Fallback to last known good backup when current profile is missing/corrupt.
+            if (result == LoadResult.Failed || result == LoadResult.MissingFile)
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                if (File.Exists(backupPath))
+                {
+                    var backupResult = XmlSettingsHandler.LoadXMLFile(backupPath, this);
+                    if (backupResult == LoadResult.Ok)
+                    {
+                        result = LoadResult.Ok;
+                        loadedFromBackup = true;
+                    }
+                }
+            }
+
             if (result == LoadResult.MissingFile)
             {
                 // Try loading from old format and migrate
@@ -137,6 +154,9 @@ namespace AgOpenGPS.Properties
             {
                 RegistrySettings.toolProfileName = toolFileName;
             }
+
+            RegistrySettings.toolProfileLoadResult = result;
+            RegistrySettings.toolProfileLoadedFromBackup = loadedFromBackup;
 
             return result;
         }
@@ -153,7 +173,17 @@ namespace AgOpenGPS.Properties
                 : RegistrySettings.toolProfileName;
 
             string path = Path.Combine(RegistrySettings.toolsDirectory, fileName + ".xml");
+
+            // Keep a last-known-good copy before writing, unless this profile was
+            // recovered from .last (primary .xml was unreadable).
+            if (File.Exists(path) && !RegistrySettings.toolProfileLoadedFromBackup)
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                File.Copy(path, backupPath, true);
+            }
+
             XmlSettingsHandler.SaveXMLFile(path, this);
+            RegistrySettings.toolProfileLoadedFromBackup = false;
         }
 
         /// <summary>
@@ -164,6 +194,14 @@ namespace AgOpenGPS.Properties
         public void Save(string fileName)
         {
             string path = Path.Combine(RegistrySettings.toolsDirectory, fileName + ".xml");
+
+            // Keep a last-known-good copy before writing.
+            if (File.Exists(path))
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                File.Copy(path, backupPath, true);
+            }
+
             XmlSettingsHandler.SaveXMLFile(path, this);
         }
 

--- a/SourceCode/GPS/Properties/VehicleSettings.cs
+++ b/SourceCode/GPS/Properties/VehicleSettings.cs
@@ -72,6 +72,23 @@ namespace AgOpenGPS.Properties
         {
             string path = Path.Combine(RegistrySettings.vehiclesDirectory, vehicleFileName + ".xml");
             var result = XmlSettingsHandler.LoadXMLFile(path, this);
+            bool loadedFromBackup = false;
+
+            // Fallback to last known good backup when current profile is missing/corrupt.
+            if (result == LoadResult.Failed || result == LoadResult.MissingFile)
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                if (File.Exists(backupPath))
+                {
+                    var backupResult = XmlSettingsHandler.LoadXMLFile(backupPath, this);
+                    if (backupResult == LoadResult.Ok)
+                    {
+                        result = LoadResult.Ok;
+                        loadedFromBackup = true;
+                    }
+                }
+            }
+
             if (result == LoadResult.MissingFile)
             {
                 // Try loading from old format and migrate
@@ -83,6 +100,9 @@ namespace AgOpenGPS.Properties
             {
                 RegistrySettings.vehicleProfileName = vehicleFileName;
             }
+
+            RegistrySettings.vehicleProfileLoadResult = result;
+            RegistrySettings.vehicleProfileLoadedFromBackup = loadedFromBackup;
 
             return result;
         }
@@ -99,7 +119,17 @@ namespace AgOpenGPS.Properties
                 : RegistrySettings.vehicleProfileName;
 
             string path = Path.Combine(RegistrySettings.vehiclesDirectory, fileName + ".xml");
+
+            // Keep a last-known-good copy before writing, unless this profile was
+            // recovered from .last (primary .xml was unreadable).
+            if (File.Exists(path) && !RegistrySettings.vehicleProfileLoadedFromBackup)
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                File.Copy(path, backupPath, true);
+            }
+
             XmlSettingsHandler.SaveXMLFile(path, this);
+            RegistrySettings.vehicleProfileLoadedFromBackup = false;
         }
 
         /// <summary>
@@ -110,6 +140,14 @@ namespace AgOpenGPS.Properties
         public void Save(string fileName)
         {
             string path = Path.Combine(RegistrySettings.vehiclesDirectory, fileName + ".xml");
+
+            // Keep a last-known-good copy before writing.
+            if (File.Exists(path))
+            {
+                string backupPath = Path.ChangeExtension(path, ".last");
+                File.Copy(path, backupPath, true);
+            }
+
             XmlSettingsHandler.SaveXMLFile(path, this);
         }
 


### PR DESCRIPTION
This release focuses on improving the robustness of settings profiles, increasing simulator safety, and refining section control.

### Key Improvements:

*   **Profile Reliability**: Implements a robust backup and recovery system for AgIO, Vehicle, and Tool settings. If a main profile file is corrupt or missing, the system attempts to load from a `.last` backup. Settings are only saved if successfully loaded, preventing overwriting a good backup with a bad current state. Provides clear user warnings for failed loads and recoveries.
*   **Simulator Safety**: Introduces a "sticky lock" mechanism for the simulator. Once disabled (either by a live GNSS fix or user action), the simulator cannot be re-enabled during the same session. This prevents simulator data from interfering with live operations and causing sudden "fix2fix" jumps.
*   **Section Control & ISOBUS**:
    *   Refines section control logic to only override painted areas with ISOBUS TC data when active clients with section control capabilities are present.
    *   Ensures proper reset of section drawing states upon field closure or reset, preventing potential corrupted files when ISOBUS TC is active.
    *   Improves the loading of `Sections.txt` files by automatically adding a default color to malformed patch data.
*   **AgShare Coordinate Conversion**: Fixes an east-axis shear issue in the local coordinate conversion process for AgShare fields, ensuring accurate data parsing.
*   **Translations & Documentation**: Adds new and updated translations for Dutch, Tamil, and Vietnamese, and cleans up the `CLAUDE.md` documentation.